### PR TITLE
Added example elm tests

### DIFF
--- a/examples/morphir-elm-projects/evaluator-tests/morphir.json
+++ b/examples/morphir-elm-projects/evaluator-tests/morphir.json
@@ -1,0 +1,22 @@
+{
+    "name": "Morphir.Examples.App",
+    "sourceDirectory": "src",
+    "exposedModules": [
+        "CurrentTests",
+        "LiteralTests",
+        "DestructureTests",
+        "ConstructorTests",
+        "IfThenElseTests",
+        "RecordTests",
+        "LambdaTests",
+        "LetDefinitionTests",
+        "LetRecursionTests",
+        "ListTests",
+        "PatternMatchTests",
+        "NativeReferenceTests",
+        "SimpleTests",
+        "TupleTests",
+        "ExampleModule",
+        "UserDefinedRefernceTests"
+    ]
+}

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ConstructorTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ConstructorTests.elm
@@ -1,0 +1,74 @@
+module Morphir.Examples.App.ConstructorTests exposing (..)
+
+{-
+    Partially-applied constructors are debateably still "Data"
+    Tests which return such are flagged with --dubiousData
+    Unhappy:
+        Constructor with reference to non-constructor (Cannot compile with elm)
+        Constructor with reference to nothing (dead) (Canot compile with elm)
+-}
+
+--define UnionType
+type UnionType = TwoArg Int String | OneArg Int | ZeroArg
+
+--Test: Constructor/ZeroArg
+--uses UnionType
+constructorZeroArgTest : () -> UnionType
+constructorZeroArgTest _ = 
+    ZeroArg
+--expected = UnionType.ZeroArg()
+
+--Test: Constructor/OneArgApplied
+--uses UnionType
+constructorOneArgAppliedTest : () -> UnionType
+constructorOneArgAppliedTest _ = 
+    OneArg 5
+--expected = UnionType.OneArg(5)
+
+--Test: Constructor/TwoArgApplied
+--uses UnionType
+constructorTwoArgAppliedTest : () -> UnionType
+constructorTwoArgAppliedTest _ = 
+    TwoArg 5 "Red"
+--expected = UnionType.TwoArg(5, "Red")
+
+--Test: Constructor/TwoArgCurried
+--uses UnionType
+constructorTwoArgCurriedTest : () -> UnionType
+constructorTwoArgCurriedTest _ = 
+    let 
+        curried = TwoArg 5
+    in
+        curried "Blue"
+--expected = UnionType.TwoArg(5, "Blue")
+
+--define LazyFunction
+type LazyFunction = Lazy (Int -> (Int, Int)) Int
+--Test: Constructor/LazyFunction Stores a function and an argument in a constructor, then applies it with a lambda
+--uses LazyFunction
+lazyFunctionTest : () -> (Int, Int)
+lazyFunctionTest _ = 
+    let 
+        lazyFunction : LazyFunction
+        lazyFunction = 
+            let
+                f x = (x, x)
+            in
+                Lazy f 5
+    in
+        let
+            apply = \(Lazy f arg) -> f arg
+        in
+            apply lazyFunction
+--expected = (5, 5)
+
+--Test: Constructor/LazyFunction Stores a function and an argument in a constructor, then applies it with a lambda
+--uses UnionType
+--dubiousData
+constructorTwoArgPartiallyAppliedTest : () -> String -> UnionType
+constructorTwoArgPartiallyAppliedTest _ = 
+    let 
+        curried = TwoArg 5
+    in
+        curried
+--expected = <function>

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/CurrentTest.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/CurrentTest.elm
@@ -1,0 +1,4 @@
+module Morphir.Examples.App.CurrentTests exposing (..)
+{-
+    Scratch space for working out new tests before storing them in appropriate file
+-}

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/DestructureTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/DestructureTests.elm
@@ -1,0 +1,158 @@
+module Morphir.Examples.App.DestructureTests exposing (..)
+
+{-
+    Not all patterns can be destructured in legal elm code, but morphir tooling compiles them anyway.
+    The ones that cannot are flagged with --invalid-elm
+    TODO: 
+        destructure value from native function
+        destructure type from native SDK
+    Unhappy:
+        Non-matching value of correct type (elm compiler forbids)
+        Non-matching value of incorrect type (elm compiler def. forbids)
+    Shadowing
+-}
+
+
+
+--Test: Destructure/As
+destructureAsTest : () -> Int
+destructureAsTest _ = 
+    let
+        destructure : Int -> Int
+        destructure toDestructure =
+            let
+                (_ as x) = toDestructure
+            in
+                x
+    in
+        destructure 5
+--expected = 5
+
+--Test: Destructure/Tuple
+destructureTupleTest : () -> (Int, Int)
+destructureTupleTest _ = 
+    let
+        destructure : (Int, Int) -> (Int, Int)
+        destructure toDestructure =
+            let
+                (x, y) = toDestructure
+            in
+                (y, x)
+    in
+        destructure (2, 1)
+--expected = (1, 2)
+
+--define SingleBranchConstructor
+type SingleBranchConstructor = Just Int String
+
+--Test: Destructure/Constructor
+--uses SingleBranchConstructor
+destructureConstructorTest : () -> (Int, String)
+destructureConstructorTest _ = 
+    let
+        destructure : SingleBranchConstructor -> (Int, String)
+        destructure toDestructure =
+            let
+                (Just x y) = toDestructure
+            in
+                (x, y)
+    in
+        destructure (Just 5 "red")
+--expected = (5, "red")
+
+--Test: Destructure/Unit
+destructureUnitTest : () -> Int
+destructureUnitTest _ = 
+    let
+        destructure : () -> Int
+        destructure toDestructure =
+            let
+                () = toDestructure
+            in
+                4
+    in
+        destructure ()
+--expected = 4
+
+--Test: Destructure/AsTwice
+destructureAsTwiceTest : () -> (Int, Int)
+destructureAsTwiceTest _ = 
+    let
+        destructure : Int -> (Int, Int)
+        destructure toDestructure =
+            let
+                (x as y) = toDestructure
+            in
+                (x, x)
+    in
+        destructure 5
+--expected = (5, 5)
+
+--Test: Destructure/TupleTwice
+destructureTupleTwiceTest : () -> (String, Int, (Int, String))
+destructureTupleTwiceTest _ = 
+    let
+        destructure : (Int, String) -> (String, Int, (Int, String))
+        destructure toDestructure =
+            let
+                ((x, y) as z) = toDestructure
+            in
+                (y, x, z)
+    in
+        destructure (5, "Blue")
+--expected = ("Blue", 5, (5, "Blue"))
+
+--Test: Destructure/Direct destructure directly nested IR
+destructureDirectTest : () -> (Int, String)
+destructureDirectTest _ = 
+    let
+        (x, y) = ("Green", 6)
+    in
+        (y, x)
+--expected = (6, "Green")
+
+
+--Test: Destructure/HeadTail
+--invalid-elm: List types have multiple variants, and as such, cannot be used in destructure
+destructureHeadTailTest : () -> Int
+destructureHeadTailTest _ = 
+    let
+        destructure : List Int -> Int
+        destructure toDestructure =
+            let
+                (x :: _) = toDestructure
+            in
+                x
+    in
+        destructure [5]
+--expected = 5
+
+--Test: Destructure/Literal
+--invalid-elm: Literal patterns have multiple values, and as such, cannot be used in destructure
+destructureLiteralTest : () -> Int
+destructureLiteralTest _ = 
+    let
+        destructure : Int -> Int
+        destructure toDestructure =
+            let
+                5 = toDestructure
+            in
+                4
+    in
+        destructure 5
+--expected = 4
+
+--Test: Destructure/EmptyList
+--invalid-elm: List patterns have multiple variants, and as such, cannot be used in destructure
+destructureEmptyListTest : () -> String
+destructureEmptyListTest _ = 
+    let
+        destructure : List Int -> String
+        destructure toDestructure =
+            let
+                [] = toDestructure
+            in
+                "Correct"
+    in
+        destructure []
+--expected = "Correct"

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/EllieStuff.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/EllieStuff.elm
@@ -1,0 +1,17 @@
+module Main exposing (main)
+
+import Browser
+import Html exposing (Html, button, div, text)
+import Html.Events exposing (onClick)
+import List exposing (map)
+
+ 
+     
+--Test: Simple/Unit
+simpleUnitTest : () ->()
+simpleUnitTest _ = 
+    ()
+--expected = ()
+
+main : Html ()
+main = text (Debug.toString (simpleUnitTest () ))

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExampleModule.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExampleModule.elm
@@ -1,0 +1,56 @@
+module Morphir.Examples.App.ExampleModule exposing (five, tupleReverse, parametricFunction, publicFunction, outputRecordFunction, inputRecordFunction, outputUnionFunction, inputUnionFunction, ModuleRecord, ModuleSingleUnion(..), ModuleUnion(..))
+
+type alias ModuleRecord = {name : String, truth : Bool}
+type ModuleUnion = Center | Up Int | Down Int
+type ModuleSingleUnion = Only String Int
+
+five : Int
+five = 5
+
+tupleReverse : (Int, Int) -> (Int, Int)
+tupleReverse t = 
+    let
+        (a, b) = t
+    in
+        (b, a)
+
+parametricFunction : a -> (a, String)
+parametricFunction arg = (arg, "Hat")
+
+publicFunction : Int -> Int
+publicFunction arg = privateFunction (arg, arg)
+
+privateFunction : (Int, Int) -> Int
+privateFunction t = 
+    let
+        (x, y) = t
+    in
+        x + y
+
+outputRecordFunction : String -> ModuleRecord
+outputRecordFunction s = {name = s, truth = False}
+
+inputRecordFunction : ModuleRecord -> String
+inputRecordFunction r = if r.truth then r.name else "Rumplestilskin"
+
+outputUnionFunction : String -> Int -> ModuleUnion
+outputUnionFunction dir dist = 
+    case dir of
+        "Up" -> 
+            Up dist
+        "Down" ->
+            Down dist
+        _ ->
+            Center
+
+inputUnionFunction : ModuleUnion -> Int
+inputUnionFunction u =
+    case u of
+        Up dist ->
+            dist
+        Down dist ->
+            -dist
+        Center ->
+            0
+
+        

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/IfThenElseTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/IfThenElseTests.elm
@@ -1,0 +1,43 @@
+module Morphir.Examples.App.IfThenElseTests exposing (..)
+
+{-
+    TODO:
+        Rework/add tests to ensure constant propogation is not short circuiting
+            (it isn't, but it might if compiler changes)
+    Unhappy:
+        Non-boolean condition
+-}
+
+--Test: IfThenElse/True
+ifThenElseTrueTest : () -> String
+ifThenElseTrueTest _ = 
+    if True then "Correct" else "Incorrect"
+--expected = "Correct"
+
+--Test: IfThenElse/False
+ifThenElseFalseTest : () -> String
+ifThenElseFalseTest _ = 
+    if False then "Incorrect" else "Correct"
+--expected = "Correct"
+
+
+--Test: IfThenElse/ElseBranchUnevaluated Ensures the else branch isn't taken if condition is true. (Otherwise does not return)
+ifThenElseElseBranchUnevaluatedTest : () -> String
+ifThenElseElseBranchUnevaluatedTest _ = 
+    let 
+        f : String -> String
+        f x = f x
+    in
+        if True then "Correct" else f "Infinite"
+--expected = "Correct"
+
+--Test: IfThenElse/ThenBranchUnevaluated Ensures the then branch isn't taken if condition is false. (Otherwise does not return)
+ifThenElseThenBranchUnevaluatedTest : () -> String
+ifThenElseThenBranchUnevaluatedTest _ = 
+    let 
+        f : String -> String
+        f x = f x
+    in
+        if False then f "Infinite" else "Correct"
+--expected = "Correct"
+

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/LambdaTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/LambdaTests.elm
@@ -1,0 +1,102 @@
+module Morphir.Examples.App.LambdaTests exposing (..)
+import Morphir.Examples.App.ExampleModule exposing (..)
+
+{-
+    Module for lambda tests
+    TODO: 
+        apply with value from native function
+        apply with constructor type from native SDK
+    Unhappy:
+        Argument passed does not match pattern (but is correct type) (elm forbids)
+        Argument passed does not match pattern (is incorrect type) (elm forbids)
+        Bindings from call site are NOT visible (should throw "Not found" error)
+    Shadowing:
+        Apply lambda twice, shadowing things in context each time, and seeing original binding second time
+-}
+
+--Test: Lambda/As (Lambda with as pattern in binding)
+{-Double binding needed or compielr treats as let definition-}
+lambdaAsTest : () -> (Int, Int)
+lambdaAsTest _ = 
+    let
+        l = \(x as y) -> (x, y)
+    in
+        l 5
+--expected = (5, 5)
+
+--Test: Lambda/As (Lambda with tuple pattern in binding)
+lambdaTupleTest : () -> (Int, Int)
+lambdaTupleTest _ = 
+    let
+        l = \(x, y) -> (y, x)
+    in
+        l (1, 0)
+--expected = (0, 1)
+
+--define SingleBranchConstructor
+type SingleBranchConstructor = Just Int String
+--Test: Lambda/Constuctor (Lambda with constructor pattern in argument)
+--uses SingleBranchConstructor
+lambdaConstructorTest : () -> (String, Int)
+lambdaConstructorTest _ = 
+    let
+        l = \(Just x y) -> (y, x)
+    in
+        l (Just 5 "Red")
+--expected = ("Red", 5)
+
+--Test: Lambda/Unit (Lambda with unit pattern in argument)
+lambdaUnitTest : () -> String
+lambdaUnitTest _ = 
+    let
+        l = \() -> "Correct"
+    in
+        l ()
+--expected = "Correct"
+
+--Test: Lambda/Direct (Lambda applied to directly nested IR)
+lambdaDirectTest : () -> (Int, Int)
+lambdaDirectTest _ = 
+    (\(x, y) -> (y, x))(1, 0)
+--expected = (0, 1)
+
+--Test: Lambda/Scope (lambdas use lexical scope)
+lambdaScopeTest : () -> (Int, (Int, Int))
+lambdaScopeTest _ = 
+    let
+        l = 
+            let
+                c = 5
+            in
+                \x -> (x, c)
+    in
+        let
+            c = 3
+        in
+            (c, l 4)
+--expected = (3, (4, 5))
+
+--Test: Lambda/HigherOrder
+lambdaHigherOrderTest : () -> (Int, Int, Int)
+lambdaHigherOrderTest _ = 
+    let
+        l = 
+            let
+                c = 5
+            in
+                \x -> (\y -> (x, y, c))
+    in
+        let
+            c = 3
+        in
+            l c 4
+--expected = (3, 4, 5)
+
+--Test: Lambda/UserDefined
+lambdaUserDefinedTest : () -> (Int, String)
+lambdaUserDefinedTest _ = 
+    let
+        l = \(Only s i) -> (i, s)
+    in
+        l (Only "Red" 5)
+--expected = (5, "Red")

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/LetDefinitionTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/LetDefinitionTests.elm
@@ -1,0 +1,103 @@
+module Morphir.Examples.App.LetRecursionTests exposing (..)
+
+{-
+    Unhappy:
+        Bindings introduced sequentially but not nested are not visible
+        Function arguments are evaluated eagerly, even if curried
+    Shadowing
+-}
+
+--Test: LetDefinition/MakeTuple
+letDefinitionMakeTupleTest : () -> (Int, Int)
+letDefinitionMakeTupleTest _ = 
+    let
+        x = 1
+    in
+        (x, x)
+--expected = (1, 1)
+
+--Test: LetDefinition/Nested
+letDefinitionNestedTest : () -> (Int, Int)
+letDefinitionNestedTest _ = 
+    let
+        x = 
+            let
+                y = 2
+            in
+                y
+    in
+        (x, x)
+--expected = (2, 2)
+
+--Test: LetDefinition/SimpleFunction
+letDefinitionSimpleFunctionTest : () -> (Int, Int)
+letDefinitionSimpleFunctionTest _ = 
+    let
+        f x = (x, x)
+    in
+        f 3
+--expected = (3, 3)
+
+--Test: LetDefinition/TwoArgFunction
+letDefinitionTwoArgFunctionFunctionTest : () -> (Int, Int)
+letDefinitionTwoArgFunctionFunctionTest _ = 
+    let
+        f x y = (y, x)
+    in
+        f 2 3
+--expected = (3, 2)
+
+--Test: LetDefinition/Curried
+letDefinitionCurriedTest : () -> (Int, Int)
+letDefinitionCurriedTest _ = 
+    let
+        f x y = (y, x)
+    in
+        let
+            curried = f 0
+        in
+            curried 2
+--expected = (2, 0)
+
+--Test: LetDefinition/ApplyTwice
+letDefinitionApplyTwiceTest : () -> ((Int, Int), (Int, Int))
+letDefinitionApplyTwiceTest _ = 
+    let
+        f x y = (y, x)
+    in
+        let
+            curried= f 0
+        in
+            (curried 1, curried 2)
+--expected = ((1, 0), (2, 0))
+
+--Test: LetDefinition/DoNotRun Ensures defined function runs only when argument is applied, even if it is not used
+letDefinitionDoNotRunTest : () -> String
+letDefinitionDoNotRunTest _ = 
+    let
+        hang _ = hang ()
+    in
+        let 
+            f x = hang ()
+        in
+            "Correct"
+--expected = "Correct"
+
+--Test: LetDefinition/ScopeTest Let definitions should use lexical scope
+letDefinitionScopeTest : () -> (Int, (Int, Int))
+letDefinitionScopeTest _ = 
+    let
+        f = 
+            let
+                c = 5
+            in
+                let
+                    f_inner x = (x, c)
+                in
+                    f_inner
+    in
+        let
+            c = 3
+        in
+            (c, f 4)
+--expected = (3, (4, 5))

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/LetRecursionTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/LetRecursionTests.elm
@@ -1,0 +1,45 @@
+module Morphir.Examples.App.LetDefinitionTests exposing (..)
+
+{-
+    TODO:
+        All letDefinitions should pass with a letRecursion IR node in their place, but it is difficult to get morphir to construct such
+        Elm won't let you make letRecursions that don't go through lambdas/functions, but morphir will - semantics can be weird.
+        In general, it is difficult to see the IR that Elm (not Morphir) creates, so expected behavior of LetRecursion nodes remains speculative
+    Shadowing
+-}
+--Test: LetRecursion/Fibonacci
+letRecursionFibonacciTest : () -> Int
+letRecursionFibonacciTest _ = 
+    let
+        fib : Int -> Int
+        fib x = if (x < 2) then 1 else (fib (x - 1)) + (fib (x - 2))
+    in
+        fib 8
+--expected = 34
+
+--Test: LetRecursion/MutualRecursion Mutuall recursive functions grab last items on a list. 
+letRecursionMutualTest : () -> (Int, Int)
+letRecursionMutualTest _ = 
+    let
+        f : List Int -> (Int, Int)
+        f l = case l of
+            head :: neck :: [] ->
+                (head, neck)
+            head :: [] ->
+                (head, head)
+            _ :: tail ->
+                g tail
+            [] ->
+                (0, 0)
+        g : List Int -> (Int, Int)
+        g l = case l of
+            head :: neck :: _ :: [] ->
+                (head, neck)
+            _ :: _ :: tail ->
+                f tail
+            other ->
+                f other
+            
+    in
+        f [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+--expected = (8, 9)

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ListTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ListTests.elm
@@ -1,0 +1,56 @@
+module Morphir.Examples.App.LetDefinitionTests exposing (..)
+import List exposing (map, (::))
+
+
+
+--Test: List/Empty
+listEmptyTest : () -> List Int
+listEmptyTest _ = 
+    []
+--expected = []
+
+--Test: List/Single
+listSingleTest : () -> List Int
+listSingleTest _ = 
+    [0]
+--expected = [0]
+
+--Test: List/Several
+listSeveralTest : () -> List Int
+listSeveralTest _ = 
+    [0, 1, 2, 3, 4, 5]
+--expected = [0, 1, 2, 3, 4, 5]
+
+--Test: List/Nested
+listNestedTest : () -> List (List String)
+listNestedTest _ = 
+    [
+        ["Red", "Blue"],
+        [],
+        ["Car", "Plane", "Truck"]
+    ]
+--expected = [["Red", "Blue"],[],["Car", "Plane", "Truck"] ]
+
+--Test: List/Flatten
+--import List exposing (map, (::))
+listFlattenTest : () -> List (String)
+listFlattenTest _ = 
+    let 
+        nested = [
+            ["Red", "Blue"],
+            [],
+            ["Car", "Plane", "Truck"]]
+    in
+        let
+            flatten : List (List String) -> List String
+            flatten l = 
+                case l of
+                    (head :: tail) :: big_tail ->
+                        head :: flatten (tail :: big_tail)
+                    [] :: big_tail ->
+                        flatten big_tail
+                    [] ->
+                        []
+        in
+            flatten nested
+--expected = ["Red","Blue","Car","Plane","Truck"]

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/LiteralTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/LiteralTests.elm
@@ -1,0 +1,56 @@
+module Morphir.Examples.App.LiteralTests exposing (..)
+{-
+    Note that "DecimalLiteral" appears in the IR definition, but not these tests.
+    I cannot find anything that compiles to such
+    It seems to be partially supported at best, even in Elm
+-}
+
+--Test: Literal/String
+litStringTest : () -> String
+litStringTest _ =
+    let
+        value : String
+        value = "Bloop"
+    in
+        value
+--expected = "Bloop"
+
+--Test: Literal/Float
+litFloatTest : () -> Float
+litFloatTest _ = 
+    let
+        value : Float
+        value = 5.0
+    in
+        value
+--expected = 5.0
+
+--Test: Literal/Char
+litCharTest : () -> Char
+litCharTest _ = 
+    let
+        value : Char
+        value = 'f'
+    in
+        value
+--expected = 'f'
+
+--Test: Literal/Bool
+litBoolTest : () -> Bool
+litBoolTest _ = 
+    let
+        value : Bool
+        value = True
+    in
+        value
+--expected = True
+
+--Test: Literal/WholeNumber
+litWholeNumberLiteralTest : () -> Int
+litWholeNumberLiteralTest _ = 
+    let
+        value : Int
+        value = 5
+    in
+        value
+--expected = 5

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/NativeReferenceTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/NativeReferenceTests.elm
@@ -1,0 +1,47 @@
+module Morphir.Examples.App.NativeReferenceTests exposing (..)
+
+{-
+    TODO:
+        Morphir compiler might be importing wrong - explicit imports from Basics make it break
+    Unhappy:
+        Missing reference (elm precludes)
+-}
+
+import List exposing (map)
+        
+--Test: NativeReference/Map
+--import List exposing (map)
+nativeReferenceMapTest : () -> List (Int, Int)
+nativeReferenceMapTest _ = 
+    map (\x -> (x, x)) [1, 2, 3]
+--expected = [(1,1),(2,2),(3,3)]
+
+--Test: NativeReference/Add
+nativeReferenceAddTest : () -> Int
+nativeReferenceAddTest _ = 
+    let
+        f x y = x + y
+    in
+        f 1 2
+--expected = 3
+
+--Test: NativeReference/CurriedLog
+--import Basics exposing (logBase)
+nativeReferenceCurriedLogTest : () -> Float
+nativeReferenceCurriedLogTest _ = 
+    let 
+        curried = 
+            let
+                f = logBase
+            in
+                f 1
+    in
+        curried 2
+--expected = Infinity
+
+--Test: NativeReference/Pi
+--import Basics exposing (pi)
+nativeReferencePiTest : () -> Float
+nativeReferencePiTest _ = 
+    pi
+--expected = 3.14

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/PatternMatchTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/PatternMatchTests.elm
@@ -1,0 +1,165 @@
+module Morphir.Examples.App.PatternMatchTests exposing (..)
+{-
+Test cased for PatternMatch
+TODO:
+    I have not ben able to construct some cases because type checking can't unify the types.
+    Either find a way to do so, or establish confidene such really can't be done.
+    A consequence is that I do not know if a "Unit" pattern can ever fail to match if it type checks
+Unhappy:
+    No case matches (elm compiler precludes this)
+-}
+
+
+--Test: PatternMatch/Wildcard
+patternMatchWildcardTest : () -> String
+patternMatchWildcardTest _ = 
+    let 
+        match : List Int -> String
+        match x = case x of
+            [] ->
+                "Not an empty list"
+            3 :: _ ->
+                "Does not start with a 3"
+            _ :: [] ->
+                "Not a list of one element"
+            _ ->
+                "Correct"
+    in
+        match ([4, 5, 6])
+--expected = "Correct"
+
+--Test: PatternMatch/Tuple
+patternMatchTupleTest : () -> String
+patternMatchTupleTest _ = 
+    let 
+        match : (Int, String, String) -> String
+        match x = case x of
+            (0, _, _) -> 
+                "First element is not 0"
+            (_, "Red", _) ->
+                "Second element is not Red"
+            (_, _, "Car") ->
+                "Third element is not Car"
+            (1, "Car", third) ->
+                third
+            _ ->
+                "An earlier item should have matched"
+    in
+        match (1, "Car", "Correct")
+--expected = "Correct"
+
+
+--define PatternMatchUnionTestType
+type PatternMatchUnionTestType = TwoArg Int String | OtherTwoArg Int String | OneArg Int | ZeroArg
+
+--Test: PatternMatch/Constructor
+--uses PatternMatchUnionTestType
+patternMatchConstructorTest : () -> String
+patternMatchConstructorTest _ = 
+    let 
+        match : PatternMatchUnionTestType -> String
+        match x = case x of
+            ZeroArg ->
+                "Not a ZeroArg"
+            OneArg 3 ->
+                "Not a OneArg"
+            TwoArg 3 "Wrong" ->
+                "Not a TwoArg with those arguments"
+            OtherTwoArg 3 word ->
+                "Arguments match but wrong constructor"
+            TwoArg 3 word ->
+                word
+            TwoArg _ _  ->
+                "An earlier item should have matched"
+            _ ->
+                "An earlier item should have matched"
+    in
+        match (TwoArg 3 "Correct")
+--expected = "Correct"
+
+--Test: PatternMatch/ZeroArgConstructor
+--uses PatternMatchUnionTestType
+patternMatchZeroArgConstructorTest : () -> String
+patternMatchZeroArgConstructorTest _ = 
+    let 
+        match : PatternMatchUnionTestType -> String
+        match x = case x of
+            OneArg _ ->
+                "Not a OneArg"
+            TwoArg _ _  ->
+                "Not a TwoArg"
+            ZeroArg ->
+                "Correct"
+            _ ->
+                "An earlier item should have matched"
+    in
+        match ZeroArg
+--expected = "Correct"
+
+--Test: PatternMatch/EmptyList
+patternMatchEmptyListTest : () -> String
+patternMatchEmptyListTest _ = 
+    let 
+        match : List String -> String
+        match x = case x of
+            _ :: [] ->
+                "Not a list of one element"
+            _ :: _ ->
+                "Not a list of several elements"
+            [] -> 
+                "Correct"
+    in
+        match []
+--expected = "Correct"
+
+--Test: PatternMatch/HeadTail
+patternMatchHeadTailTest : () -> (String, String)
+patternMatchHeadTailTest _ = 
+    let 
+        match : List String -> (String, String)
+        match x = case x of
+            "Nope" :: _ ->
+                ("Does not start with that element", "")
+            _ :: _ :: [] ->
+                ("Not two elements long", "")
+            [] -> 
+                ("Not an empty list", "")
+            head :: neck :: _ ->
+                (neck, head)
+            _ ->
+                ("An earlier item should have matched", "")
+    in
+        match ["Red", "Dog", "Blue", "Car"]
+--expected = ("Dog", "Red")
+
+--Test: PatternMatch/Literal
+patternMatchLiteralTest : () -> String
+patternMatchLiteralTest _ = 
+    let 
+        match : String -> String
+        match x = case x of
+            "Nope" ->
+                "Not that"
+            "Yes" ->
+                "Correct"
+            _ ->
+                "An earlier item should have matched"
+    in
+        match "Yes"
+--expected = "Correct"
+
+--Test: PatternMatch/RepeatedAs
+patternMatchRepeatedAsTest : () -> (Int, (Int, Int))
+patternMatchRepeatedAsTest _ = 
+    let 
+        match : (Int, Int) -> (Int, (Int, Int))
+        match x = case x of
+            (0, _) ->
+                (0, (0, 0))
+            (1, y) as z ->
+                (y, z)
+            _ ->
+                (0, (0, 0))
+    in
+        match (1, 2)
+--expected = (2, (1, 2))

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/RecordTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/RecordTests.elm
@@ -1,0 +1,140 @@
+module Morphir.Examples.App.RecordTests exposing (..)
+
+import List exposing (map)
+
+{-
+    This module includes tests for all four record-specific nodes: Record, Field, FieldFunction and UpdateRecord
+    Unapplied field functions are (barely) arguably data. Tests returning such are flagged as --dubiousData
+    TODO: 
+        Extract field from native type
+    Unhappy:
+        Record node used with non-record type
+        Record node used with record that lacks field
+        Field function applied to non-record
+        Field function applied to record that lacks field
+-}
+
+--define RecordType
+type alias RecordType = {name : String, number : Int}
+
+--Test: Record/FieldTest
+--uses RecordType
+recordFieldTest : () -> String
+recordFieldTest _ = 
+    {name = "Correct", number = 0}.name
+--expected = "Correct"
+
+--Test: Record/FielFromBoundTest
+--uses RecordType
+recordFieldFromBoundTest : () -> String
+recordFieldFromBoundTest _ = 
+    let
+        myRecord = {name = "Correct", number = 0}
+    in
+        myRecord.name
+--expected = "Correct"
+
+--define RecordType
+type alias RecordType = {name : String, number : Int}
+
+--Test: FieldFunction/Apply
+--uses RecordType
+fieldFunctionApplyTest : () -> String
+fieldFunctionApplyTest _ = 
+    let
+        myRecord = {name = "Correct", number = 0}
+        f = .name
+    in
+        f myRecord
+--expected = "Correct"
+
+--Test: FieldFunction/ApplyTwice
+--uses RecordType
+fieldFunctionApplyTwiceTest : () -> (Int, Int)
+fieldFunctionApplyTwiceTest _ = 
+    let
+        record1 = {name = "Correct", number = 1}
+        record2 = {name = "Correct", number = 2}
+        f = .number
+    in
+        (f record1, f record2)
+--expected = (1, 2)
+
+--Test: FieldFunction/Unapplied
+--uses RecordType
+--dubiousData
+fieldFunctionUnappliedTest : () -> RecordType -> Int
+fieldFunctionUnappliedTest _ = 
+    .number
+--expected = <function>
+
+
+--Test: FieldFunction/Map
+--import import List exposing map
+--uses RecordType
+fieldFunctionMapTest : () -> List String
+fieldFunctionMapTest _ = 
+    let
+        l = [
+            {name = "Soso", number = 3},
+            {name = "Ponyo", number = 4},
+            {name = "Odin", number = 3000}]
+    in
+        let 
+            f = .name
+        in
+            map f l
+--expected = ["Soso", "Ponyo", "Odin"]
+--Test: Record/Simple
+--uses RecordType
+recordSimpleTest : () -> RecordType
+recordSimpleTest _ = 
+    {name = "Fido", number = 5}
+--expected = {name = "Fido", number = 5}
+
+--define NestedRecordType
+type alias NestedRecordType = {name : String, records : List RecordType}
+
+--Test: Record/Nested
+--uses RecordType
+--uses NestedRecordType
+recordNestedTest : () -> NestedRecordType
+recordNestedTest _ = 
+    {name = "Dogs", records = [
+        {name = "Ponyo", number = 3}, 
+        {name = "Soso", number = 3}
+    ]}
+--expected = {name = "Dogs", records = [{"Ponyo", 3}, {"Soso", 3}]}
+
+--Test: UpdateRecord/Simple
+--uses RecordType
+updateRecordSimpleTest : () ->String
+updateRecordSimpleTest _ = 
+    let
+        initial = {name = "Ponyo", number = 5}
+    in
+        {initial | name = "Soso"}.name
+--expected = "Soso"
+
+--Test: UpdateRecord/Full
+--uses RecordType
+updateRecordFullTest : () -> RecordType
+updateRecordFullTest _ = 
+    let
+        initial = {name = "Ponyo", number = 5}
+    in
+        {initial | name = "Soso"}
+--expected = {"Soso", 5}
+
+--Test: UpdateRecord/Immutable (ensure record updates are not using mutation)
+--uses RecordType
+updateRecordImmutableTest : () -> List RecordType
+updateRecordImmutableTest _ = 
+    let
+        initial = {name = "Ponyo", number = 4}
+    in
+        [
+            {initial | name = "Soso"},
+            {initial | number = 5}
+        ]
+--expected = [{"Soso, 4"}, {"Ponyo", 5}]

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/SimpleTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/SimpleTests.elm
@@ -1,0 +1,8 @@
+module Morphir.Examples.App.SimpleTests exposing (..)
+
+        
+--Test: Simple/Unit
+simpleUnitTest : () ->()
+simpleUnitTest _ = 
+    ()
+--expected = ()

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/TupleTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/TupleTests.elm
@@ -1,0 +1,20 @@
+module Morphir.Examples.App.TupleTests exposing (..)
+
+
+--Test: Tuple/Two
+tupleTwoTest : () ->(Int, Int)
+tupleTwoTest _ = 
+    (5, 4)
+--expected = (5, 4)
+
+--Test: Tuple/Three
+tupleThreeTest : () ->(Int, Bool, String)
+tupleThreeTest _ = 
+    (0, True, "Green")
+--expected =  (0, True, Green)
+
+--Test: Tuple/Nested
+tupleNestedTest : () ->(Int, (String, (Int, String)))
+tupleNestedTest _ = 
+    (5, ("Four",(4, "Five")))
+--expected = (5, ("Four",(4, "Five")))

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/UserDefinedReferenceTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/UserDefinedReferenceTests.elm
@@ -1,0 +1,70 @@
+module Morphir.Examples.App.UserDefinedTests exposing (..)
+
+{-
+    TODO: Check expected values vs. elm (Ellie is not friendly to multiple modules)
+-}
+
+import Morphir.Examples.App.ExampleModule exposing (..)
+
+
+--Test: UserDefinedReference/Value
+--import Morphir.Examples.App.ExampleModule exposing (..)
+userDefinedReferenceValueTest : () -> Int
+userDefinedReferenceValueTest _ = 
+    five
+--expected = 5
+
+--Test: UserDefinedReference/CurriedFunction
+--import Morphir.Examples.App.ExampleModule exposing (..)
+userDefinedReferenceCurriedTest : () -> String
+userDefinedReferenceCurriedTest _ = 
+    let 
+        curried = outputUnionFunction "Up"
+    in
+        case (curried 5) of
+            Center ->
+                "Wrong"
+            Up 5 -> 
+                "Correct"
+            _ ->
+                "An earlier branch should have matched"
+--expected = "Correct"
+
+--Test: UserDefinedReference/SimpleFunction
+--import Morphir.Examples.App.ExampleModule exposing (..)
+userDefinedReferenceSimpleFunctionTest : () -> (Int, Int)
+userDefinedReferenceSimpleFunctionTest _ = 
+    tupleReverse (2, 1)
+--expected = (1, 2)
+
+--Test: UserDefinedReference/PublicPrivate Calls public function which relies on private function
+--import Morphir.Examples.App.ExampleModule exposing (..)
+userDefinedReferencePublicPrivateTest : () -> Int
+userDefinedReferencePublicPrivateTest _ = 
+   publicFunction 5
+--expected = 10
+
+--Test: UserDefinedReference/Record
+--import Morphir.Examples.App.ExampleModule exposing (..)
+userDefinedReferenceRecordTest : () -> String
+userDefinedReferenceRecordTest _ = 
+    let
+        f : () -> ModuleRecord
+        f _ = outputRecordFunction "Tom Tit Tot"
+    in  
+        let
+            liar = f()
+        in
+            {liar | truth = True}.name
+--expected = "Tom Tit Tot"
+
+--Test: UserDefinedReference/Union
+--import Morphir.Examples.App.ExampleModule exposing (..)
+userDefinedReferenceUnionTest : () -> Int
+userDefinedReferenceUnionTest _ = 
+    let
+        f : () -> ModuleUnion
+        f _ = Down 6
+    in  
+        inputUnionFunction (f ())
+--expected = -6

--- a/examples/morphir-elm-projects/evaluator-tests/tests.txt
+++ b/examples/morphir-elm-projects/evaluator-tests/tests.txt
@@ -1,0 +1,19 @@
+
+//
+//TODO: Remainint tests: Elm, Unhappy, Shadowing, Native Types, Function Leak, .map
+
+    //Unwritten Apply Tests
+   // TODO:(Test)(Unhappy) handle applying a value that is not a function
+
+
+   // For organization, 3 suites: Reference to value, reference to function definition, reference to native function
+   // Value:
+   // TODO:(Test) Simple value
+   // TODO:(Test) Value whose body contains other references
+   // TODO:(Test) Value whose body contains let definitions
+   // TODO:(Test) Value which returns a function referencing variables from context defined in reference
+   // Function definition:
+   // TODO:(Test) Tests of currying from let definition
+
+
+  //TODO:(Test)(Unhappy) handle unbound variable


### PR DESCRIPTION
To drive testing of the evaluator, we wanted a broad coverage of syntax features with expected results. This PR adds such to examples/morphir-elm-projects/evaluator-tests