### PR TITLE
Update macros, fix warnings, change datamodel.json.zio to CrossBuild

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -216,7 +216,7 @@ trait MorphirModule extends Cross.Module[String] { morphir =>
     }
 
     object json extends Module {
-      object zio extends Module {
+      object zio extends CrossPlatform {
         object jvm extends MorphirJVMModule with MorphirPublishModule {
 
           def ivyDeps    = Agg(Deps.dev.zio.`zio-json`)

--- a/morphir/datamodel/src-3/org/finos/morphir/datamodel/Deriver.scala
+++ b/morphir/datamodel/src-3/org/finos/morphir/datamodel/Deriver.scala
@@ -68,7 +68,7 @@ object Deriver {
                   // enum case with fields
                   if (isCaseClass[head]) {
                     summonProductDeriver[head] match {
-                      case deriver: GenericProductDeriver[Product] =>
+                      case deriver: GenericProductDeriver[Product] @unchecked =>
                         SumBuilder.EnumProduct(fieldName, ct, deriver)
                       case other =>
                         throw new IllegalArgumentException(
@@ -93,6 +93,7 @@ object Deriver {
         }
     }
 
+  /** Not possible to check variants in pattern-match here. Setting them as widest possible type. */
   inline def deriveProductFields[Fields <: Tuple, Elems <: Tuple](i: Int): List[ProductBuilderField] =
     inline erasedValue[Fields] match {
       case EmptyTuple => Nil
@@ -103,11 +104,11 @@ object Deriver {
           case _: (head *: tail) =>
             val derivationStage =
               summonDeriver[head] match {
-                case deriver: SpecificDeriver[Any] =>
+                case deriver: SpecificDeriver[Any] @unchecked =>
                   ProductBuilder.Leaf(fieldName, i, deriver)
-                case deriver: GenericProductDeriver[Product] =>
+                case deriver: GenericProductDeriver[Product] @unchecked =>
                   ProductBuilder.Product(fieldName, i, deriver)
-                case deriver: GenericSumDeriver[Any] =>
+                case deriver: GenericSumDeriver[Any] @unchecked =>
                   ProductBuilder.Sum(fieldName, i, deriver)
               }
             derivationStage +: deriveProductFields[fields, tail](i + 1)

--- a/morphir/datamodel/src-3/org/finos/morphir/datamodel/SumBuilder.scala
+++ b/morphir/datamodel/src-3/org/finos/morphir/datamodel/SumBuilder.scala
@@ -27,6 +27,9 @@ private[datamodel] case class SumBuilder(tpe: SumBuilder.SumType, variants: List
                       failInsideNotProduct(other)
                   }
                 Concept.Enum.Case(Label(v.enumLabel), enumVariantFields)
+
+              case variant: SumBuilder.Variant =>
+                throw new IllegalArgumentException("Non-Discrimiated union decoding is not supported yet.")
             }
 
           }


### PR DESCRIPTION
* summonDeriver, summonProduct deriver were not working the same way as Deriver.gen which introduces strange inconsistencies e.g. certain things are inferred as a product-type despite having no product mirror and then later fail later with a wrong error.
* Some erasure checks need to be disabled because types are being widened.
* Change datamodel.json.zio to be a CrossBuild so devMode works.