### PR TITLE
Update macros with Namespace, minor build update

### DIFF
--- a/mill-build/src/millbuild/crossplatform/CrossPlatform.scala
+++ b/mill-build/src/millbuild/crossplatform/CrossPlatform.scala
@@ -18,8 +18,8 @@ trait CrossPlatform extends Module with DynamicModule { self =>
   def compiledModuleDeps: Seq[CrossPlatform] = Seq.empty
 
   def enableJVM(module: Module): Boolean    = buildSettings.jvm.enable
-  def enableJS(module: Module): Boolean     = buildSettings.js.enable
-  def enableNative(module: Module): Boolean = buildSettings.native.enable
+  def enableJS(module: Module): Boolean     = !devMode && buildSettings.js.enable
+  def enableNative(module: Module): Boolean = !devMode && buildSettings.native.enable
 
   private def enableModuleCondition(module: Module): Boolean = module match {
     case _: ScalaNativeModule => enableNative(module)

--- a/mill-build/src/millbuild/settings/ScalaSettings.scala
+++ b/mill-build/src/millbuild/settings/ScalaSettings.scala
@@ -7,6 +7,7 @@ import zio.config.typesafe._
 import zio.config.yaml._
 import com.typesafe.config.ConfigFactory
 import zio.Config
+import millbuild.crossplatform.DevMode
 
 final case class ScalaSettings(
     defaultVersion: String = ScalaSettings.defaultVersion,
@@ -16,6 +17,8 @@ final case class ScalaSettings(
 )
 
 object ScalaSettings {
+  import DevMode._
+
   val config: Config[ScalaSettings]                          = deriveConfig[ScalaSettings]
   lazy val default: ScalaSettings                            = ScalaSettings()
   lazy val defaultVersion                                    = defaultScala3xVersion
@@ -23,7 +26,7 @@ object ScalaSettings {
 
   val defaultScala213Version                  = "2.13.11"
   val defaultScala3xVersion                   = "3.3.0"
-  val defaultCrossScalaVersions: List[String] = List(defaultScala3xVersion, defaultScala213Version)
+  val defaultCrossScalaVersions: List[String] = if (devMode) List(defaultScala3xVersion) else List(defaultScala3xVersion, defaultScala213Version)
 }
 
 

--- a/morphir/datamodel/json/zio/src/org/finos/morphir/datamodel/json/zio/codecs.scala
+++ b/morphir/datamodel/json/zio/src/org/finos/morphir/datamodel/json/zio/codecs.scala
@@ -1,7 +1,8 @@
 package org.finos.morphir.datamodel.json.zio
 
-import org.finos.morphir.datamodel._
-import zio.json._
+import org.finos.morphir.datamodel.*
+import org.finos.morphir.datamodel.namespacing.QualifiedName
+import zio.json.*
 
 object codecs extends SchemaZioJsonSupport with DataZioJsonSupport
 
@@ -17,6 +18,11 @@ trait SchemaZioJsonEncoders extends ZioJsonBaseEncoders {
   implicit val EnumCaseEncoder: JsonEncoder[Concept.Enum.Case] = DeriveJsonEncoder.gen[Concept.Enum.Case]
   implicit val SchemaAliasEncoder: JsonEncoder[Concept.Alias]  = DeriveJsonEncoder.gen[Concept.Alias]
   implicit val SchemaJsonEncoder: JsonEncoder[Concept]         = DeriveJsonEncoder.gen[Concept]
+
+  implicit val QualifiedNameEncoder: JsonEncoder[QualifiedName] =
+    JsonEncoder.string.contramap {
+      (qname: QualifiedName) => qname.toString
+    }
 }
 
 trait DataZioJsonSupport extends DataZioJsonEncoders { self: SchemaZioJsonSupport => }

--- a/morphir/datamodel/src-3/org/finos/morphir/datamodel/DeriverMacros.scala
+++ b/morphir/datamodel/src-3/org/finos/morphir/datamodel/DeriverMacros.scala
@@ -1,10 +1,20 @@
 package org.finos.morphir.datamodel
 
 import org.finos.morphir.datamodel.Deriver.UnionType
+import org.finos.morphir.datamodel.namespacing.{LocalName, Namespace}
 
 import scala.quoted.*
 import scala.reflect.ClassTag
 import scala.deriving.Mirror
+
+trait GlobalNamespace {
+  def value: Namespace
+}
+
+trait TypeNamespace[T] {
+  def value: Namespace
+  def nameOverride: Option[LocalName] = None
+}
 
 object DeriverMacros {
   import DeriverTypes._
@@ -13,6 +23,45 @@ object DeriverMacros {
   def typeNameImpl[T: Type](using Quotes): Expr[String] = {
     import quotes.reflect._
     Expr(TypeRepr.of[T].typeSymbol.name)
+  }
+
+  inline def summonNamespaceOrFail[T]: (Namespace, Option[LocalName]) = ${ summonNamespaceOrFailImpl[T] }
+  def summonNamespaceOrFailImpl[T: Type](using Quotes): Expr[(Namespace, Option[LocalName])] = {
+    import quotes.reflect._
+
+    def summonTypeNamespace(): Option[Expr[(Namespace, Option[LocalName])]] =
+      Expr.summon[TypeNamespace[T]].map(tns =>
+        '{ ($tns.value, $tns.nameOverride) }
+      )
+
+    def summonGlobalNamespace(): Option[Expr[(Namespace, Option[LocalName])]] =
+      Expr.summon[GlobalNamespace].map(gns =>
+        '{ ($gns.value, None) }
+      )
+
+    val namespace: Expr[(Namespace, Option[LocalName])] =
+      summonTypeNamespace()
+        .orElse(summonGlobalNamespace())
+        .getOrElse {
+          val tpeStr = TypeRepr.of[T].widen.show
+          report.errorAndAbort(
+            s"""
+               |Cannot find a namespace for the type $tpeStr and a global default namespace has also not
+               |been found. To define a namespace for a specific type do the following:
+               |implicit val ns: TypeNamespace[$tpeStr] = new TypeNamespace[${TypeRepr.of[T].widen.show}] {
+               |  import org.finos.morphir.datamodel.namespacing.*
+               |  def value: Namespace = root / "path" / "to" / "my" / "package"
+               |}
+               |
+               |To define a global namespace for all types do the following:
+               |  implicit val ns: GlobalNamespace = new GlobalNamespace {
+               |  def value: Namespace = root / "path" / "to" / "my" / "package"
+               |}
+               |""".stripMargin
+          )
+        }
+
+    namespace
   }
 
   inline def showFlags[T]: String = ${ showFlagsImpl[T] }

--- a/morphir/datamodel/src-3/org/finos/morphir/datamodel/GenericProductDeriver.scala
+++ b/morphir/datamodel/src-3/org/finos/morphir/datamodel/GenericProductDeriver.scala
@@ -30,7 +30,7 @@ object GenericProductDeriver {
             case ProductBuilder.Sum(field, index, deriver) =>
               (Label(field), deriver.concept)
           }
-        Concept.Record(fields)
+        Concept.Record(productBuilder.name, fields)
       }
     }
 

--- a/morphir/datamodel/src-3/org/finos/morphir/datamodel/ProductBuilder.scala
+++ b/morphir/datamodel/src-3/org/finos/morphir/datamodel/ProductBuilder.scala
@@ -7,6 +7,7 @@ import scala.deriving.*
 import scala.compiletime.{codeOf, constValue, erasedValue, error, summonFrom, summonInline}
 import org.finos.morphir.datamodel.Data
 import org.finos.morphir.datamodel.Label
+import org.finos.morphir.datamodel.namespacing.QualifiedName
 
 private[datamodel] sealed trait ProductBuilder
 
@@ -46,8 +47,8 @@ private[datamodel] object ProductBuilder {
       }
   }
 
-  case class MirrorProduct(fields: List[ProductBuilderField]) extends ProductBuilder {
+  case class MirrorProduct(name: QualifiedName, fields: List[ProductBuilderField]) extends ProductBuilder {
     def run(parent: scala.Product) =
-      Data.Record(fields.map(f => (Label(f.field), f.run(parent))))
+      Data.Record(name, fields.map(f => (Label(f.field), f.run(parent))))
   }
 }

--- a/morphir/datamodel/src-3/org/finos/morphir/datamodel/SumBuilder.scala
+++ b/morphir/datamodel/src-3/org/finos/morphir/datamodel/SumBuilder.scala
@@ -1,5 +1,7 @@
 package org.finos.morphir.datamodel
 
+import org.finos.morphir.datamodel.namespacing.{LocalName, Namespace, QualifiedName}
+
 import scala.reflect.ClassTag
 
 private[datamodel] case class SumBuilder(tpe: SumBuilder.SumType, variants: List[SumBuilder.Variant]) {
@@ -21,7 +23,7 @@ private[datamodel] case class SumBuilder(tpe: SumBuilder.SumType, variants: List
               case variant: SumBuilder.EnumProduct =>
                 val enumVariantFields =
                   variant.deriver.concept match {
-                    case Concept.Record(fields) =>
+                    case Concept.Record(_, fields) =>
                       fields.map { case (label, concept) => (EnumLabel(label.value), concept) }
                     case other =>
                       failInsideNotProduct(other)
@@ -60,7 +62,7 @@ private[datamodel] case class SumBuilder(tpe: SumBuilder.SumType, variants: List
             case p: Product =>
               val enumCaseRecord = v.deriver.derive(p)
               enumCaseRecord match {
-                case Data.Record(values) =>
+                case Data.Record(_, values) =>
                   values.map { case (label, data) => (EnumLabel(label.value), data) }
                 case other =>
                   failInsideNotProduct(other)
@@ -98,7 +100,11 @@ object SumBuilder {
 
   sealed trait SumType
   object SumType {
-    case class Enum(name: java.lang.String) extends SumType
+    case class Enum(name: QualifiedName) extends SumType
+    object Enum {
+      def apply(name: String, ns: Namespace) = new Enum(QualifiedName(ns, LocalName(name)))
+    }
+
     // TODO Union for non-discrimited unions
   }
 }

--- a/morphir/datamodel/src/org/finos/morphir/datamodel/Concept.scala
+++ b/morphir/datamodel/src/org/finos/morphir/datamodel/Concept.scala
@@ -1,4 +1,7 @@
 package org.finos.morphir.datamodel
+
+import org.finos.morphir.datamodel.namespacing.QualifiedName
+
 //TODO: Keep this non-GADT version as Concept and make a GADT version `Schema[A]`
 sealed trait Concept
 
@@ -49,9 +52,17 @@ object Concept {
   case object Unit      extends Basic[scala.Unit]
   case object Nothing   extends Basic[scala.Nothing]
 
-  case class Record(fields: scala.List[(Label, Concept)]) extends Concept
+  case class Record(namespace: QualifiedName, fields: scala.List[(Label, Concept)]) extends Concept
+  object Record {
+    def apply(namespace: QualifiedName, fields: (Label, Concept)*) = new Record(namespace, fields.toList)
+  }
 
-  case class Alias(name: String, value: Concept) extends Concept
+  case class Struct(fields: scala.List[(Label, Concept)]) extends Concept
+  object Struct {
+    def apply(fields: (Label, Concept)*) = new Struct(fields.toList)
+  }
+
+  case class Alias(name: QualifiedName, value: Concept) extends Concept
 
   case class List(elementType: Concept) extends Concept
 
@@ -120,10 +131,10 @@ object Concept {
    *   )
    * }}}
    */
-  case class Enum(name: java.lang.String, cases: scala.List[Enum.Case]) extends Concept
+  case class Enum(name: QualifiedName, cases: scala.List[Enum.Case]) extends Concept
 
   object Enum {
-    def apply(name: java.lang.String, cases: Enum.Case*) =
+    def apply(name: QualifiedName, cases: Enum.Case*) =
       new Enum(name, cases.toList)
 
     case class Case(label: Label, fields: scala.List[(EnumLabel, Concept)])

--- a/morphir/datamodel/src/org/finos/morphir/datamodel/Data.scala
+++ b/morphir/datamodel/src/org/finos/morphir/datamodel/Data.scala
@@ -1,7 +1,11 @@
 package org.finos.morphir.datamodel
+
+import org.finos.morphir.datamodel.namespacing.{Namespace, QualifiedName}
+
 import java.io.OutputStream
 import scala.collection.immutable.ListMap
 import scala.collection.mutable
+
 sealed trait Data extends geny.Writable {
   def shape: Concept
   def writeBytesTo(out: OutputStream): Unit = {
@@ -47,11 +51,26 @@ object Data {
   case class Tuple(values: scala.List[Data]) extends Data {
     val shape: Concept.Tuple = Concept.Tuple(values.map(_.shape))
   }
-  case class Record(values: scala.List[(Label, Data)]) extends Data {
-    val shape: Concept.Record = Concept.Record(values.map { case (label, data) => (label, data.shape) })
-  }
+  case class Record private (values: scala.List[(Label, Data)], shape: Concept.Record) extends Data
   object Record {
-    def apply(entry: (Label, Data)*): Record = Record(entry.toList)
+    def apply(namespace: QualifiedName, fields: (Label, Data)*): Record =
+      apply(namespace, fields.toList)
+
+    def apply(namespace: QualifiedName, fields: scala.List[(Label, Data)]): Record = {
+      val concept = Concept.Record(namespace, fields.map { case (label, data) => (label, data.shape) })
+      Record(fields.toList, concept)
+    }
+
+    /** Unapply of a record should contain it's qname and the field values, not the shape */
+    def unapply(record: Record) =
+      Some((record.shape.namespace, record.values))
+  }
+
+  case class Struct(values: scala.List[(Label, Data)]) extends Data {
+    val shape: Concept.Struct = Concept.Struct(values.map { case (label, data) => (label, data.shape) })
+  }
+  object Struct {
+    def apply(fields: (Label, Data)*): Struct = new Struct(fields.toList)
   }
 
   /**

--- a/morphir/datamodel/src/org/finos/morphir/datamodel/namespacing.scala
+++ b/morphir/datamodel/src/org/finos/morphir/datamodel/namespacing.scala
@@ -26,10 +26,6 @@ object namespacing {
       def segments: Chunk[NamespaceSegment]       = unwrap(self)
       def /(segment: NamespaceSegment): Namespace = Namespace(unwrap(self) :+ segment)
       def /(namespace: Namespace): Namespace      = Namespace(unwrap(self) ++ unwrap(namespace))
-      // def /(name: String): Namespace = Namespace(unwrap(self) :+ NamespaceSegment(name))
-      // def /(names: Iterable[String]): Namespace = Namespace(unwrap(self) ++ names.map(NamespaceSegment(_)))
-      // def /(names: String*): Namespace = /(names)
-      // def /(names: Chunk[String]): Namespace = Namespace(unwrap(self) ++ names.map(NamespaceSegment(_)))
     }
   }
 

--- a/morphir/datamodel/test/src-3/org/finos/morphir/datamodel/NamespaceExt.scala
+++ b/morphir/datamodel/test/src-3/org/finos/morphir/datamodel/NamespaceExt.scala
@@ -1,0 +1,22 @@
+package org.finos.morphir.datamodel
+
+import org.finos.morphir.datamodel.namespacing.Namespace.unwrap
+import org.finos.morphir.datamodel.namespacing.{LocalName, Namespace, NamespaceSegment, QualifiedName}
+import org.finos.morphir.foundations.Chunk
+
+import scala.annotation.targetName
+
+// Cannot put these into NamespaceOps in namespacing because Scala 3 will not correctly detect the operators
+// e.g. report bogus errors such as:
+// value :: is not a member of String, but could be made available as an extension method.
+extension (self: Namespace) {
+  @targetName("slashString")
+  def /(name: String): Namespace            = Namespace(unwrap(self) :+ NamespaceSegment(name))
+  def /(names: Iterable[String]): Namespace = Namespace(unwrap(self) ++ names.map(NamespaceSegment(_)))
+  def /(names: String*): Namespace          = /(names)
+  def /(names: Chunk[String]): Namespace    = Namespace(unwrap(self) ++ names.map(NamespaceSegment(_)))
+
+  def ::(localName: LocalName) = QualifiedName(self, localName)
+  @targetName("slashLocalNameString")
+  def ::(localName: String) = QualifiedName(self, LocalName(localName))
+}

--- a/morphir/datamodel/test/src-3/org/finos/morphir/datamodel/ToDataEnums.scala
+++ b/morphir/datamodel/test/src-3/org/finos/morphir/datamodel/ToDataEnums.scala
@@ -5,8 +5,19 @@ import org.finos.morphir.datamodel.Concept.Enum
 import org.finos.morphir.datamodel.Data
 import org.finos.morphir.datamodel.Data.Case
 import org.finos.morphir.datamodel.Util.*
+import org.finos.morphir.datamodel.namespacing.*
+import org.finos.morphir.datamodel.namespacing.Namespace.root
+
+object EnumGns {
+  val gns: Namespace = root / "enumtest"
+}
 
 object EnumData1 {
+  import EnumGns._
+  implicit val gnsImpl: GlobalNamespace = new GlobalNamespace {
+    def value = gns
+  }
+
   sealed trait Foo
   case object Bar               extends Foo
   case class Baz(value: String) extends Foo
@@ -15,6 +26,11 @@ object EnumData1 {
 }
 
 object EnumData2 {
+  import EnumGns._
+  implicit val gnsImpl: GlobalNamespace = new GlobalNamespace {
+    def value = gns
+  }
+
   enum Foo {
     case Bar
     case Baz(value: String)
@@ -23,14 +39,31 @@ object EnumData2 {
   val deriver = Deriver.gen[Foo]
 }
 
+object EnumData3 {
+  import EnumGns._
+  implicit val gnsImpl: TypeNamespace[Foo] = new TypeNamespace[Foo] {
+    def value = gns
+  }
+
+  implicit val gnsImpl2: TypeNamespace[Baz] = new TypeNamespace[Baz] {
+    def value = gns
+  }
+
+  sealed trait Foo
+  case object Bar               extends Foo
+  case class Baz(value: String) extends Foo
+
+  val deriver = Deriver.gen[Foo]
+}
+
 class ToDataEnums extends munit.FunSuite {
+  import EnumGns._
   // DONT use Deriver.gen in same project while working on it
   // if it fails, it messes up IntelliJ's ability to know what
   // is compiled and what is not
-
   val concept =
     Enum(
-      "Foo",
+      gns :: ("Foo"),
       Enum.Case(l"Bar"),
       Enum.Case(l"Baz", (el"value", Concept.String))
     )
@@ -73,6 +106,7 @@ class ToDataEnums extends munit.FunSuite {
     assertEquals(
       Deriver.toData(stuff),
       Data.Record(
+        gns :: "Stuff",
         l"a" -> Data.String("a_str"),
         l"b" -> Case(el"value" -> Data.String("baz_val"))("Baz", concept),
         l"c" -> Data.Int(123)
@@ -88,8 +122,9 @@ class ToDataEnums extends munit.FunSuite {
     assertEquals(
       Deriver.toData(stuff),
       Data.Record(
+        gns :: "Stuff",
         l"a" -> Data.String("a_str"),
-        l"b" -> Data.Record(l"value" -> Data.String("baz_val")),
+        l"b" -> Data.Record(gns :: "Baz", l"value" -> Data.String("baz_val")),
         l"c" -> Data.Int(123)
       )
     )
@@ -102,6 +137,7 @@ class ToDataEnums extends munit.FunSuite {
     assertEquals(
       Deriver.toData(stuff),
       Data.Record(
+        gns :: "Stuff",
         l"a" -> Data.String("a_str"),
         l"b" -> Case(el"value" -> Data.String("baz_val"))("Baz", concept),
         l"c" -> Data.Int(123)
@@ -136,6 +172,14 @@ class ToDataEnums extends munit.FunSuite {
 
   test("Enum Data 2 - Value") {
     import EnumData1._
+    assertEquals(
+      deriver.derive(Baz("something")),
+      Case(el"value" -> Data.String("something"))("Baz", concept)
+    )
+  }
+
+  test("Enum Data 2 - Value") {
+    import EnumData3._
     assertEquals(
       deriver.derive(Baz("something")),
       Case(el"value" -> Data.String("something"))("Baz", concept)

--- a/morphir/datamodel/test/src-3/org/finos/morphir/datamodel/ToDataRecords.scala
+++ b/morphir/datamodel/test/src-3/org/finos/morphir/datamodel/ToDataRecords.scala
@@ -1,14 +1,48 @@
 package org.finos.morphir.datamodel
 
 import org.finos.morphir.datamodel.Deriver
-import org.finos.morphir.datamodel.Util._
+import org.finos.morphir.datamodel.Util.*
+import org.finos.morphir.datamodel.namespacing.{LocalName, Namespace}
+import org.finos.morphir.datamodel.namespacing.Namespace.root
 
 class ToDataRecords extends munit.FunSuite {
+  val gns: Namespace = root / "recordtest"
+  given GlobalNamespace with {
+    def value = gns
+  }
+
   test("basic record") {
-    case class Person(name: String, age: Int) ////////
+    case class Person(name: String, age: Int)
     assertEquals(
-      Deriver.toData(Person("Joe", 123)), //
-      Data.Record(l"name" -> Data.String("Joe"), l"age" -> Data.Int(123))
+      Deriver.toData(Person("Joe", 123)),
+      Data.Record(gns :: "Person", l"name" -> Data.String("Joe"), l"age" -> Data.Int(123))
+    )
+  }
+
+  test("basic record - override namespace") {
+    case class Person(name: String, age: Int)
+    val tns: Namespace = root / "override"
+    given TypeNamespace[Person] with {
+      def value = tns
+    }
+
+    assertEquals(
+      Deriver.toData(Person("Joe", 123)),
+      Data.Record(tns :: "Person", l"name" -> Data.String("Joe"), l"age" -> Data.Int(123))
+    )
+  }
+
+  test("basic record - override namespace, override name") {
+    case class Person(name: String, age: Int)
+    val tns: Namespace = root / "override"
+    given TypeNamespace[Person] with {
+      def value                                    = tns
+      override def nameOverride: Option[LocalName] = Some(LocalName("Person2"))
+    }
+
+    assertEquals(
+      Deriver.toData(Person("Joe", 123)),
+      Data.Record(tns :: "Person2", l"name" -> Data.String("Joe"), l"age" -> Data.Int(123))
     )
   }
 
@@ -18,7 +52,8 @@ class ToDataRecords extends munit.FunSuite {
     assertEquals(
       Deriver.toData(Person(Name("Joe", "Bloggs"), 123)),
       Data.Record(
-        l"name" -> Data.Record(l"first" -> Data.String("Joe"), l"last" -> Data.String("Bloggs")),
+        gns :: "Person",
+        l"name" -> Data.Record(gns :: "Name", l"first" -> Data.String("Joe"), l"last" -> Data.String("Bloggs")),
         l"age"  -> Data.Int(123)
       )
     )
@@ -30,10 +65,11 @@ class ToDataRecords extends munit.FunSuite {
     assertEquals(
       Deriver.toData(Person(List(Name("Joe", "Bloggs"), Name("Jim", "Roogs")), 123)),
       Data.Record(
+        gns :: "Person",
         l"name" ->
           Data.List(
-            Data.Record(l"first" -> Data.String("Joe"), l"last" -> Data.String("Bloggs")),
-            Data.Record(l"first" -> Data.String("Jim"), l"last" -> Data.String("Roogs"))
+            Data.Record(gns :: "Name", l"first" -> Data.String("Joe"), l"last" -> Data.String("Bloggs")),
+            Data.Record(gns :: "Name", l"first" -> Data.String("Jim"), l"last" -> Data.String("Roogs"))
           ),
         l"age" -> Data.Int(123)
       )

--- a/morphir/foundations/src/org/finos/morphir/foundations/capabilities/Show.scala
+++ b/morphir/foundations/src/org/finos/morphir/foundations/capabilities/Show.scala
@@ -9,7 +9,6 @@ object Show extends ShowInstancesPriority0 {
 
   def fromToString[A]: Show[A] = _.toString()
 
-  
 }
 
 private[foundations] trait ShowInstancesPriority0 {


### PR DESCRIPTION
* Concept.Record now contains QualifiedName
* Concept.Enum now contains QualifiedName
* Concept.Alias now contains QualifiedName
* Minor changes to Data.Record and other constructors to accommodate the QualifiedName
* Various changes to Deriver macros to accommodate QualifiedName
* GlobalNamespace and TypeNamespace typeclasses introduced so that users can specify which namespaces projects can use on a global or per-type basis. TypeNamesapce can also override the LocalName of a type (in case we need to change it and we do not control it e.g. it's from a library).
* Ergonomic additions to Namespace could not be introduced into NamespaceOps due to bogus Scala 3 errors. They were introduced via a separate Scala-3 only file called NamespaceExt that uses the Scala-3 `extension` construct. 
* Minor build changes to enhance devMode.