### PR TITLE
Enums optionally can be Single-Record-Constructor Types

### DIFF
--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
@@ -144,6 +144,9 @@ object Loop {
                |loc : $loc
                |Store contents from that package:
                |  ${store.ctors.keys.filter(_.getPackagePath == pkg).map(_.toString).mkString("\n\t")}
+               |
+               |Other Store Contents:
+               |  ${store.ctors.keys.map(_.toString).mkString("\n\t")}
                |""".stripMargin
           )
         }

--- a/morphir/src-3/org/finos/morphir/datamodel/EnumTranslation.scala
+++ b/morphir/src-3/org/finos/morphir/datamodel/EnumTranslation.scala
@@ -1,0 +1,7 @@
+package org.finos.morphir.datamodel
+
+sealed trait EnumTranslation
+object EnumTranslation {
+  case object MutiFieldConstructor  extends EnumTranslation
+  case object SingleFieldWithRecord extends EnumTranslation
+}

--- a/morphir/src-3/org/finos/morphir/datamodel/EnumWrapper.scala
+++ b/morphir/src-3/org/finos/morphir/datamodel/EnumWrapper.scala
@@ -14,7 +14,7 @@ extension (v: Data.Boolean.type) {
       override def concept: Concept            = wrapper.concept
     }
   inline def deriveEnumWrapper[T](label: String, fromScalaType: T => Boolean): SpecificDeriver[T] = {
-    val (partialName, _) = DeriverMacros.summonNamespaceOrFail[T]
+    val (partialName, _, _) = DeriverMacros.summonNamespaceOrFail[T]
     deriveEnumWrapperNamespaced(partialName, label, fromScalaType)
   }
   inline def deriveEnumWrapper[T](fromScalaType: T => Boolean): SpecificDeriver[T] = {
@@ -35,7 +35,7 @@ extension (v: Data.Byte.type) {
       override def concept: Concept            = wrapper.concept
     }
   inline def deriveEnumWrapper[T](label: String, fromScalaType: T => Byte): SpecificDeriver[T] = {
-    val (partialName, _) = DeriverMacros.summonNamespaceOrFail[T]
+    val (partialName, _, _) = DeriverMacros.summonNamespaceOrFail[T]
     deriveEnumWrapperNamespaced(partialName, label, fromScalaType)
   }
   inline def deriveEnumWrapper[T](fromScalaType: T => Byte): SpecificDeriver[T] = {
@@ -56,7 +56,7 @@ extension (v: Data.Decimal.type) {
       override def concept: Concept            = wrapper.concept
     }
   inline def deriveEnumWrapper[T](label: String, fromScalaType: T => scala.BigDecimal): SpecificDeriver[T] = {
-    val (partialName, _) = DeriverMacros.summonNamespaceOrFail[T]
+    val (partialName, _, _) = DeriverMacros.summonNamespaceOrFail[T]
     deriveEnumWrapperNamespaced(partialName, label, fromScalaType)
   }
   inline def deriveEnumWrapper[T](fromScalaType: T => scala.BigDecimal): SpecificDeriver[T] = {
@@ -77,7 +77,7 @@ extension (v: Data.Integer.type) {
       override def concept: Concept            = wrapper.concept
     }
   inline def deriveEnumWrapper[T](label: String, fromScalaType: T => scala.BigInt): SpecificDeriver[T] = {
-    val (partialName, _) = DeriverMacros.summonNamespaceOrFail[T]
+    val (partialName, _, _) = DeriverMacros.summonNamespaceOrFail[T]
     deriveEnumWrapperNamespaced(partialName, label, fromScalaType)
   }
   inline def deriveEnumWrapper[T](fromScalaType: T => scala.BigInt): SpecificDeriver[T] = {
@@ -98,7 +98,7 @@ extension (v: Data.Int16.type) {
       override def concept: Concept            = wrapper.concept
     }
   inline def deriveEnumWrapper[T](label: String, fromScalaType: T => Short): SpecificDeriver[T] = {
-    val (partialName, _) = DeriverMacros.summonNamespaceOrFail[T]
+    val (partialName, _, _) = DeriverMacros.summonNamespaceOrFail[T]
     deriveEnumWrapperNamespaced(partialName, label, fromScalaType)
   }
   inline def deriveEnumWrapper[T](fromScalaType: T => Short): SpecificDeriver[T] = {
@@ -119,7 +119,7 @@ extension (v: Data.Int32.type) {
       override def concept: Concept            = wrapper.concept
     }
   inline def deriveEnumWrapper[T](label: String, fromScalaType: T => Int): SpecificDeriver[T] = {
-    val (partialName, _) = DeriverMacros.summonNamespaceOrFail[T]
+    val (partialName, _, _) = DeriverMacros.summonNamespaceOrFail[T]
     deriveEnumWrapperNamespaced(partialName, label, fromScalaType)
   }
   inline def deriveEnumWrapper[T](fromScalaType: T => Int): SpecificDeriver[T] = {
@@ -140,7 +140,7 @@ extension (v: Data.String.type) {
       override def concept: Concept            = wrapper.concept
     }
   inline def deriveEnumWrapper[T](label: String, fromScalaType: T => String): SpecificDeriver[T] = {
-    val (partialName, _) = DeriverMacros.summonNamespaceOrFail[T]
+    val (partialName, _, _) = DeriverMacros.summonNamespaceOrFail[T]
     deriveEnumWrapperNamespaced(partialName, label, fromScalaType)
   }
   inline def deriveEnumWrapper[T](fromScalaType: T => String): SpecificDeriver[T] = {
@@ -161,7 +161,7 @@ extension (v: Data.LocalDate.type) {
       override def concept: Concept            = wrapper.concept
     }
   inline def deriveEnumWrapper[T](label: String, fromScalaType: T => java.time.LocalDate): SpecificDeriver[T] = {
-    val (partialName, _) = DeriverMacros.summonNamespaceOrFail[T]
+    val (partialName, _, _) = DeriverMacros.summonNamespaceOrFail[T]
     deriveEnumWrapperNamespaced(partialName, label, fromScalaType)
   }
   inline def deriveEnumWrapper[T](fromScalaType: T => java.time.LocalDate): SpecificDeriver[T] = {
@@ -182,7 +182,7 @@ extension (v: Data.Month.type) {
       override def concept: Concept            = wrapper.concept
     }
   inline def deriveEnumWrapper[T](label: String, fromScalaType: T => java.time.Month): SpecificDeriver[T] = {
-    val (partialName, _) = DeriverMacros.summonNamespaceOrFail[T]
+    val (partialName, _, _) = DeriverMacros.summonNamespaceOrFail[T]
     deriveEnumWrapperNamespaced(partialName, label, fromScalaType)
   }
   inline def deriveEnumWrapper[T](fromScalaType: T => java.time.Month): SpecificDeriver[T] = {
@@ -203,7 +203,7 @@ extension (v: Data.LocalTime.type) {
       override def concept: Concept            = wrapper.concept
     }
   inline def deriveEnumWrapper[T](label: String, fromScalaType: T => java.time.LocalTime): SpecificDeriver[T] = {
-    val (partialName, _) = DeriverMacros.summonNamespaceOrFail[T]
+    val (partialName, _, _) = DeriverMacros.summonNamespaceOrFail[T]
     deriveEnumWrapperNamespaced(partialName, label, fromScalaType)
   }
   inline def deriveEnumWrapper[T](fromScalaType: T => java.time.LocalTime): SpecificDeriver[T] = {
@@ -224,7 +224,7 @@ extension (v: Data.Char.type) {
       override def concept: Concept            = wrapper.concept
     }
   inline def deriveEnumWrapper[T](label: String, fromScalaType: T => Char): SpecificDeriver[T] = {
-    val (partialName, _) = DeriverMacros.summonNamespaceOrFail[T]
+    val (partialName, _, _) = DeriverMacros.summonNamespaceOrFail[T]
     deriveEnumWrapperNamespaced(partialName, label, fromScalaType)
   }
   inline def deriveEnumWrapper[T](fromScalaType: T => Char): SpecificDeriver[T] = {
@@ -244,7 +244,7 @@ extension (v: Data.Unit.type) {
       override def concept: Concept            = wrapper.concept
     }
   inline def deriveEnumWrapper[T](label: String): SpecificDeriver[T] = {
-    val (partialName, _) = DeriverMacros.summonNamespaceOrFail[T]
+    val (partialName, _, _) = DeriverMacros.summonNamespaceOrFail[T]
     deriveEnumWrapperNamespaced(partialName, label)
   }
   inline def deriveEnumWrapper[T]: SpecificDeriver[T] = {

--- a/morphir/src-3/org/finos/morphir/datamodel/SumBuilder.scala
+++ b/morphir/src-3/org/finos/morphir/datamodel/SumBuilder.scala
@@ -5,6 +5,7 @@ import scala.reflect.ClassTag
 
 private[datamodel] case class SumBuilder(
     tpe: SumBuilder.SumType,
+    enumTranslation: EnumTranslation,
     ordinalGetter: Any => Int,
     variants: List[SumBuilder.Variant]
 ) {
@@ -25,14 +26,19 @@ private[datamodel] case class SumBuilder(
                 Concept.Enum.Case(Label(v.enumLabel), List())
 
               case variant: SumBuilder.EnumProduct =>
-                val enumVariantFields =
+                val structMembers =
                   variant.deriver.concept match {
-                    case Concept.Record(_, fields) =>
-                      fields.map { case (label, concept) => (EnumLabel(label.value), concept) }
+                    case record: Concept.Record =>
+                      enumTranslation match {
+                        case EnumTranslation.SingleFieldWithRecord =>
+                          List(EnumLabel.Empty -> record.toStruct)
+                        case EnumTranslation.MutiFieldConstructor =>
+                          record.fields.map { case (label, concept) => (EnumLabel(label.value), concept) }
+                      }
                     case other =>
                       failInsideNotProduct(other)
                   }
-                Concept.Enum.Case(Label(v.enumLabel), enumVariantFields)
+                Concept.Enum.Case(Label(v.enumLabel), structMembers)
 
               case variant: SumBuilder.Variant =>
                 throw new IllegalArgumentException("Non-Discrimiated union decoding is not supported yet.")
@@ -56,8 +62,33 @@ private[datamodel] case class SumBuilder(
             case p: Product =>
               val enumCaseRecord = v.deriver.derive(p)
               enumCaseRecord match {
-                case Data.Record(_, values) =>
-                  values.map { case (label, data) => (EnumLabel(label.value), data) }
+                case record: Data.Record =>
+                  /*
+                  Translate:
+                    sealed trait Foo
+                    case class Bar(blin: String, blu: Int)
+                    case object Baz
+                    === or ===
+                    enum Foo {
+                      case Bar(blin: String, blu: Int)
+                      case Baz
+                    }
+                    === into when EnumTranslation.MultiFieldConstructor ===
+                    type Foo
+                      = Bar String Int
+                      | Baz
+                    === into when EnumTranslation.SingleFieldWithRecord ===
+                    type Foo
+                      = Bar { blin: String blu: Int }
+                      | Baz
+                   */
+                  enumTranslation match {
+                    case EnumTranslation.SingleFieldWithRecord =>
+                      List(EnumLabel.Empty -> record.toStruct)
+                    case EnumTranslation.MutiFieldConstructor =>
+                      record.values.map { case (label, data) => (EnumLabel(label.value), data) }
+                  }
+
                 case other =>
                   failInsideNotProduct(other)
               }

--- a/morphir/src/org/finos/morphir/datamodel/Concept.scala
+++ b/morphir/src/org/finos/morphir/datamodel/Concept.scala
@@ -68,7 +68,9 @@ object Concept {
   case object Unit      extends Basic[scala.Unit]
   case object Nothing   extends Basic[scala.Nothing]
 
-  case class Record(namespace: FQName, fields: scala.List[(Label, Concept)]) extends Concept
+  case class Record(namespace: FQName, fields: scala.List[(Label, Concept)]) extends Concept {
+    def toStruct: Concept.Struct = Concept.Struct(fields: _*)
+  }
   object Record {
     def apply(namespace: FQName, fields: (Label, Concept)*) = new Record(namespace, fields.toList)
   }

--- a/morphir/src/org/finos/morphir/datamodel/Data.scala
+++ b/morphir/src/org/finos/morphir/datamodel/Data.scala
@@ -67,7 +67,9 @@ object Data {
     def apply(values: Data*): Tuple = Tuple(values.toList)
   }
 
-  case class Record private (values: scala.List[(Label, Data)], shape: Concept.Record) extends Data
+  case class Record private (values: scala.List[(Label, Data)], shape: Concept.Record) extends Data {
+    def toStruct = Data.Struct(values)
+  }
   object Record {
     def apply(namespace: FQName, fields: (Label, Data)*): Record =
       apply(namespace, fields.toList)

--- a/morphir/src/org/finos/morphir/datamodel/PrintSpec.scala
+++ b/morphir/src/org/finos/morphir/datamodel/PrintSpec.scala
@@ -1,12 +1,13 @@
 package org.finos.morphir.datamodel
 
-import org.finos.morphir.naming._
 import org.finos.morphir.datamodel.Concept
+import org.finos.morphir.naming.*
 import zio.Chunk
+import org.finos.morphir.datamodel.*
 
 object PrintSpec {
 
-  private[datamodel] class QualifiedNameCollector extends ConceptStatefulTransformer[Chunk[FQName]] {
+  class QualifiedNameCollector extends ConceptStatefulTransformer[Chunk[FQName]] {
     override def of(c: Concept) =
       c match {
         case v @ Concept.Record(name, fields) => Stateful.succeedWithState(v)(chunk => chunk :+ name)
@@ -15,23 +16,25 @@ object PrintSpec {
         case other                            => super.of(other)
       }
   }
-  private[datamodel] object QualifiedNameCollector {
+  object QualifiedNameCollector {
     def collectFrom(c: Concept) =
       (new QualifiedNameCollector().of(c)).run(Chunk[FQName]()) match {
         case (chunk, _) => chunk
       }
   }
 
+  import PathRenderer.TitleCase.given
+
   def of(concept: Concept): String = {
     val typesList = concept.collectAll
 
     def printModuleDef(qn: FQName) =
-      s"{- ============ Declaring ${s"${qn.pack.show}:${qn.modulePath}:${qn.localName}"} ============ -}\n" +
-        s"module ${qn.pack.show}.${qn.modulePath} exposing (${qn.localName})"
+      s"{- ============ Declaring ${s"${qn.pack.render}:${qn.modulePath.path.render}:${qn.localName.render}"} ============ -}\n" +
+        s"module ${qn.pack.render}.${qn.modulePath.path.render} exposing (${qn.localName.render})"
 
     def printImportDef(qn: FQName) =
-      s"{- Importing ${s"${qn.pack.show}:${qn.modulePath}:${qn.localName}"} -}\n" +
-        s"import ${qn.pack.show}.${qn.modulePath} exposing (${qn.localName})"
+      s"{- Importing ${s"${qn.pack.render}:${qn.modulePath.path.render}:${qn.localName.render}"} -}\n" +
+        s"import ${qn.pack.render}.${qn.modulePath.path.render} exposing (${qn.localName.render})"
 
     def printFields(fields: List[(Label, Concept)]): String = {
       val fieldPrints = fields.map { case (label, field) =>
@@ -48,7 +51,7 @@ object PrintSpec {
     }
 
     def printRecordDef(r: Concept.Record) = {
-      val alias       = s"type alias ${r.namespace.localName} ="
+      val alias       = s"type alias ${r.namespace.localName.render} ="
       val fieldPrints = printFields(r.fields)
       val allFieldPrints =
         alias + "\n" + "  " + fieldPrints
@@ -92,7 +95,7 @@ object PrintSpec {
 
       printModuleDef(e.name) + "\n" +
         importDefsPrint +
-        s"type ${e.name.localName}" + "\n" + casePrintString
+        s"type ${e.name.localName.render}" + "\n" + casePrintString
     }
 
     def printRecordInfo(r: Concept.Record) = {
@@ -121,7 +124,7 @@ object PrintSpec {
 
         case r: Concept.Record =>
           if (isTopLevel) printRecordInfo(r)
-          else r.namespace.localName.toString
+          else r.namespace.localName.render
 
         case Concept.Struct(fields) =>
           printFields(fields)
@@ -130,7 +133,7 @@ object PrintSpec {
         //      we need a folder that collects QNames (what about things inside of record? should record def handle that?)
         case Concept.Alias(name, value) =>
           val rhs = printConcept(value)
-          s"${printModuleDef(name)}\ntype alias ${name.localName} = $rhs".stripMargin
+          s"${printModuleDef(name)}\ntype alias ${name.localName.render} = $rhs".stripMargin
 
         case Concept.List(elementType) =>
           val rhs = printConcept(elementType)
@@ -155,7 +158,7 @@ object PrintSpec {
 
         case e: Concept.Enum =>
           if (isTopLevel) printEnumDef(e)
-          else e.name.localName.toString
+          else e.name.localName.render
 
         case Concept.Union(cases) => "<UNION NOT SUPPORTED IN ELM>"
       }

--- a/morphir/src/org/finos/morphir/datamodel/PrintSpec.scala
+++ b/morphir/src/org/finos/morphir/datamodel/PrintSpec.scala
@@ -23,7 +23,7 @@ object PrintSpec {
       }
   }
 
-  import PathRenderer.TitleCase.given
+  import PathRenderer.TitleCase._
 
   def of(concept: Concept): String = {
     val typesList = concept.collectAll

--- a/morphir/src/org/finos/morphir/util/Compare.scala
+++ b/morphir/src/org/finos/morphir/util/Compare.scala
@@ -1,8 +1,8 @@
-package org.finos.morphir.ir.json.util
+package org.finos.morphir.util
 
+import scala.collection.immutable
 import scala.collection.immutable.ListMap
 import scala.reflect.ClassTag
-import scala.collection.immutable
 
 object Compare {
   sealed trait Diff

--- a/morphir/src/org/finos/morphir/util/PrintDiff.scala
+++ b/morphir/src/org/finos/morphir/util/PrintDiff.scala
@@ -1,4 +1,4 @@
-package org.finos.morphir.ir.json.util
+package org.finos.morphir.util
 
 object PrintDiff {
   def apply(value: Compare.Diff) = new PrintDiff().apply(value)
@@ -6,12 +6,10 @@ object PrintDiff {
 
 private class PrintDiff(val defaultWidth: Int = 150) extends pprint.Walker {
   import fansi.Str
+  import pprint.Tree.{Apply, Infix, KeyValue, Lazy}
   import pprint.{Renderer, Tree, Truncated}
+
   import java.util.function.UnaryOperator
-  import pprint.Tree.Apply
-  import pprint.Tree.KeyValue
-  import pprint.Tree.Lazy
-  import pprint.Tree.Infix
 
   // Show field names e.g.
   // Property(ir = Ident(name = "inst"), name = "currentDate") vs

--- a/morphir/test/src-3/org/finos/morphir/datamodel/ToDataEnums.scala
+++ b/morphir/test/src-3/org/finos/morphir/datamodel/ToDataEnums.scala
@@ -14,7 +14,8 @@ object EnumGns {
 object EnumData1 {
   import EnumGns._
   implicit val gnsImpl: GlobalDatamodelContext = new GlobalDatamodelContext {
-    def value = gns
+    def value                    = gns
+    override def enumTranslation = EnumTranslation.MutiFieldConstructor
   }
 
   sealed trait Foo
@@ -27,7 +28,8 @@ object EnumData1 {
 object EnumData2 {
   import EnumGns._
   implicit val gnsImpl: GlobalDatamodelContext = new GlobalDatamodelContext {
-    def value = gns
+    def value                    = gns
+    override def enumTranslation = EnumTranslation.MutiFieldConstructor
   }
 
   enum Foo {
@@ -41,11 +43,13 @@ object EnumData2 {
 object EnumData3 {
   import EnumGns._
   implicit val gnsImpl: TypeDatamodelContext[Foo] = new TypeDatamodelContext[Foo] {
-    def value = gns
+    def value                    = gns
+    override def enumTranslation = EnumTranslation.MutiFieldConstructor
   }
 
   implicit val gnsImpl2: TypeDatamodelContext[Baz] = new TypeDatamodelContext[Baz] {
-    def value = gns
+    def value                    = gns
+    override def enumTranslation = EnumTranslation.MutiFieldConstructor
   }
 
   sealed trait Foo

--- a/morphir/test/src-3/org/finos/morphir/datamodel/ToDataEnumsSimple.scala
+++ b/morphir/test/src-3/org/finos/morphir/datamodel/ToDataEnumsSimple.scala
@@ -20,6 +20,22 @@ object EnumData4 {
   val deriver = Deriver.gen[Foo]
 }
 
+object EnumData5 {
+  import EnumGns._
+  implicit val gnsImpl: GlobalDatamodelContext = new GlobalDatamodelContext {
+    def value                    = gns
+    override def enumTranslation = EnumTranslation.SingleFieldWithRecord
+  }
+
+  sealed trait Foo
+  object Foo {
+    case object Bar               extends Foo
+    case class Baz(value: String) extends Foo
+  }
+
+  val deriver = Deriver.gen[Foo]
+}
+
 class ToDataEnumsSimple extends munit.FunSuite {
   import EnumGns._
 
@@ -40,5 +56,30 @@ class ToDataEnumsSimple extends munit.FunSuite {
     interceptMessage[IllegalArgumentException]("The value `null` is not an instance of the needed enum class Foo") {
       deriver.derive(null)
     }
+  }
+
+  val concept2 =
+    Enum(
+      gns % ("Foo"),
+      Enum.Case(l"Bar"),
+      Enum.Case(Label("Baz"), EnumLabel.Empty -> Concept.Struct(Label("value") -> Concept.String))
+    )
+
+  test("Enum Data 5 - Concept") {
+    import EnumData5._
+    assertEquals(deriver.concept, concept2)
+  }
+
+  test("Enum Data 5 - NoVals") {
+    import EnumData5._
+    assertEquals(deriver.derive(Foo.Bar), Case(List(), "Bar", concept2))
+  }
+
+  test("Enum Data 5 - Value") {
+    import EnumData5._
+    assertEquals(
+      deriver.derive(Foo.Baz("something")),
+      Case(EnumLabel.Empty -> Data.Struct(l"value" -> Data.String("something")))("Baz", concept2)
+    )
   }
 }

--- a/morphir/toolkit/codec/zio/json/test/src/org/finos/morphir/ir/json/util/CustomAssert.scala
+++ b/morphir/toolkit/codec/zio/json/test/src/org/finos/morphir/ir/json/util/CustomAssert.scala
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter.Indenter
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 import com.fasterxml.jackson.core.util.DefaultIndenter
+import org.finos.morphir.util.{Compare, PrintDiff}
 
 object CustomAssert {
   def stringEqualTo(thatRaw: String): Assertion[String] =

--- a/morphir/toolkit/core/src/org/finos/morphir/ir/conversion/ToMorphirType.scala
+++ b/morphir/toolkit/core/src/org/finos/morphir/ir/conversion/ToMorphirType.scala
@@ -88,7 +88,6 @@ object ToMorphirType {
         val types: scala.List[(String, UType)] = fields.map {
           case (k: Label, v: Concept) => (k.value, conceptToTypeIR(v).morphirType)
         }
-        // TODO: When we provide MorphirType map this to a spec or definition
         toUTypeConverter(T.record(types: _*))
 
       // Treat a record as an aliased reference on the type level, on the value level it has fields

--- a/morphir/toolkit/core/src/org/finos/morphir/ir/conversion/ToMorphirValue.scala
+++ b/morphir/toolkit/core/src/org/finos/morphir/ir/conversion/ToMorphirValue.scala
@@ -138,9 +138,15 @@ trait ToMorphirTypedValueInstancesLowPriority { self: ToMorphirValueFunctions =>
         V.reference(shape.morphirType, FQName.fromString("Morphir.SDK:Dict:fromList")),
         V.list(Concept.List(tupleShape).morphirType, zio.Chunk.fromIterable(tuples))
       )
+
     case record: Data.Record =>
       val fields = record.values.map { case (Label(name), value) => (name, dataToIR(value)) }
       V.record(record.shape.morphirType, fields: _*)
+
+    case struct: Data.Struct =>
+      val fields = struct.values.map { case (Label(name), value) => (name, dataToIR(value)) }
+      V.record(struct.shape.morphirType, fields: _*)
+
     case tuple: Data.Tuple =>
       val values = tuple.values.map { data => dataToIR(data) }
       V.tuple(tuple.shape.morphirType, zio.Chunk.fromIterable(values))


### PR DESCRIPTION
* Introduce configuration parameter into GlobalDatamodelContext which allows Enum derivation as single-record enum (this is the new default!)
* Fixed respective tests that use this and added tests for the new behavior
* Fixed PrintSpec
* Move PrintDiff and Compare into morphir-runtime utils package