### PR TITLE
Add Printing and fromString to QualifiedModuleName

### DIFF
--- a/morphir/extensibility/src/org/finos/morphir/Names.scala
+++ b/morphir/extensibility/src/org/finos/morphir/Names.scala
@@ -10,3 +10,4 @@ trait Names
     with PackageNameModule
     with QualifiedModuleNameModule
     with QNameModule
+    with NamingOptionsModule

--- a/morphir/extensibility/src/org/finos/morphir/NamingOptionsModule.scala
+++ b/morphir/extensibility/src/org/finos/morphir/NamingOptionsModule.scala
@@ -1,0 +1,11 @@
+package org.finos.morphir
+
+trait NamingOptionsModule { self: PackageNameModule with ModuleNameModule =>
+
+  sealed case class FQNamingOptions(defaultPackage: PackageName, defaultModule: ModuleName, defaultSeparator: String)
+
+  object FQNamingOptions {
+    implicit val default: FQNamingOptions =
+      FQNamingOptions(PackageName.empty, ModuleName.empty, ":")
+  }
+}

--- a/morphir/extensibility/src/org/finos/morphir/fqname.scala
+++ b/morphir/extensibility/src/org/finos/morphir/fqname.scala
@@ -3,7 +3,8 @@ package org.finos.morphir
 trait FQNameModule {
   self: NameModule with ModuleNameModule with NamespaceModule with PackageNameModule with PathModule
     with QualifiedModuleNameModule
-    with QNameModule =>
+    with QNameModule
+    with NamingOptionsModule =>
 
   sealed case class FQName(packagePath: PackageName, modulePath: ModuleName, localName: Name) { self =>
     def getPackagePath: Path = packagePath.toPath
@@ -98,13 +99,6 @@ trait FQNameModule {
     object ReferenceName {
       def unapply(fqName: FQName): Some[String] = Some(fqName.toReferenceName)
     }
-  }
-
-  sealed case class FQNamingOptions(defaultPackage: PackageName, defaultModule: ModuleName, defaultSeparator: String)
-
-  object FQNamingOptions {
-    implicit val default: FQNamingOptions =
-      FQNamingOptions(PackageName.empty, ModuleName.empty, ":")
   }
 
   sealed case class FQNameParsingError(invalidName: String)

--- a/morphir/extensibility/src/org/finos/morphir/nodeID.scala
+++ b/morphir/extensibility/src/org/finos/morphir/nodeID.scala
@@ -1,7 +1,8 @@
 package org.finos.morphir
 
 trait NodeIDModule {
-  self: FQNameModule with NameModule with PathModule with PackageNameModule with ModuleNameModule
+  self: FQNameModule with NamingOptionsModule with NameModule with PathModule with PackageNameModule
+    with ModuleNameModule
     with QualifiedModuleNameModule =>
   import NodePath.*
 

--- a/morphir/extensibility/src/org/finos/morphir/qualifiedModuleName.scala
+++ b/morphir/extensibility/src/org/finos/morphir/qualifiedModuleName.scala
@@ -1,5 +1,6 @@
 package org.finos.morphir
 
+// TODO printing options
 trait QualifiedModuleNameModule {
   self: PackageNameModule with PathModule with ModuleNameModule with NamespaceModule =>
 

--- a/morphir/extensibility/src/org/finos/morphir/qualifiedModuleName.scala
+++ b/morphir/extensibility/src/org/finos/morphir/qualifiedModuleName.scala
@@ -1,8 +1,8 @@
 package org.finos.morphir
 
-// TODO printing options
 trait QualifiedModuleNameModule {
-  self: PackageNameModule with PathModule with ModuleNameModule with NamespaceModule =>
+  self: NameModule with PackageNameModule with PathModule with ModuleNameModule with NamespaceModule
+    with NamingOptionsModule =>
 
   /// A qualified module name is a globally unique identifier for a module. It is represented by the combination of a package name and the module name.
   sealed case class QualifiedModuleName(packageName: PackageName, modulePath: ModuleName) { self =>
@@ -12,6 +12,11 @@ trait QualifiedModuleNameModule {
       QualifiedModuleName(self.packageName, modulePath.addPart(namespaceAddition))
 
     def toTuple: (Path, Path) = (packageName.toPath, modulePath.toPath)
+
+    override def toString: String = Array(
+      Path.toString(Name.toTitleCase, ".", packageName.toPath),
+      Path.toString(Name.toTitleCase, ".", modulePath.toPath)
+    ).mkString(":")
   }
 
   object QualifiedModuleName {
@@ -23,9 +28,33 @@ trait QualifiedModuleNameModule {
     def apply(modulePath: String)(implicit packageName: PackageName): QualifiedModuleName =
       QualifiedModuleName(packageName, ModuleName.fromString(modulePath))
 
+    /** Parse a string into a QualifedModuleName using splitter as the separator between package, and module */
+    def fromString(nameString: String, splitter: String)(implicit options: FQNamingOptions): QualifiedModuleName =
+      nameString.split(splitter) match {
+        case Array(moduleNameString, localNameString) =>
+          qmn(moduleNameString, localNameString)
+        case Array(localNameString) =>
+          qmn(localNameString)
+        case _ => throw QualifiedModuleNameParsingError(nameString)
+      }
+
+    def fromString(fqNameString: String)(implicit options: FQNamingOptions): QualifiedModuleName =
+      fromString(fqNameString, options.defaultSeparator)
+
+    /** Convenience function to create a fully-qualified name from 2 strings with default package name */
+    def qmn(packageName: String, moduleName: String)(implicit options: FQNamingOptions): QualifiedModuleName =
+      QualifiedModuleName(PackageName.fromString(packageName), ModuleName(Path.fromString(moduleName)))
+
+    /** Convenience function to create a fully-qualified name from 1 string with defaults for package and module */
+    def qmn(moduleName: String)(implicit options: FQNamingOptions): QualifiedModuleName =
+      QualifiedModuleName(options.defaultPackage, ModuleName(Path.fromString(moduleName)))
+
     object AsTuple {
       def unapply(name: QualifiedModuleName): Option[(Path, Path)] =
         Some(name.toTuple)
     }
   }
+
+  sealed case class QualifiedModuleNameParsingError(invalidName: String)
+      extends Exception(s"Unable to parse: [$invalidName] into a valid QualifiedModuleName")
 }

--- a/morphir/extensibility/src/org/finos/morphir/qualifiedModuleName.scala
+++ b/morphir/extensibility/src/org/finos/morphir/qualifiedModuleName.scala
@@ -42,7 +42,7 @@ trait QualifiedModuleNameModule {
       fromString(fqNameString, options.defaultSeparator)
 
     /** Convenience function to create a fully-qualified name from 2 strings with default package name */
-    def qmn(packageName: String, moduleName: String)(implicit options: FQNamingOptions): QualifiedModuleName =
+    def qmn(packageName: String, moduleName: String): QualifiedModuleName =
       QualifiedModuleName(PackageName.fromString(packageName), ModuleName(Path.fromString(moduleName)))
 
     /** Convenience function to create a fully-qualified name from 1 string with defaults for package and module */


### PR DESCRIPTION
* QualifiedModuleName needs a toString to print easily.
* Also should have a fromString to parse easily.
* In order to do that, need to add helpers similar to fqn. I called them `qmn`.
* Also, it's easiest to reuse FQNaming options so I extracted that out into a separate module.