### PR TITLE
Make Result.Tuple(Any) typed, better Dict.fromList, add Dict.toList

### DIFF
--- a/examples/morphir-elm-projects/evaluator-tests/morphir-hashes.json
+++ b/examples/morphir-elm-projects/evaluator-tests/morphir-hashes.json
@@ -2,7 +2,7 @@
     "src/Morphir/Examples/App/ConstructorTests.elm": "56fdf0bd81a5d4b51e8e94cf16d01c05",
     "src/Morphir/Examples/App/CurrentTest.elm": "7217989153ede6e82dfe1edb324e8aa5",
     "src/Morphir/Examples/App/DestructureTests.elm": "130b60a9f5c1f62b9e1394b2b1b74339",
-    "src/Morphir/Examples/App/DictionaryTests.elm": "4dd8cb526ee1cc0fe2515d77eb0dcf36",
+    "src/Morphir/Examples/App/DictionaryTests.elm": "8bbf548cc783dab52dd17bf25384027f",
     "src/Morphir/Examples/App/EllieStuff.elm": "f9259184f634d714dabcd8ec90f07e7a",
     "src/Morphir/Examples/App/EnumTest.elm": "1bdb50499357960926f3ffe7984a83c0",
     "src/Morphir/Examples/App/ExampleModule.elm": "e90c60dd8d4756d55d91efd7923a8cca",

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/DictionaryTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/DictionaryTests.elm
@@ -5,6 +5,13 @@ import Dict exposing (Dict)
 {-
 -}
 
+dictToListTest: () -> List (Int, String)
+dictToListTest _ =
+  let
+    dict = Dict.fromList [(1, "Red"), (2, "Blue"), (3, "Orange")]
+  in
+    Dict.toList dict
+
 dictFilterTest: () -> Dict Int String
 dictFilterTest _ =
     let

--- a/morphir/runtime/src/org/finos/morphir/runtime/MorphirRuntimeError.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/MorphirRuntimeError.scala
@@ -23,6 +23,7 @@ sealed abstract class EvaluationError(message: String) extends MorphirRuntimeErr
 final case class IrToDatamodelError(message: String)         extends EvaluationError(message)
 final case class MissingField(message: String)               extends EvaluationError(message)
 final case class UnexpectedType(message: String)             extends EvaluationError(message)
+final case class IllegalValue(message: String)               extends EvaluationError(message)
 final case class UnmatchedPattern(message: String)           extends EvaluationError(message)
 final case class FunctionWithoutParameters(message: String)  extends EvaluationError(message)
 final case class VariableNotFound(message: String)           extends EvaluationError(message)

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/EvaluatorQuick.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/EvaluatorQuick.scala
@@ -59,8 +59,7 @@ object EvaluatorQuick {
       case Result.ListResult(elements) => elements.map(unwrap(_)) // Needed for non-higher-order head, presumably others
       case Result.SetResult(elements)  => elements.map(unwrap(_)) // Needed for non-higher-order head, presumably others
       case Result.Tuple(elements) => // Needed for tuple.first, possibly others
-        val listed =
-          Helpers.tupleToList(elements).getOrElse(throw new UnexpectedType("Invalid tuple returned to top level"))
+        val listed = elements.toList
         val mapped = listed.map(unwrap(_))
         Helpers.listToTuple(mapped)
       case Result.MapResult(elements) => elements.map { case (key, value) =>
@@ -80,8 +79,8 @@ object EvaluatorQuick {
         })
       case l: List[_]                  => Result.ListResult(l.map(wrap(_)))
       case s: mutable.LinkedHashSet[_] => Result.SetResult(s.map(wrap(_)))
-      case (first, second)             => Result.Tuple((wrap(first), wrap(second)))
-      case (first, second, third)      => Result.Tuple((wrap(first), wrap(second), wrap(third)))
+      case (first, second)             => Result.Tuple(TupleSigniture.Tup2((wrap(first), wrap(second))))
+      case (first, second, third)      => Result.Tuple(TupleSigniture.Tup3((wrap(first), wrap(second), wrap(third))))
       // TODO: Option, Result, LocalDate
       case intType: IntType => Result.Primitive.Long(intType.toLong)
       case primitive        => Result.Primitive.makeOrFail(primitive)
@@ -271,7 +270,7 @@ object EvaluatorQuick {
           Data.Case(argData, fqName.localName.toTitleCase, enumConcept)
         }
       case (Concept.Tuple(conceptElements), Result.Tuple(resultElements)) =>
-        val listed = Helpers.tupleToList[Unit, Type.UType](resultElements).get
+        val listed = resultElements.toList
         if (conceptElements.length != listed.length) {
           throw new ResultDoesNotMatchType(
             s"Tuple type elements $conceptElements of different length than result $resultElements"

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Helpers.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Helpers.scala
@@ -43,10 +43,7 @@ object Helpers {
           tailBindings <- matchPatternCase(tailPattern, Result.ListResult(tail))
         } yield headBindings ++ tailBindings
       case (TuplePattern(_, patterns), Result.Tuple(tuple)) =>
-        for {
-          listedTuple: List[Result[TA, VA]] <- tupleToList[TA, VA](tuple)
-          res                               <- matchListOfPatterns(patterns.toList, listedTuple)
-        } yield res
+        matchListOfPatterns(patterns.toList, tuple.toList)
       case (ConstructorPattern(_, patternName, patterns), Result.ConstructorResult(valueName, values))
           if patternName == valueName =>
         matchListOfPatterns(patterns.toList, values)
@@ -67,42 +64,6 @@ object Helpers {
         } yield priorBindings ++ newBindings
       }
     } yield res
-
-  def tupleToList[TA, VA](tuple: Any): Option[List[Result[TA, VA]]] = {
-    val anyList = tuple match {
-      case Tuple1(a)                                     => Some(List(a))
-      case (a, b)                                        => Some(List(a, b))
-      case (a, b, c)                                     => Some(List(a, b, c))
-      case (a, b, c, d)                                  => Some(List(a, b, c, d))
-      case (a, b, c, d, e)                               => Some(List(a, b, c, d, e))
-      case (a, b, c, d, e, f)                            => Some(List(a, b, c, d, e, f))
-      case (a, b, c, d, e, f, g)                         => Some(List(a, b, c, d, e, f, g))
-      case (a, b, c, d, e, f, g, h)                      => Some(List(a, b, c, d, e, f, g, h))
-      case (a, b, c, d, e, f, g, h, i)                   => Some(List(a, b, c, d, e, f, g, h, i))
-      case (a, b, c, d, e, f, g, h, i, j)                => Some(List(a, b, c, d, e, f, g, h, i, j))
-      case (a, b, c, d, e, f, g, h, i, j, k)             => Some(List(a, b, c, d, e, f, g, h, i, j, k))
-      case (a, b, c, d, e, f, g, h, i, j, k, l)          => Some(List(a, b, c, d, e, f, g, h, i, j, k, l))
-      case (a, b, c, d, e, f, g, h, i, j, k, l, m)       => Some(List(a, b, c, d, e, f, g, h, i, j, k, l, m))
-      case (a, b, c, d, e, f, g, h, i, j, k, l, m, n)    => Some(List(a, b, c, d, e, f, g, h, i, j, k, l, m, n))
-      case (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => Some(List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o))
-      case (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) =>
-        Some(List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p))
-      case (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) =>
-        Some(List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q))
-      case (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) =>
-        Some(List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r))
-      case (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) =>
-        Some(List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s))
-      case (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) =>
-        Some(List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t))
-      case (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) =>
-        Some(List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u))
-      case (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) =>
-        Some(List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v))
-      case _ => None
-    }
-    anyList.map(_.map(_.asInstanceOf[Result[TA, VA]]))
-  }
 
   def listToTuple(
       items: List[Any]

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
@@ -277,7 +277,7 @@ object Loop {
 
   def handleTuple[TA, VA](va: VA, elements: List[Value[TA, VA]], store: Store[TA, VA]): Result[TA, VA] = {
     val evaluatedElements = elements.map(loop(_, store))
-    Result.Tuple(listToTuple(evaluatedElements))
+    Result.Tuple(TupleSigniture.fromList(evaluatedElements))
   }
 
   def handleUnit[TA, VA](va: VA): Result[TA, VA] = Result.Unit()

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
@@ -101,7 +101,7 @@ object Loop {
 
         }
       case Result.NativeFunction(arguments, curried, function) =>
-        def assertNumArgs(num: Int) =
+        def assertCurriedNumArgs(num: Int) =
           if (curried.size != num) throw new IllegalValue(
             s"Curried wrong number of (uncurried) args. Needed ${function.numArgs} args but got (${curried.size}) when applying the function $function"
           )
@@ -110,20 +110,20 @@ object Loop {
           case 1 =>
             function match {
               case NativeFunctionSignature.Fun1(f) =>
-                assertNumArgs(1)
-                f(curried(0))
+                assertCurriedNumArgs(0)
+                f(argValue)
               case NativeFunctionSignature.Fun2(f) =>
-                assertNumArgs(2)
-                f(curried(0), curried(1))
+                assertCurriedNumArgs(1)
+                f(curried(0), argValue)
               case NativeFunctionSignature.Fun3(f) =>
-                assertNumArgs(3)
-                f(curried(0), curried(1), curried(2))
+                assertCurriedNumArgs(2)
+                f(curried(0), curried(1), argValue)
               case NativeFunctionSignature.Fun4(f) =>
-                assertNumArgs(4)
-                f(curried(0), curried(1), curried(2), curried(3))
+                assertCurriedNumArgs(3)
+                f(curried(0), curried(1), curried(2), argValue)
               case NativeFunctionSignature.Fun5(f) =>
-                assertNumArgs(5)
-                f(curried(0), curried(1), curried(2), curried(3), curried(4))
+                assertCurriedNumArgs(4)
+                f(curried(0), curried(1), curried(2), curried(3), argValue)
             }
           // If there are more arguments left in the native-signature, that needs we have more uncurrying to do
           case x => Result.NativeFunction[TA, VA](x - 1, curried :+ argValue, function)

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Native.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Native.scala
@@ -2,7 +2,7 @@ package org.finos.morphir.runtime.quick
 
 import org.finos.morphir.ir.Type
 import org.finos.morphir.naming.*
-import org.finos.morphir.runtime.UnsupportedType
+import org.finos.morphir.runtime.{IllegalValue, UnexpectedType, UnsupportedType}
 import org.finos.morphir.runtime.quick.Result.Primitive
 
 import scala.collection.mutable
@@ -28,17 +28,23 @@ object DictSDK {
 
   val fromList: SDKValue[Unit, Type.UType] = SDKValue.SDKNativeFunction.fun1 {
     (l: Result[Unit, Type.UType]) =>
-      val list = l.asInstanceOf[Result.ListResult[Unit, Type.UType]].elements
-      val mapped = list
+      val list = l.unwrapList
+      val mappedList = list
         .map { input =>
-          val asTuple = input
-            .asInstanceOf[Result.Tuple[Unit, Type.UType]]
-            .elements
-            .asInstanceOf[(Result[Unit, Type.UType], Result[Unit, Type.UType])]
-          asTuple._1 -> asTuple._2
+          input.unwrapTuple match {
+            case TupleSigniture.Tup2((a, b)) => (a, b)
+            case _ =>
+              throw new IllegalValue(s"Input to Dict.fromList was not a Tuple2-based element, it was: `$input`")
+          }
         }
-        .to(mutable.LinkedHashMap)
-      Result.MapResult(mapped)
+      Result.MapResult(mutable.LinkedHashMap(mappedList: _*))
+  }
+
+  val toList: SDKValue[Unit, Type.UType] = SDKValue.SDKNativeFunction.fun1 {
+    (d: Result[Unit, Type.UType]) =>
+      val dict     = d.unwrapMap
+      val elements = dict.toList.map { case (k, v) => Result.Tuple(TupleSigniture.Tup2(k, v)) }
+      Result.ListResult(elements)
   }
 
   val empty: SDKValue[Unit, Type.UType] = SDKValue.SDKNativeValue(Result.MapResult(mutable.LinkedHashMap()))
@@ -67,6 +73,7 @@ object DictSDK {
 
   val sdk: Map[FQName, SDKValue[Unit, Type.UType]] = Map(
     FQName.fromString("Morphir.SDK:Dict:fromList") -> fromList,
+    FQName.fromString("Morphir.SDK:Dict:toList")   -> toList,
     FQName.fromString("Morphir.SDK:Dict:get")      -> get,
     FQName.fromString("Morphir.SDK:Dict:filter")   -> filter,
     FQName.fromString("Morphir.SDK:Dict:insert")   -> insert,

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Native.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Native.scala
@@ -43,7 +43,7 @@ object DictSDK {
   val toList: SDKValue[Unit, Type.UType] = SDKValue.SDKNativeFunction.fun1 {
     (d: Result[Unit, Type.UType]) =>
       val dict     = d.unwrapMap
-      val elements = dict.toList.map { case (k, v) => Result.Tuple(TupleSigniture.Tup2(k, v)) }
+      val elements = dict.toList.map { case (k, v) => Result.Tuple(TupleSigniture.Tup2((k, v))) }
       Result.ListResult(elements)
   }
 

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/NativeFunctionSignature.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/NativeFunctionSignature.scala
@@ -13,7 +13,13 @@ object NativeFunctionSignature {
       extends NativeFunctionSignature[TA, VA] { val numArgs = 3 }
   case class Fun4[TA, VA](f: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA]) => Result[TA, VA])
       extends NativeFunctionSignature[TA, VA] { val numArgs = 4 }
-  case class Fun5[TA, VA](f: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA]) => Result[TA, VA])
+  case class Fun5[TA, VA](f: (
+      Result[TA, VA],
+      Result[TA, VA],
+      Result[TA, VA],
+      Result[TA, VA],
+      Result[TA, VA]
+  ) => Result[TA, VA])
       extends NativeFunctionSignature[TA, VA] { val numArgs = 5 }
 }
 
@@ -21,6 +27,15 @@ object NativeFunctionSignature {
 sealed trait NativeFunctionSignatureAdv[TA, VA] {
   def numArgs: Int
   def f: Store[TA, VA] => Any
+  // Apply the store an convert back to a regular function
+  def applyStore(store: Store[TA, VA]) =
+    this match {
+      case NativeFunctionSignatureAdv.Fun1(f) => NativeFunctionSignature.Fun1(f(store))
+      case NativeFunctionSignatureAdv.Fun2(f) => NativeFunctionSignature.Fun2(f(store))
+      case NativeFunctionSignatureAdv.Fun3(f) => NativeFunctionSignature.Fun3(f(store))
+      case NativeFunctionSignatureAdv.Fun4(f) => NativeFunctionSignature.Fun4(f(store))
+      case NativeFunctionSignatureAdv.Fun5(f) => NativeFunctionSignature.Fun5(f(store))
+    }
 }
 object NativeFunctionSignatureAdv {
   case class Fun1[TA, VA](f: Store[TA, VA] => Result[TA, VA] => Result[TA, VA])
@@ -37,6 +52,7 @@ object NativeFunctionSignatureAdv {
   ) => Result[TA, VA])
       extends NativeFunctionSignatureAdv[TA, VA] { val numArgs = 4 }
   case class Fun5[TA, VA](f: Store[TA, VA] => (
+      Result[TA, VA],
       Result[TA, VA],
       Result[TA, VA],
       Result[TA, VA],

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Result.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Result.scala
@@ -374,6 +374,9 @@ object Result {
     }
   }
 
-  case class NativeFunction[TA, VA](arguments: Int, curried: List[Result[TA, VA]], function: Any)
-      extends Result[TA, VA] {}
+  case class NativeFunction[TA, VA](
+      arguments: Int,
+      curried: List[Result[TA, VA]],
+      function: NativeFunctionSignature[TA, VA]
+  ) extends Result[TA, VA] {}
 }

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Result.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Result.scala
@@ -23,6 +23,7 @@ sealed trait Result[TA, VA] {
   def unwrapPrimitive = Result.unwrapPrimitive(this)
   def unwrapNumeric   = Result.unwrapNumeric(this)
   def unwrapList      = Result.unwrapList(this)
+  def unwrapTuple     = Result.unwrapTuple(this)
   def unwrapMap       = Result.unwrapMap(this)
 }
 
@@ -35,9 +36,7 @@ object Result {
       case ListResult(elements) => elements.map(unwrap(_))
       case SetResult(elements)  => elements.map(unwrap(_))
       case Tuple(elements) =>
-        val listed =
-          Helpers.tupleToList(elements).getOrElse(throw new UnexpectedType("Invalid tuple returned to top level"))
-        val mapped = listed.map(unwrap(_))
+        val mapped = elements.toList.map(unwrap(_))
         Helpers.listToTuple(mapped)
       case Record(elements)                => elements.map { case (name, value) => name.toCamelCase -> unwrap(value) }
       case MapResult(elements)             => elements.map { case (key, value) => unwrap(key) -> unwrap(value) }
@@ -60,6 +59,15 @@ object Result {
   def unwrapMap[TA, VA](arg: Result[TA, VA]): LinkedHashMap[Result[TA, VA], Result[TA, VA]] =
     arg match {
       case Result.MapResult(map) => map
+      case _ =>
+        throw new UnexpectedType(
+          s"Cannot unwrap the value `${arg}` into a MapResult value. It is not a list result!"
+        )
+    }
+
+  def unwrapTuple[TA, VA](arg: Result[TA, VA]): TupleSigniture[TA, VA] =
+    arg match {
+      case Result.Tuple(tup) => tup
       case _ =>
         throw new UnexpectedType(
           s"Cannot unwrap the value `${arg}` into a MapResult value. It is not a list result!"
@@ -304,10 +312,10 @@ object Result {
     override def succinct(depth: Int) = s"LocalTime($value)"
   }
 
-  case class Tuple[TA, VA](elements: Any) extends Result[TA, VA] {
+  case class Tuple[TA, VA](elements: TupleSigniture[TA, VA]) extends Result[TA, VA] {
     override def succinct(depth: Int) = if (depth == 0) "Tuple(...)"
     else {
-      s"Tuple(${Helpers.tupleToList(elements).map((res: Any) => res.asInstanceOf[Result[TA, VA]]).map(_.succinct(depth - 1)).mkString(", ")})"
+      s"Tuple(${elements.toList.map(_.succinct(depth - 1)).mkString(", ")})"
     }
   }
 

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Store.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Store.scala
@@ -30,7 +30,13 @@ object SDKValue {
       new SDKNativeFunction(Fun3[TA, VA](f))
     def fun4[TA, VA](f: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA]) => Result[TA, VA]) =
       new SDKNativeFunction(Fun4[TA, VA](f))
-    def fun5[TA, VA](f: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA]) => Result[TA, VA]) =
+    def fun5[TA, VA](f: (
+        Result[TA, VA],
+        Result[TA, VA],
+        Result[TA, VA],
+        Result[TA, VA],
+        Result[TA, VA]
+    ) => Result[TA, VA]) =
       new SDKNativeFunction(Fun5[TA, VA](f))
   }
 

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/TupleSigniture.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/TupleSigniture.scala
@@ -1,0 +1,72 @@
+package org.finos.morphir.runtime.quick
+
+import org.finos.morphir.runtime.IllegalValue
+
+sealed trait TupleSigniture[TA, VA] {
+  def value: Product
+  def toList = value.productIterator.map(_.asInstanceOf[Result[TA, VA]]).toList
+}
+object TupleSigniture {
+  def fromList[TA, VA](list: List[Result[TA, VA]]) =
+    // Large tuple signatures will overflow the formatting limitations, just need for this part of the file
+    // format: off
+    list match {
+      case List(a) => Tup1[TA, VA](Tuple1(a))
+      case List(a, b) => Tup2[TA, VA]((a, b))
+      case List(a, b, c) => Tup3[TA, VA]((a, b, c))
+      case List(a, b, c, d) => Tup4[TA, VA]((a, b, c, d))
+      case List(a, b, c, d, e) => Tup5[TA, VA]((a, b, c, d, e))
+      case List(a, b, c, d, e, f) => Tup6[TA, VA]((a, b, c, d, e, f))
+      case List(a, b, c, d, e, f, g) => Tup7[TA, VA]((a, b, c, d, e, f, g))
+      case List(a, b, c, d, e, f, g, h) => Tup8[TA, VA]((a, b, c, d, e, f, g, h))
+      case List(a, b, c, d, e, f, g, h, i) => Tup9[TA, VA]((a, b, c, d, e, f, g, h, i))
+      case List(a, b, c, d, e, f, g, h, i, j) => Tup10[TA, VA]((a, b, c, d, e, f, g, h, i, j))
+      case List(a, b, c, d, e, f, g, h, i, j, k) => Tup11[TA, VA]((a, b, c, d, e, f, g, h, i, j, k))
+      case List(a, b, c, d, e, f, g, h, i, j, k, l) => Tup12[TA, VA]((a, b, c, d, e, f, g, h, i, j, k, l))
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m) => Tup13[TA, VA]((a, b, c, d, e, f, g, h, i, j, k, l, m))
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n) => Tup14[TA, VA]((a, b, c, d, e, f, g, h, i, j, k, l, m, n))
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => Tup15[TA, VA]((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o))
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => Tup16[TA, VA]((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p))
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) => Tup17[TA, VA]((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q))
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) => Tup18[TA, VA]((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r))
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) => Tup19[TA, VA]((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s))
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) => Tup20[TA, VA]((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t))
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) => Tup21[TA, VA]((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u))
+      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) => Tup22[TA, VA]((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v))
+      case _ => throw new IllegalValue(
+          s"Cannot convert a list of length ${list.length} into a tuple, it is too big (the first elements of the list are [${printListUpTo10(list)}])."
+        )
+    }
+    // format: on
+
+  private def printListUpTo10[T](list: List[T]) = {
+    val dots = if (list.length > 10) "..." else ""
+    list.take(10).mkString("", ", ", dots)
+  }
+
+  // Large tuple signatures will overflow the formatting limitations, just need for this part of the file
+  // format: off
+  case class Tup1[TA, VA](value: Tuple1[Result[TA, VA]]) extends TupleSigniture[TA, VA]
+  case class Tup2[TA, VA](value: (Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup3[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup4[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup5[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup6[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup7[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup8[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup9[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup10[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup11[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup12[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup13[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup14[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup15[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup16[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup17[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup18[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup19[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup20[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup21[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+  case class Tup22[TA, VA](value: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA])) extends TupleSigniture[TA, VA]
+// format: off
+}

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -598,6 +598,11 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           (Data.Int(4), Data.String("White")),
           (Data.Int(5), Data.String("Green"))
         )),
+        testEvaluation("Converts a dictionary into a list")("dictionaryTests", "dictToListTest")(Data.List(
+          Data.Tuple(Data.Int(1), Data.String("Red")),
+          Data.Tuple(Data.Int(2), Data.String("Blue")),
+          Data.Tuple(Data.Int(3), Data.String("Orange"))
+        )),
         testEvaluation("Get")("dictionaryTests", "dictGetTest")(Data.Optional.Some(Data.String("Cat"))),
         testEvaluation("Filters a dictionary")("dictionaryTests", "dictFilterTest")(Data.Map(
           (Data.Int(3), Data.String("Blue")),


### PR DESCRIPTION
* Make `Result.Tuple(Any)` argument typed similar to the way SDKNativeFunction was done.
* Make `Result.NativeFunction(Any)` type similar to the way SDKNativeFunction was done
* Needed a few helpers for the above things e.g. List => Tuple translation (that stuff exists in the standard library but only in Scala 3 and we're cross-compiling the evaluator)
* Needed a few helpers to convert NativeFunctionSignature if it takes a store (i.e. something that can execute inside of a native function like `List.map`)
* These things required various changes in `EvaluatorQuick.scala` and `Loop.scala`
* Implemented `Dict.toList` and fixed up `Dict.fromList`. Added a test. 