### PR TITLE
Simplify evaluator-loop call from Native

### DIFF
--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
@@ -57,6 +57,20 @@ object Loop {
     handleApplyResult(va, functionValue, argValue, store)
   }
 
+  def handleApplyResult2[TA, VA](
+      va: VA,
+      functionValue: Result[TA, VA],
+      arg1: Result[TA, VA],
+      arg2: Result[TA, VA],
+      store: Store[TA, VA]
+  ): Result[TA, VA] = {
+    val partiallyAppliedFunction =
+      Loop.handleApplyResult[TA, VA](va, functionValue, arg1, store)
+    val result =
+      Loop.handleApplyResult[TA, VA](va, partiallyAppliedFunction, arg2, store)
+    result
+  }
+
   def handleApplyResult[TA, VA](
       va: VA,
       functionValue: Result[TA, VA],


### PR DESCRIPTION
NOTE: Dmitry has an upcoming change, please merge his first.

* Some helper functions to call the evaluator loop from Native.scala
* Helper functions to deconstruct `Result.ConstructorResult(Morphir.SDK.Maybe:just/nothing)` into Option