### PR TITLE
Simplify Evaluator calls in Native Functions

### DIFF
--- a/morphir/runtime/src/org/finos/morphir/runtime/Succinct.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/Succinct.scala
@@ -28,7 +28,7 @@ object Succinct {
         case Reference(_, fqName, args) => s"$fqName ${args.map(apply(_, depth - 1)).mkString(" ")}"
         case Tuple(_, elements)         => s"(${elements.map(apply(_, depth - 1)).mkString(", ")})"
         case Function(_, arg, ret)      => s"(${apply(arg, depth - 1)} -> ${apply(ret, depth - 1)}})"
-        case other                      => other.getClass.getSimpleName
+        case other                      => other.getClass.getName
       }
 
     def apply[TA](tpe: Type[TA]): String = apply(tpe, 2)
@@ -37,7 +37,7 @@ object Succinct {
   object Pattern {
     def apply[VA](pattern: Pattern[VA], depth: Int): String =
       pattern match {
-        case other => other.getClass.getSimpleName
+        case other => other.getClass.getName
       }
     def apply[VA](pattern: Pattern[VA]): String = apply(pattern, 2)
 

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/GatherReferences.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/GatherReferences.scala
@@ -15,17 +15,17 @@ import zio.Chunk
 object GatherReferences {
   type TypedValue = Value[Unit, UType]
   // Gather references from distribution*
-  // Also from Store? (Yeah, redundancy is okay, and there are
+  // Also from GlobalDefs? (Yeah, redundancy is okay, and there are
   // Helper: Recursively explore value
-  // Diff vs. Store
-  def fromStore(store: Store[Unit, UType]): ReferenceSet =
-    store.definitions.map { case (name, value) =>
+  // Diff vs. GlobalDefs
+  def fromGlobalDefs(globals: GlobalDefs[Unit, UType]): ReferenceSet =
+    globals.definitions.map { case (name, value) =>
       value match {
         case SDKValue.SDKValueDefinition(definition) => loop(definition.body).withDefinition(name) // TODO: Types!
         case _                                       => ReferenceSet.empty.withDefinition(name)
       }
     }.foldLeft(ReferenceSet.empty)((acc, next) => acc ++ next) ++
-      store.ctors.keys.foldLeft(ReferenceSet.empty)((acc, next) => acc.withConstructor(next))
+      globals.ctors.keys.foldLeft(ReferenceSet.empty)((acc, next) => acc.withConstructor(next))
 
   def fromEntrySet(entrySet: ReferenceSet, dists: Distribution*): ReferenceSet = {
     val mapped = dists.map(dist => (dist.asInstanceOf[Library].packageName, dist)).toMap

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
@@ -18,14 +18,14 @@ import org.finos.morphir.runtime.{
   VariableNotFound
 }
 
-object Loop {
-  def loop[TA, VA](ir: Value[TA, VA], store: Store[TA, VA]): Result[TA, VA] =
+case class Loop[TA, VA](globals: GlobalDefs[TA, VA]) {
+  def loop(ir: Value[TA, VA], store: Store[TA, VA]): Result[TA, VA] =
     ir match {
       case Literal(va, lit)              => handleLiteral(va, lit)
       case Apply(va, function, argument) => handleApply(va, function, argument, store)
       case Destructure(va, pattern, valueToDestruct, inValue) =>
         handleDestructure(va, pattern, valueToDestruct, inValue, store)
-      case Constructor(va, name)        => handleConstructor(va, name, store)
+      case Constructor(va, name)        => handleConstructor(va, name)
       case Field(va, recordValue, name) => handleField(va, recordValue, name, store)
       case FieldFunction(va, name)      => handleFieldFunction(va, name)
       case IfThenElse(va, condition, thenValue, elseValue) =>
@@ -44,9 +44,9 @@ object Loop {
       case Variable(va, name)                      => handleVariable(va, name, store)
     }
 
-  def handleLiteral[TA, VA](va: VA, literal: Lit) = Result.Primitive.makeOrFail[TA, VA, Any](unpackLit(literal))
+  def handleLiteral(va: VA, literal: Lit) = Result.Primitive.makeOrFail[TA, VA, Any](unpackLit(literal))
 
-  def handleApply[TA, VA](
+  def handleApply(
       va: VA,
       function: Value[TA, VA],
       argument: Value[TA, VA],
@@ -54,14 +54,13 @@ object Loop {
   ): Result[TA, VA] = {
     val functionValue = loop(function, store)
     val argValue      = loop(argument, store)
-    handleApplyResult(va, functionValue, argValue, store)
+    handleApplyResult(va, functionValue, argValue)
   }
 
-  def handleApplyResult[TA, VA](
+  def handleApplyResult(
       va: VA,
       functionValue: Result[TA, VA],
-      argValue: Result[TA, VA],
-      store: Store[TA, VA]
+      argValue: Result[TA, VA]
   ): Result[TA, VA] =
     functionValue match {
       case Result.FieldFunction(name) =>
@@ -74,14 +73,14 @@ object Loop {
         val newBindings = matchPatternCase[TA, VA](pattern, argValue)
           .getOrElse(throw UnmatchedPattern(s"Lambda argument did not match expected pattern"))
           .map { case (name, value) => name -> StoredValue.Eager(value) }
-        loop(body, Store(store.definitions, store.ctors, context.push(newBindings)))
+        loop(body, Store(context.push(newBindings)))
       case Result.DefinitionFunction(body, arguments, curried, closingContext) =>
         arguments match {
           case (name, _, _) :: Nil =>
             val newBindings = (curried :+ (name -> argValue)).map { case (name, value) =>
               name -> StoredValue.Eager(value)
             }.toMap
-            loop(body, Store(store.definitions, store.ctors, closingContext.push(newBindings)))
+            loop(body, Store(closingContext.push(newBindings)))
           case (name, _, _) :: tail =>
             Result.DefinitionFunction(body, tail, curried :+ (name -> argValue), closingContext)
           case Nil =>
@@ -100,7 +99,15 @@ object Loop {
             )
 
         }
-      case Result.NativeFunction(arguments, curried, function) =>
+      case nativeFunctionResult: Result.NativeFunctionResult[_, _] =>
+        val (arguments, curried, function) =
+          nativeFunctionResult match {
+            case Result.NativeFunction(arguments, curried, function) =>
+              (arguments, curried, function)
+            case Result.NativeInnerFunction(arguments, curried, function) =>
+              (arguments, curried, function.injectEvaluator(this))
+          }
+
         def assertCurriedNumArgs(num: Int) =
           if (curried.size != num) throw new IllegalValue(
             s"Curried wrong number of (uncurried) args. Needed ${function.numArgs} args but got (${curried.size}) when applying the function $function"
@@ -131,7 +138,7 @@ object Loop {
       case other => throw new UnexpectedType(s"$other is not a function")
     }
 
-  def handleDestructure[TA, VA](
+  def handleDestructure(
       va: VA,
       pattern: Pattern[VA],
       valueToDestruct: Value[TA, VA],
@@ -146,8 +153,8 @@ object Loop {
     }
   }
 
-  def handleConstructor[TA, VA](va: VA, name: FQName, store: Store[TA, VA]): Result[TA, VA] =
-    store.getCtor(name) match {
+  def handleConstructor(va: VA, name: FQName): Result[TA, VA] =
+    globals.getCtor(name) match {
       case Some(SDKConstructor(List()))    => Result.ConstructorResult(name, List())
       case Some(SDKConstructor(arguments)) => Result.ConstructorFunction[TA, VA](name, arguments, List())
       case None =>
@@ -158,15 +165,15 @@ object Loop {
              |mod : $mod
              |loc : $loc
              |Store contents from that package:
-             |  ${store.ctors.keys.filter(_.getPackagePath == pkg).map(_.toString).mkString("\n\t")}
+             |  ${globals.ctors.keys.filter(_.getPackagePath == pkg).map(_.toString).mkString("\n\t")}
              |
              |Other Store Contents:
-             |  ${store.ctors.keys.map(_.toString).mkString("\n\t")}
+             |  ${globals.ctors.keys.map(_.toString).mkString("\n\t")}
              |""".stripMargin
         )
     }
 
-  def handleField[TA, VA](
+  def handleField(
       va: VA,
       recordValue: Value[TA, VA],
       fieldName: Name,
@@ -178,9 +185,9 @@ object Loop {
       case other => throw new UnexpectedType(s"Expected record but found $other")
     }
 
-  def handleFieldFunction[TA, VA](va: VA, name: Name): Result[TA, VA] = Result.FieldFunction(name)
+  def handleFieldFunction(va: VA, name: Name): Result[TA, VA] = Result.FieldFunction(name)
 
-  def handleIfThenElse[TA, VA](
+  def handleIfThenElse(
       va: VA,
       condition: Value[TA, VA],
       thenValue: Value[TA, VA],
@@ -193,7 +200,7 @@ object Loop {
       case other                   => throw new UnexpectedType(s"$other is not a boolean result")
     }
 
-  def handleLambda[TA, VA](
+  def handleLambda(
       va: VA,
       pattern: Pattern[VA],
       body: Value[TA, VA],
@@ -201,7 +208,7 @@ object Loop {
   ): Result[TA, VA] =
     Result.LambdaFunction(body, pattern, store.callStack)
 
-  def handleLetDefinition[TA, VA](
+  def handleLetDefinition(
       va: VA,
       valueName: Name,
       valueDefinition: Definition[TA, VA],
@@ -215,7 +222,7 @@ object Loop {
     loop(inValue, store.push(Map(valueName -> StoredValue.Eager(value))))
   }
 
-  def handleLetRecursion[TA, VA](
+  def handleLetRecursion(
       va: VA,
       definitions: Map[Name, Definition[TA, VA]],
       inValue: Value[TA, VA],
@@ -227,10 +234,10 @@ object Loop {
     loop(inValue, store.push(siblings))
   }
 
-  def handleListValue[TA, VA](va: VA, elements: List[Value[TA, VA]], store: Store[TA, VA]): Result[TA, VA] =
+  def handleListValue(va: VA, elements: List[Value[TA, VA]], store: Store[TA, VA]): Result[TA, VA] =
     Result.ListResult(elements.map(loop(_, store)))
 
-  def handlePatternMatch[TA, VA](
+  def handlePatternMatch(
       va: VA,
       value: Value[TA, VA],
       cases: List[(Pattern[VA], Value[TA, VA])],
@@ -251,13 +258,13 @@ object Loop {
     loop(inValue, store.push(bindings.map { case (name, value) => name -> StoredValue.Eager(value) }))
   }
 
-  def handleRecord[TA, VA](va: VA, fields: List[(Name, Value[TA, VA])], store: Store[TA, VA]): Result[TA, VA] =
+  def handleRecord(va: VA, fields: List[(Name, Value[TA, VA])], store: Store[TA, VA]): Result[TA, VA] =
     Result.Record(fields.map { case (name, value) => name -> loop(value, store) }.toMap)
 
-  def handleReference[TA, VA](va: VA, name: FQName, store: Store[TA, VA]): Result[TA, VA] =
-    store.getDefinition(name) match {
+  def handleReference(va: VA, name: FQName, store: Store[TA, VA]): Result[TA, VA] =
+    globals.getDefinition(name) match {
       case None =>
-        val filtered = store.definitions.keys.filter(_.getPackagePath == name.getPackagePath)
+        val filtered = globals.definitions.keys.filter(_.getPackagePath == name.getPackagePath)
         val hint = if (Utils.isNative(name)) "You might be calling an unimplemented native function"
         else "You might be calling a function not defined in the given distributions"
         throw DefinitionNotFound(
@@ -279,18 +286,18 @@ object Loop {
       case Some(SDKNativeValue(value)) => value
       case Some(SDKNativeFunction(function)) =>
         Result.NativeFunction(function.numArgs, List(), function)
-      case Some(SDKNativeInnerFunction(storeFunction)) =>
-        Result.NativeFunction(storeFunction.numArgs, List(), storeFunction.applyStore(store))
+      case Some(SDKNativeInnerFunction(function)) =>
+        Result.NativeInnerFunction(function.numArgs, List(), function)
     }
 
-  def handleTuple[TA, VA](va: VA, elements: List[Value[TA, VA]], store: Store[TA, VA]): Result[TA, VA] = {
+  def handleTuple(va: VA, elements: List[Value[TA, VA]], store: Store[TA, VA]): Result[TA, VA] = {
     val evaluatedElements = elements.map(loop(_, store))
     Result.Tuple(TupleSigniture.fromList(evaluatedElements))
   }
 
-  def handleUnit[TA, VA](va: VA): Result[TA, VA] = Result.Unit()
+  def handleUnit(va: VA): Result[TA, VA] = Result.Unit()
 
-  def handleUpdateRecord[TA, VA](
+  def handleUpdateRecord(
       va: VA,
       valueToUpdate: Value[TA, VA],
       fields: Map[Name, Value[TA, VA]],
@@ -303,7 +310,7 @@ object Loop {
       case other => throw UnexpectedType(s"$other is not a record")
     }
 
-  def handleVariable[TA, VA](va: VA, name: Name, store: Store[TA, VA]) =
+  def handleVariable(va: VA, name: Name, store: Store[TA, VA]) =
     store.getVariable(name) match {
       case None                         => throw VariableNotFound(s"Variable $name not found")
       case Some(StoredValue.Eager(res)) => res

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
@@ -18,7 +18,7 @@ import org.finos.morphir.runtime.{
   VariableNotFound
 }
 
-case class Loop[TA, VA](globals: GlobalDefs[TA, VA]) {
+private[morphir] case class Loop[TA, VA](globals: GlobalDefs[TA, VA]) {
   def loop(ir: Value[TA, VA], store: Store[TA, VA]): Result[TA, VA] =
     ir match {
       case Literal(va, lit)              => handleLiteral(va, lit)

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
@@ -57,6 +57,19 @@ case class Loop[TA, VA](globals: GlobalDefs[TA, VA]) {
     handleApplyResult(va, functionValue, argValue)
   }
 
+  def handleApplyResult2(
+      va: VA,
+      functionValue: Result[TA, VA],
+      arg1: Result[TA, VA],
+      arg2: Result[TA, VA]
+  ): Result[TA, VA] = {
+    val partiallyAppliedFunction =
+      handleApplyResult(va, functionValue, arg1)
+    val result =
+      handleApplyResult(va, partiallyAppliedFunction, arg2)
+    result
+  }
+
   def handleApplyResult(
       va: VA,
       functionValue: Result[TA, VA],

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Native.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Native.scala
@@ -7,6 +7,7 @@ import org.finos.morphir.runtime.quick.Result.Primitive
 import org.finos.morphir.runtime.Extractors._
 import scala.collection.mutable
 
+// TODO simplify evaluator calls
 object DictSDK {
   val filter: SDKValue[Unit, Type.UType] = SDKValue.SDKNativeInnerFunction {
     NativeFunctionSignatureAdv.Fun2 {

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/NativeFunctionSignature.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/NativeFunctionSignature.scala
@@ -26,32 +26,32 @@ object NativeFunctionSignature {
 // Advanced native function that takes a store
 sealed trait NativeFunctionSignatureAdv[TA, VA] {
   def numArgs: Int
-  def f: Store[TA, VA] => Any
+  def f: Loop[TA, VA] => Any
   // Apply the store an convert back to a regular function
-  def applyStore(store: Store[TA, VA]) =
+  def injectEvaluator(loop: Loop[TA, VA]) =
     this match {
-      case NativeFunctionSignatureAdv.Fun1(f) => NativeFunctionSignature.Fun1(f(store))
-      case NativeFunctionSignatureAdv.Fun2(f) => NativeFunctionSignature.Fun2(f(store))
-      case NativeFunctionSignatureAdv.Fun3(f) => NativeFunctionSignature.Fun3(f(store))
-      case NativeFunctionSignatureAdv.Fun4(f) => NativeFunctionSignature.Fun4(f(store))
-      case NativeFunctionSignatureAdv.Fun5(f) => NativeFunctionSignature.Fun5(f(store))
+      case NativeFunctionSignatureAdv.Fun1(f) => NativeFunctionSignature.Fun1(f(loop))
+      case NativeFunctionSignatureAdv.Fun2(f) => NativeFunctionSignature.Fun2(f(loop))
+      case NativeFunctionSignatureAdv.Fun3(f) => NativeFunctionSignature.Fun3(f(loop))
+      case NativeFunctionSignatureAdv.Fun4(f) => NativeFunctionSignature.Fun4(f(loop))
+      case NativeFunctionSignatureAdv.Fun5(f) => NativeFunctionSignature.Fun5(f(loop))
     }
 }
 object NativeFunctionSignatureAdv {
-  case class Fun1[TA, VA](f: Store[TA, VA] => Result[TA, VA] => Result[TA, VA])
+  case class Fun1[TA, VA](f: Loop[TA, VA] => Result[TA, VA] => Result[TA, VA])
       extends NativeFunctionSignatureAdv[TA, VA] { val numArgs = 1 }
-  case class Fun2[TA, VA](f: Store[TA, VA] => (Result[TA, VA], Result[TA, VA]) => Result[TA, VA])
+  case class Fun2[TA, VA](f: Loop[TA, VA] => (Result[TA, VA], Result[TA, VA]) => Result[TA, VA])
       extends NativeFunctionSignatureAdv[TA, VA] { val numArgs = 2 }
-  case class Fun3[TA, VA](f: Store[TA, VA] => (Result[TA, VA], Result[TA, VA], Result[TA, VA]) => Result[TA, VA])
+  case class Fun3[TA, VA](f: Loop[TA, VA] => (Result[TA, VA], Result[TA, VA], Result[TA, VA]) => Result[TA, VA])
       extends NativeFunctionSignatureAdv[TA, VA] { val numArgs = 3 }
-  case class Fun4[TA, VA](f: Store[TA, VA] => (
+  case class Fun4[TA, VA](f: Loop[TA, VA] => (
       Result[TA, VA],
       Result[TA, VA],
       Result[TA, VA],
       Result[TA, VA]
   ) => Result[TA, VA])
       extends NativeFunctionSignatureAdv[TA, VA] { val numArgs = 4 }
-  case class Fun5[TA, VA](f: Store[TA, VA] => (
+  case class Fun5[TA, VA](f: Loop[TA, VA] => (
       Result[TA, VA],
       Result[TA, VA],
       Result[TA, VA],

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/QuickMorphirRuntime.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/QuickMorphirRuntime.scala
@@ -21,7 +21,7 @@ import org.finos.morphir.runtime.{EvaluationError, MorphirRuntimeError}
 import org.finos.morphir.runtime.environment.MorphirEnv
 import zio.prelude.fx.ZPure
 
-private[runtime] case class QuickMorphirRuntime(dists: Distributions, store: Store[scala.Unit, UType])
+private[runtime] case class QuickMorphirRuntime(dists: Distributions, globals: GlobalDefs[scala.Unit, UType])
     extends TypedMorphirRuntime {
   // private val store: Store[scala.Unit, UType] = Store.empty //
 
@@ -38,7 +38,7 @@ private[runtime] case class QuickMorphirRuntime(dists: Distributions, store: Sto
   def evaluate(value: Value[scala.Unit, UType]): RTAction[MorphirEnv, MorphirRuntimeError, Data] =
     for {
       _   <- typeCheck(value)
-      res <- EvaluatorQuick.evalAction(value, store, dists)
+      res <- EvaluatorQuick.evalAction(value, globals, dists)
     } yield res
 
   def fetchType(fqn: FQName): RTAction[MorphirEnv, MorphirRuntimeError, UType] = {
@@ -88,8 +88,8 @@ private[runtime] case class QuickMorphirRuntime(dists: Distributions, store: Sto
 object QuickMorphirRuntime {
 
   def fromDistributions(distributions: Distribution*): QuickMorphirRuntime = {
-    val store = Store.fromDistributions(distributions: _*)
-    QuickMorphirRuntime(Distributions(distributions: _*), store)
+    val globalDefs = GlobalDefs.fromDistributions(distributions: _*)
+    QuickMorphirRuntime(Distributions(distributions: _*), globalDefs)
   }
 
   def fromDistributionRTAction(distributions: Distribution*)

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Result.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Result.scala
@@ -374,9 +374,17 @@ object Result {
     }
   }
 
+  sealed trait NativeFunctionResult[TA, VA] extends Result[TA, VA]
+
   case class NativeFunction[TA, VA](
       arguments: Int,
       curried: List[Result[TA, VA]],
       function: NativeFunctionSignature[TA, VA]
-  ) extends Result[TA, VA] {}
+  ) extends NativeFunctionResult[TA, VA] {}
+
+  case class NativeInnerFunction[TA, VA](
+      arguments: Int,
+      curried: List[Result[TA, VA]],
+      function: NativeFunctionSignatureAdv[TA, VA]
+  ) extends NativeFunctionResult[TA, VA] {}
 }

--- a/morphir/toolkit/core/src/org/finos/morphir/ir/internal/ValueDefinition.scala
+++ b/morphir/toolkit/core/src/org/finos/morphir/ir/internal/ValueDefinition.scala
@@ -8,7 +8,8 @@ import Type.{Type, UType}
 import Value.{RawValue, TypedValue}
 import zio.Chunk
 
-private[ir] final case class ValueDefinition[+TA, +VA](
+// needs to be scoped on morphir because they are used in the type-checker (in runtime)
+private[morphir] final case class ValueDefinition[+TA, +VA](
     inputTypes: Chunk[(Name, VA, Type[TA])],
     outputType: Type[TA],
     body: Value[TA, VA]
@@ -19,7 +20,7 @@ private[ir] final case class ValueDefinition[+TA, +VA](
 
 }
 
-private[ir] object ValueDefinition {
+private[morphir] object ValueDefinition {
   def apply[TA, VA](outputType: Type[TA], body: Value[TA, VA]): ValueDefinition[TA, VA] =
     ValueDefinition(Chunk.empty, outputType, body)
 


### PR DESCRIPTION
* Passing around the `Store` object in the Native SDK objects does not conceptually make sense, pass around the evaluator instead.
* Instead of passing around global evaluator definitions in the Store object, separate them out into `GlobalDefs` and pass those around. This significantly simplifies many evaluator functions including `handleApplyResult` which Native often uses. This involved breaking things aren't actually the call-stack (i.e. global definitions) from Store. They don't make sense in there anyway.
* Add a `handleApplyResult2` which helps calling native functions that have lambdas with multiple arguments e.g. `Dict.filter` (which has `k` and `v` arguments).