### PR TITLE
Remove TA,VA from EvaluatorQuick components: Loop, Native, Result, SDKValue, etc...

### DIFF
--- a/morphir/runtime/src/org/finos/morphir/runtime/EvaluationLibrary.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/EvaluationLibrary.scala
@@ -2,7 +2,7 @@ package org.finos.morphir.runtime
 
 import org.finos.morphir.ir.Type.UType
 
-case class EvaluationLibrary(runtime: MorphirRuntime[scala.Unit, UType], modulePrefix: Option[String])
+case class EvaluationLibrary(runtime: TypedMorphirRuntime, modulePrefix: Option[String])
 
 //TODO: Delete after moving loadDistribution to json support package
 object EvaluationLibrary extends EvaluationLibraryPlatformSpecific {}

--- a/morphir/runtime/src/org/finos/morphir/runtime/MorphirRuntime.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/MorphirRuntime.scala
@@ -4,33 +4,42 @@ import org.finos.morphir.internal.AllTypeLevelModules
 import org.finos.morphir.ir.Type.UType
 import org.finos.morphir.ir.Value.Value
 import org.finos.morphir.ir.distribution.Distribution
-import org.finos.morphir.naming._
-
+import org.finos.morphir.naming.*
 import org.finos.morphir.runtime.environment.MorphirEnv
 import org.finos.morphir.runtime.exports.RTAction
 import org.finos.morphir.runtime.quick.QuickMorphirRuntime
-trait MorphirRuntime[TA, VA] {
+
+trait MorphirRuntime {
+  type TypeAttribs
+  type ValueAttribs
+
   def evaluate(
-      entryPoint: Value[TA, VA],
-      param: Value[TA, VA],
-      params: Value[TA, VA]*
+      entryPoint: Value[TypeAttribs, ValueAttribs],
+      param: Value[TypeAttribs, ValueAttribs],
+      params: Value[TypeAttribs, ValueAttribs]*
   ): RTAction[MorphirEnv, MorphirRuntimeError, Data]
-  def evaluate(entryPoint: Value[TA, VA], param: Data, params: Data*): RTAction[MorphirEnv, MorphirRuntimeError, Data]
+  def evaluate(
+      entryPoint: Value[TypeAttribs, ValueAttribs],
+      param: Data,
+      params: Data*
+  ): RTAction[MorphirEnv, MorphirRuntimeError, Data]
   def evaluate(entryPoint: FQName, param: Data, params: Data*): RTAction[MorphirEnv, MorphirRuntimeError, Data]
   def evaluate(
       entryPoint: FQName,
-      param: Value[TA, VA],
-      params: Value[TA, VA]*
+      param: Value[TypeAttribs, ValueAttribs],
+      params: Value[TypeAttribs, ValueAttribs]*
   ): RTAction[MorphirEnv, MorphirRuntimeError, Data]
 
-  def applyParams(entryPoint: Value[TA, VA], params: Value[TA, VA]*): RTAction[MorphirEnv, TypeError, Value[TA, VA]]
+  def applyParams(
+      entryPoint: Value[TypeAttribs, ValueAttribs],
+      params: Value[TypeAttribs, ValueAttribs]*
+  ): RTAction[MorphirEnv, TypeError, Value[TypeAttribs, ValueAttribs]]
 
-  def evaluate(value: Value[TA, VA]): RTAction[MorphirEnv, MorphirRuntimeError, Data]
+  def evaluate(value: Value[TypeAttribs, ValueAttribs]): RTAction[MorphirEnv, MorphirRuntimeError, Data]
 
 }
 
 object MorphirRuntime extends MorphirRuntimePlatformSpecific {
-
-  def quick(distributions: Distribution*): MorphirRuntime[scala.Unit, UType] =
+  def quick(distributions: Distribution*): TypedMorphirRuntime =
     QuickMorphirRuntime.fromDistributions(distributions: _*)
 }

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypedMorphirRuntime.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypedMorphirRuntime.scala
@@ -13,7 +13,10 @@ import org.finos.morphir.datamodel.*
 import org.finos.morphir.runtime.environment.MorphirEnv
 import org.finos.morphir.runtime.exports.*
 
-trait TypedMorphirRuntime extends MorphirRuntime[scala.Unit, UType] {
+trait TypedMorphirRuntime extends MorphirRuntime {
+  type TypeAttribs  = TypedMorphirRuntime.TypeAttribs
+  type ValueAttribs = TypedMorphirRuntime.ValueAttribs
+
   final def evaluate(
       entryPoint: Value[scala.Unit, UType],
       param: Value[scala.Unit, UType],
@@ -41,4 +44,11 @@ trait TypedMorphirRuntime extends MorphirRuntime[scala.Unit, UType] {
     val inputIRs = params.map(toValue(_))
     evaluate(entryPoint, inputIR, inputIRs: _*)
   }
+}
+
+object TypedMorphirRuntime {
+  final type TypeAttribs  = scala.Unit
+  final type ValueAttribs = UType
+  type RuntimeValue       = Value[TypeAttribs, ValueAttribs]
+  type RuntimeDefinition  = Value.Definition[TypeAttribs, ValueAttribs]
 }

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/GatherReferences.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/GatherReferences.scala
@@ -11,14 +11,15 @@ import org.finos.morphir.ir.distribution.Distribution.Library
 import org.finos.morphir.ir.distribution.Distribution
 import scala.collection.immutable.Set
 import zio.Chunk
+import org.finos.morphir.runtime.TypedMorphirRuntime.{TypeAttribs, ValueAttribs}
 
 object GatherReferences {
-  type TypedValue = Value[Unit, UType]
+  type TypedValue = Value[TypeAttribs, ValueAttribs]
   // Gather references from distribution*
   // Also from GlobalDefs? (Yeah, redundancy is okay, and there are
   // Helper: Recursively explore value
   // Diff vs. GlobalDefs
-  def fromGlobalDefs(globals: GlobalDefs[Unit, UType]): ReferenceSet =
+  def fromGlobalDefs(globals: GlobalDefs): ReferenceSet =
     globals.definitions.map { case (name, value) =>
       value match {
         case SDKValue.SDKValueDefinition(definition) => loop(definition.body).withDefinition(name) // TODO: Types!

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
@@ -6,6 +6,8 @@ import org.finos.morphir.ir.Value.{Pattern, Value}
 import org.finos.morphir.ir.Value.Value.{List as ListValue, *}
 import Helpers.{listToTuple, matchPatternCase, unpackLit}
 import SDKValue.{SDKNativeFunction, SDKNativeInnerFunction, SDKNativeValue}
+import org.finos.morphir.ir.Type.UType
+import org.finos.morphir.runtime.TypedMorphirRuntime.{RuntimeDefinition, RuntimeValue, TypeAttribs, ValueAttribs}
 import org.finos.morphir.runtime.{
   ConstructorNotFound,
   DefinitionNotFound,
@@ -18,8 +20,8 @@ import org.finos.morphir.runtime.{
   VariableNotFound
 }
 
-private[morphir] case class Loop[TA, VA](globals: GlobalDefs[TA, VA]) {
-  def loop(ir: Value[TA, VA], store: Store[TA, VA]): Result[TA, VA] =
+private[morphir] case class Loop(globals: GlobalDefs) {
+  def loop(ir: RuntimeValue, store: Store): Result =
     ir match {
       case Literal(va, lit)              => handleLiteral(va, lit)
       case Apply(va, function, argument) => handleApply(va, function, argument, store)
@@ -44,25 +46,25 @@ private[morphir] case class Loop[TA, VA](globals: GlobalDefs[TA, VA]) {
       case Variable(va, name)                      => handleVariable(va, name, store)
     }
 
-  def handleLiteral(va: VA, literal: Lit) = Result.Primitive.makeOrFail[TA, VA, Any](unpackLit(literal))
+  def handleLiteral(va: ValueAttribs, literal: Lit) = Result.Primitive.makeOrFail[Any](unpackLit(literal))
 
   def handleApply(
-      va: VA,
-      function: Value[TA, VA],
-      argument: Value[TA, VA],
-      store: Store[TA, VA]
-  ): Result[TA, VA] = {
+      va: ValueAttribs,
+      function: RuntimeValue,
+      argument: RuntimeValue,
+      store: Store
+  ): Result = {
     val functionValue = loop(function, store)
     val argValue      = loop(argument, store)
     handleApplyResult(va, functionValue, argValue)
   }
 
   def handleApplyResult2(
-      va: VA,
-      functionValue: Result[TA, VA],
-      arg1: Result[TA, VA],
-      arg2: Result[TA, VA]
-  ): Result[TA, VA] = {
+      va: ValueAttribs,
+      functionValue: Result,
+      arg1: Result,
+      arg2: Result
+  ): Result = {
     val partiallyAppliedFunction =
       handleApplyResult(va, functionValue, arg1)
     val result =
@@ -71,10 +73,10 @@ private[morphir] case class Loop[TA, VA](globals: GlobalDefs[TA, VA]) {
   }
 
   def handleApplyResult(
-      va: VA,
-      functionValue: Result[TA, VA],
-      argValue: Result[TA, VA]
-  ): Result[TA, VA] =
+      va: ValueAttribs,
+      functionValue: Result,
+      argValue: Result
+  ): Result =
     functionValue match {
       case Result.FieldFunction(name) =>
         argValue match {
@@ -83,7 +85,7 @@ private[morphir] case class Loop[TA, VA](globals: GlobalDefs[TA, VA]) {
           case other => throw UnexpectedType(s"Expected record but found $other")
         }
       case Result.LambdaFunction(body, pattern, context) =>
-        val newBindings = matchPatternCase[TA, VA](pattern, argValue)
+        val newBindings = matchPatternCase(pattern, argValue)
           .getOrElse(throw UnmatchedPattern(s"Lambda argument did not match expected pattern"))
           .map { case (name, value) => name -> StoredValue.Eager(value) }
         loop(body, Store(context.push(newBindings)))
@@ -104,15 +106,15 @@ private[morphir] case class Loop[TA, VA](globals: GlobalDefs[TA, VA]) {
         }
       case Result.ConstructorFunction(name, arguments, curried) =>
         arguments match {
-          case _ :: Nil  => Result.ConstructorResult[TA, VA](name, curried :+ argValue)
-          case _ :: tail => Result.ConstructorFunction[TA, VA](name, tail, curried :+ argValue)
+          case _ :: Nil  => Result.ConstructorResult(name, curried :+ argValue)
+          case _ :: tail => Result.ConstructorFunction(name, tail, curried :+ argValue)
           case Nil =>
             throw FunctionWithoutParameters(
               s"Tried to apply to constructor function with no arguments (should not exist)"
             )
 
         }
-      case nativeFunctionResult: Result.NativeFunctionResult[_, _] =>
+      case nativeFunctionResult: Result.NativeFunctionResult =>
         val (arguments, curried, function) =
           nativeFunctionResult match {
             case Result.NativeFunction(arguments, curried, function) =>
@@ -146,30 +148,31 @@ private[morphir] case class Loop[TA, VA](globals: GlobalDefs[TA, VA]) {
                 f(curried(0), curried(1), curried(2), curried(3), argValue)
             }
           // If there are more arguments left in the native-signature, that needs we have more uncurrying to do
-          case x => Result.NativeFunction[TA, VA](x - 1, curried :+ argValue, function)
+          case x => Result.NativeFunction(x - 1, curried :+ argValue, function)
         }
       case other => throw new UnexpectedType(s"$other is not a function")
     }
 
   def handleDestructure(
-      va: VA,
-      pattern: Pattern[VA],
-      valueToDestruct: Value[TA, VA],
-      inValue: Value[TA, VA],
-      store: Store[TA, VA]
-  ): Result[TA, VA] = {
+      va: ValueAttribs,
+      pattern: Pattern[ValueAttribs],
+      valueToDestruct: RuntimeValue,
+      inValue: RuntimeValue,
+      store: Store
+  ): Result = {
     val value = loop(valueToDestruct, store)
-    matchPatternCase[TA, VA](pattern, value) match {
+    matchPatternCase(pattern, value) match {
       case None => throw UnmatchedPattern(s"Value $value does not match pattern $pattern")
       case Some(bindings) =>
         loop(inValue, store.push(bindings.map { case (name, value) => name -> StoredValue.Eager(value) }))
     }
   }
 
-  def handleConstructor(va: VA, name: FQName): Result[TA, VA] =
+  def handleConstructor(va: ValueAttribs, name: FQName): Result =
     globals.getCtor(name) match {
-      case Some(SDKConstructor(List()))    => Result.ConstructorResult(name, List())
-      case Some(SDKConstructor(arguments)) => Result.ConstructorFunction[TA, VA](name, arguments, List())
+      case Some(SDKConstructor(List())) => Result.ConstructorResult(name, List())
+      case Some(SDKConstructor(arguments)) =>
+        Result.ConstructorFunction(name, arguments, List())
       case None =>
         val (pkg, mod, loc) = (name.getPackagePath, name.getModulePath, name.localName)
         throw new ConstructorNotFound(
@@ -187,25 +190,25 @@ private[morphir] case class Loop[TA, VA](globals: GlobalDefs[TA, VA]) {
     }
 
   def handleField(
-      va: VA,
-      recordValue: Value[TA, VA],
+      va: ValueAttribs,
+      recordValue: RuntimeValue,
       fieldName: Name,
-      store: Store[TA, VA]
-  ): Result[TA, VA] =
+      store: Store
+  ): Result =
     loop(recordValue, store) match {
       case Result.Record(fields) =>
         fields.getOrElse(fieldName, throw MissingField(s"Record fields $fields do not contain name $fieldName"))
       case other => throw new UnexpectedType(s"Expected record but found $other")
     }
 
-  def handleFieldFunction(va: VA, name: Name): Result[TA, VA] = Result.FieldFunction(name)
+  def handleFieldFunction(va: ValueAttribs, name: Name): Result = Result.FieldFunction(name)
 
   def handleIfThenElse(
-      va: VA,
-      condition: Value[TA, VA],
-      thenValue: Value[TA, VA],
-      elseValue: Value[TA, VA],
-      store: Store[TA, VA]
+      va: ValueAttribs,
+      condition: RuntimeValue,
+      thenValue: RuntimeValue,
+      elseValue: RuntimeValue,
+      store: Store
   ) =
     loop(condition, store) match {
       case Result.Primitive(true)  => loop(thenValue, store)
@@ -214,19 +217,19 @@ private[morphir] case class Loop[TA, VA](globals: GlobalDefs[TA, VA]) {
     }
 
   def handleLambda(
-      va: VA,
-      pattern: Pattern[VA],
-      body: Value[TA, VA],
-      store: Store[TA, VA]
-  ): Result[TA, VA] =
+      va: ValueAttribs,
+      pattern: Pattern[ValueAttribs],
+      body: RuntimeValue,
+      store: Store
+  ): Result =
     Result.LambdaFunction(body, pattern, store.callStack)
 
   def handleLetDefinition(
-      va: VA,
+      va: ValueAttribs,
       valueName: Name,
-      valueDefinition: Definition[TA, VA],
-      inValue: Value[TA, VA],
-      store: Store[TA, VA]
+      valueDefinition: RuntimeDefinition,
+      inValue: RuntimeValue,
+      store: Store
   ) = {
     val value =
       if (valueDefinition.inputTypes.isEmpty) loop(valueDefinition.body, store)
@@ -236,31 +239,31 @@ private[morphir] case class Loop[TA, VA](globals: GlobalDefs[TA, VA]) {
   }
 
   def handleLetRecursion(
-      va: VA,
-      definitions: Map[Name, Definition[TA, VA]],
-      inValue: Value[TA, VA],
-      store: Store[TA, VA]
-  ): Result[TA, VA] = {
+      va: ValueAttribs,
+      definitions: Map[Name, Definition[TypeAttribs, ValueAttribs]],
+      inValue: RuntimeValue,
+      store: Store
+  ): Result = {
     val siblings = definitions.map { case (name, definition) =>
       name -> StoredValue.Lazy(definition, store.callStack, definitions)
     }
     loop(inValue, store.push(siblings))
   }
 
-  def handleListValue(va: VA, elements: List[Value[TA, VA]], store: Store[TA, VA]): Result[TA, VA] =
+  def handleListValue(va: ValueAttribs, elements: List[RuntimeValue], store: Store): Result =
     Result.ListResult(elements.map(loop(_, store)))
 
   def handlePatternMatch(
-      va: VA,
-      value: Value[TA, VA],
-      cases: List[(Pattern[VA], Value[TA, VA])],
-      store: Store[TA, VA]
-  ): Result[TA, VA] = {
+      va: ValueAttribs,
+      value: RuntimeValue,
+      cases: List[(Pattern[ValueAttribs], RuntimeValue)],
+      store: Store
+  ): Result = {
     val evaluated = loop(value, store)
 
     def firstPatternMatching(
-        remainingCases: List[(Pattern[VA], Value[TA, VA])]
-    ): (Value[TA, VA], Map[Name, Result[TA, VA]]) =
+        remainingCases: List[(Pattern[ValueAttribs], RuntimeValue)]
+    ): (RuntimeValue, Map[Name, Result]) =
       remainingCases match {
         case (pattern, inValue) :: tail =>
           matchPatternCase(pattern, evaluated).map((inValue, _)).getOrElse(firstPatternMatching(tail))
@@ -271,10 +274,10 @@ private[morphir] case class Loop[TA, VA](globals: GlobalDefs[TA, VA]) {
     loop(inValue, store.push(bindings.map { case (name, value) => name -> StoredValue.Eager(value) }))
   }
 
-  def handleRecord(va: VA, fields: List[(Name, Value[TA, VA])], store: Store[TA, VA]): Result[TA, VA] =
+  def handleRecord(va: ValueAttribs, fields: List[(Name, RuntimeValue)], store: Store): Result =
     Result.Record(fields.map { case (name, value) => name -> loop(value, store) }.toMap)
 
-  def handleReference(va: VA, name: FQName, store: Store[TA, VA]): Result[TA, VA] =
+  def handleReference(va: ValueAttribs, name: FQName, store: Store): Result =
     globals.getDefinition(name) match {
       case None =>
         val filtered = globals.definitions.keys.filter(_.getPackagePath == name.getPackagePath)
@@ -303,19 +306,19 @@ private[morphir] case class Loop[TA, VA](globals: GlobalDefs[TA, VA]) {
         Result.NativeInnerFunction(function.numArgs, List(), function)
     }
 
-  def handleTuple(va: VA, elements: List[Value[TA, VA]], store: Store[TA, VA]): Result[TA, VA] = {
+  def handleTuple(va: ValueAttribs, elements: List[RuntimeValue], store: Store): Result = {
     val evaluatedElements = elements.map(loop(_, store))
     Result.Tuple(evaluatedElements)
   }
 
-  def handleUnit(va: VA): Result[TA, VA] = Result.Unit()
+  def handleUnit(va: ValueAttribs): Result = Result.Unit()
 
   def handleUpdateRecord(
-      va: VA,
-      valueToUpdate: Value[TA, VA],
-      fields: Map[Name, Value[TA, VA]],
-      store: Store[TA, VA]
-  ): Result[TA, VA] =
+      va: ValueAttribs,
+      valueToUpdate: RuntimeValue,
+      fields: Map[Name, RuntimeValue],
+      store: Store
+  ): Result =
     loop(valueToUpdate, store) match {
       case Result.Record(oldFields) =>
         val newFields = fields.map { case (name, value) => name -> loop(value, store) }
@@ -323,12 +326,12 @@ private[morphir] case class Loop[TA, VA](globals: GlobalDefs[TA, VA]) {
       case other => throw UnexpectedType(s"$other is not a record")
     }
 
-  def handleVariable(va: VA, name: Name, store: Store[TA, VA]) =
+  def handleVariable(va: ValueAttribs, name: Name, store: Store) =
     store.getVariable(name) match {
       case None                         => throw VariableNotFound(s"Variable $name not found")
       case Some(StoredValue.Eager(res)) => res
       case Some(StoredValue.Lazy(definition, parentContext, siblings)) =>
-        val newBindings: Map[Name, StoredValue[TA, VA]] = siblings.map { case (name, sibling) =>
+        val newBindings: Map[Name, StoredValue] = siblings.map { case (name, sibling) =>
           name -> StoredValue.Lazy(sibling, parentContext, siblings)
         }
         if (definition.inputTypes.isEmpty)

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/NativeFunctionSignature.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/NativeFunctionSignature.scala
@@ -1,34 +1,34 @@
 package org.finos.morphir.runtime.quick
 
-sealed trait NativeFunctionSignature[TA, VA] {
+sealed trait NativeFunctionSignature {
   def numArgs: Int
   def f: Any
 }
 object NativeFunctionSignature {
-  case class Fun1[TA, VA](f: Result[TA, VA] => Result[TA, VA])
-      extends NativeFunctionSignature[TA, VA] { val numArgs = 1 }
-  case class Fun2[TA, VA](f: (Result[TA, VA], Result[TA, VA]) => Result[TA, VA])
-      extends NativeFunctionSignature[TA, VA] { val numArgs = 2 }
-  case class Fun3[TA, VA](f: (Result[TA, VA], Result[TA, VA], Result[TA, VA]) => Result[TA, VA])
-      extends NativeFunctionSignature[TA, VA] { val numArgs = 3 }
-  case class Fun4[TA, VA](f: (Result[TA, VA], Result[TA, VA], Result[TA, VA], Result[TA, VA]) => Result[TA, VA])
-      extends NativeFunctionSignature[TA, VA] { val numArgs = 4 }
-  case class Fun5[TA, VA](f: (
-      Result[TA, VA],
-      Result[TA, VA],
-      Result[TA, VA],
-      Result[TA, VA],
-      Result[TA, VA]
-  ) => Result[TA, VA])
-      extends NativeFunctionSignature[TA, VA] { val numArgs = 5 }
+  case class Fun1(f: Result => Result)
+      extends NativeFunctionSignature { val numArgs = 1 }
+  case class Fun2(f: (Result, Result) => Result)
+      extends NativeFunctionSignature { val numArgs = 2 }
+  case class Fun3(f: (Result, Result, Result) => Result)
+      extends NativeFunctionSignature { val numArgs = 3 }
+  case class Fun4(f: (Result, Result, Result, Result) => Result)
+      extends NativeFunctionSignature { val numArgs = 4 }
+  case class Fun5(f: (
+      Result,
+      Result,
+      Result,
+      Result,
+      Result
+  ) => Result)
+      extends NativeFunctionSignature { val numArgs = 5 }
 }
 
 // Advanced native function that takes a store
-sealed trait NativeFunctionSignatureAdv[TA, VA] {
+sealed trait NativeFunctionSignatureAdv {
   def numArgs: Int
-  def f: Loop[TA, VA] => Any
+  def f: Loop => Any
   // Apply the store an convert back to a regular function
-  def injectEvaluator(loop: Loop[TA, VA]) =
+  def injectEvaluator(loop: Loop) =
     this match {
       case NativeFunctionSignatureAdv.Fun1(f) => NativeFunctionSignature.Fun1(f(loop))
       case NativeFunctionSignatureAdv.Fun2(f) => NativeFunctionSignature.Fun2(f(loop))
@@ -38,25 +38,25 @@ sealed trait NativeFunctionSignatureAdv[TA, VA] {
     }
 }
 object NativeFunctionSignatureAdv {
-  case class Fun1[TA, VA](f: Loop[TA, VA] => Result[TA, VA] => Result[TA, VA])
-      extends NativeFunctionSignatureAdv[TA, VA] { val numArgs = 1 }
-  case class Fun2[TA, VA](f: Loop[TA, VA] => (Result[TA, VA], Result[TA, VA]) => Result[TA, VA])
-      extends NativeFunctionSignatureAdv[TA, VA] { val numArgs = 2 }
-  case class Fun3[TA, VA](f: Loop[TA, VA] => (Result[TA, VA], Result[TA, VA], Result[TA, VA]) => Result[TA, VA])
-      extends NativeFunctionSignatureAdv[TA, VA] { val numArgs = 3 }
-  case class Fun4[TA, VA](f: Loop[TA, VA] => (
-      Result[TA, VA],
-      Result[TA, VA],
-      Result[TA, VA],
-      Result[TA, VA]
-  ) => Result[TA, VA])
-      extends NativeFunctionSignatureAdv[TA, VA] { val numArgs = 4 }
-  case class Fun5[TA, VA](f: Loop[TA, VA] => (
-      Result[TA, VA],
-      Result[TA, VA],
-      Result[TA, VA],
-      Result[TA, VA],
-      Result[TA, VA]
-  ) => Result[TA, VA])
-      extends NativeFunctionSignatureAdv[TA, VA] { val numArgs = 5 }
+  case class Fun1(f: Loop => Result => Result)
+      extends NativeFunctionSignatureAdv { val numArgs = 1 }
+  case class Fun2(f: Loop => (Result, Result) => Result)
+      extends NativeFunctionSignatureAdv { val numArgs = 2 }
+  case class Fun3(f: Loop => (Result, Result, Result) => Result)
+      extends NativeFunctionSignatureAdv { val numArgs = 3 }
+  case class Fun4(f: Loop => (
+      Result,
+      Result,
+      Result,
+      Result
+  ) => Result)
+      extends NativeFunctionSignatureAdv { val numArgs = 4 }
+  case class Fun5(f: Loop => (
+      Result,
+      Result,
+      Result,
+      Result,
+      Result
+  ) => Result)
+      extends NativeFunctionSignatureAdv { val numArgs = 5 }
 }

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Result.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Result.scala
@@ -3,15 +3,17 @@ package org.finos.morphir.runtime.quick
 import org.finos.morphir.naming.*
 import org.finos.morphir.ir.{Module, Type}
 import org.finos.morphir.ir.Value.Value.{List as ListValue, Unit as UnitValue, *}
+import org.finos.morphir.ir.Type.Type
 import org.finos.morphir.ir.Value.{Pattern, Value}
 
 import scala.collection.mutable.LinkedHashMap
 import Name.toTitleCase
+import org.finos.morphir.runtime.TypedMorphirRuntime.{RuntimeValue, TypeAttribs, ValueAttribs}
 import org.finos.morphir.runtime.UnexpectedType
 
 import scala.collection.mutable
 
-sealed trait Result[TA, VA] {
+sealed trait Result {
   def succinct(depth: Int): String = s"${this.getClass} (Default implementation)"
   def succinct: String             = succinct(2)
 
@@ -31,7 +33,7 @@ sealed trait Result[TA, VA] {
 
 object Result {
 
-  def unwrapList[TA, VA](arg: Result[TA, VA]): List[Result[TA, VA]] =
+  def unwrapList(arg: Result): List[Result] =
     arg match {
       case Result.ListResult(list) => list
       case _ =>
@@ -40,7 +42,7 @@ object Result {
         )
     }
 
-  def unwrapMap[TA, VA](arg: Result[TA, VA]): LinkedHashMap[Result[TA, VA], Result[TA, VA]] =
+  def unwrapMap(arg: Result): LinkedHashMap[Result, Result] =
     arg match {
       case Result.MapResult(map) => map
       case _ =>
@@ -49,7 +51,7 @@ object Result {
         )
     }
 
-  def unwrapTuple[TA, VA](arg: Result[TA, VA]): List[Result[TA, VA]] =
+  def unwrapTuple(arg: Result): List[Result] =
     arg match {
       case Result.Tuple(tup) => tup
       case _ =>
@@ -58,10 +60,10 @@ object Result {
         )
     }
 
-  def unwrapBoolean[TA, VA](arg: Result[TA, VA]): Boolean =
+  def unwrapBoolean(arg: Result): Boolean =
     arg match {
       case Primitive.Boolean(v) => v
-      case _: Primitive[_, _, _] =>
+      case _: Primitive[_] =>
         throw new UnexpectedType(
           s"Could not unwrap the primitive `${arg}` into a Boolean value because it was not a Primitive.Boolean"
         )
@@ -70,10 +72,10 @@ object Result {
     }
 
   // A Moprhir/ELM float is a Java Double, calling this unwrapDouble since that's the Java datatype being returned
-  def unwrapDouble[TA, VA](arg: Result[TA, VA]): Double =
+  def unwrapDouble(arg: Result): Double =
     arg match {
       case Primitive.Float(v) => v
-      case _: Primitive[_, _, _] =>
+      case _: Primitive[_] =>
         throw new UnexpectedType(
           s"Could not unwrap the primitive `${arg}` into a Double value because it was not a Primitive.Double"
         )
@@ -81,7 +83,7 @@ object Result {
         throw new UnexpectedType(s"Cannot unwrap the value `${arg}` into a primitive Double. It is not a primitive!")
     }
 
-  def unwrapInt[TA, VA](arg: Result[TA, VA]): Int =
+  def unwrapInt(arg: Result): Int =
     arg match {
       case Primitive.Int(v) => v
       case Primitive.Long(v) =>
@@ -89,7 +91,7 @@ object Result {
           throw new UnexpectedType(s"Cannot unwrap ${arg} into an integer because it's value is too large")
         else
           v.toInt
-      case _: Primitive[_, _, _] =>
+      case _: Primitive[_] =>
         throw new UnexpectedType(
           s"Could not unwrap the primitive `${arg}` into a Int value because it was not a Primitive.Int"
         )
@@ -97,10 +99,10 @@ object Result {
         throw new UnexpectedType(s"Cannot unwrap the value `${arg}` into a primitive Int. It is not a primitive!")
     }
 
-  def unwrapFloat[TA, VA](arg: Result[TA, VA]): Double =
+  def unwrapFloat(arg: Result): Double =
     arg match {
       case Primitive.Float(v) => v.toDouble
-      case _: Primitive[_, _, _] =>
+      case _: Primitive[_] =>
         throw new UnexpectedType(
           s"Could not unwrap the primitive `${arg}` into a Float value because it was not a Primitive.Float"
         )
@@ -108,10 +110,10 @@ object Result {
         throw new UnexpectedType(s"Cannot unwrap the value `${arg}` into a primitive Float. It is not a primitive!")
     }
 
-  def unwrapDecimal[TA, VA](arg: Result[TA, VA]): BigDecimal =
+  def unwrapDecimal(arg: Result): BigDecimal =
     arg match {
       case Primitive.BigDecimal(v) => v
-      case _: Primitive[_, _, _] =>
+      case _: Primitive[_] =>
         throw new UnexpectedType(
           s"Could not unwrap the primitive `${arg}` into a BigDecimal value because it was not a Primitive.BigDecimal"
         )
@@ -121,11 +123,11 @@ object Result {
         )
     }
 
-  def unwrapLong[TA, VA](arg: Result[TA, VA]): Long =
+  def unwrapLong(arg: Result): Long =
     arg match {
       case Primitive.Int(v)  => v.toLong
       case Primitive.Long(v) => v
-      case _: Primitive[_, _, _] =>
+      case _: Primitive[_] =>
         throw new UnexpectedType(
           s"Could not unwrap the primitive `${arg}` into a Long value because it was not a Primitive.Long"
         )
@@ -133,10 +135,10 @@ object Result {
         throw new UnexpectedType(s"Cannot unwrap the value `${arg}` into a primitive Long. It is not a primitive!")
     }
 
-  def unwrapString[TA, VA](arg: Result[TA, VA]): String =
+  def unwrapString(arg: Result): String =
     arg match {
       case Primitive.String(v) => v
-      case _: Primitive[_, _, _] =>
+      case _: Primitive[_] =>
         throw new UnexpectedType(
           s"Could not unwrap the primitive `${arg}` into a String value because it was not a Primitive.String"
         )
@@ -144,15 +146,15 @@ object Result {
         throw new UnexpectedType(s"Cannot unwrap the value `${arg}` into a primitive String. It is not a primitive!")
     }
 
-  def unwrapPrimitive[TA, VA](arg: Result[TA, VA]): Primitive[TA, VA, _] =
+  def unwrapPrimitive(arg: Result): Primitive[_] =
     arg match {
-      case p: Primitive[_, _, _] => p.asInstanceOf[Primitive[TA, VA, _]]
-      case _                     => throw new UnexpectedType(s"Cannot unwrap the value `${arg}` into a primitive")
+      case p: Primitive[_] => p.asInstanceOf[Primitive[_]]
+      case _               => throw new UnexpectedType(s"Cannot unwrap the value `${arg}` into a primitive")
     }
 
-  def unwrapNumeric[TA, VA](arg: Result[TA, VA]): Primitive.Numeric[TA, VA, _] =
+  def unwrapNumeric(arg: Result): Primitive.Numeric[_] =
     arg match {
-      case p: Primitive.Numeric[_, _, _] => p.asInstanceOf[Primitive.Numeric[TA, VA, _]]
+      case p: Primitive.Numeric[_] => p.asInstanceOf[Primitive.Numeric[_]]
       case _ => throw new UnexpectedType(s"Cannot unwrap the value `${arg}` into a primitive numeric")
     }
 
@@ -172,9 +174,9 @@ object Result {
 
   // Without a function that unwraps both types together with the numeric, it is very difficult to get all the
   // types to line up correctly for the Numeric instance to properly recognize what type it is supposed to take
-  def unwrapNumericsWithHelper[TA, VA, N](
-      arg1: Result[TA, VA],
-      arg2: Result[TA, VA]
+  def unwrapNumericsWithHelper[N](
+      arg1: Result,
+      arg2: Result
   ): NumericsWithHelper[N] = {
     val a = unwrapNumeric(arg1)
     val b = unwrapNumeric(arg2)
@@ -192,7 +194,7 @@ object Result {
     )
   }
 
-  def unwrapNumericWithHelper[TA, VA, N](arg: Result[TA, VA]): NumericWithHelper[N] = {
+  def unwrapNumericWithHelper[N](arg: Result): NumericWithHelper[N] = {
     val a = unwrapNumeric(arg)
     NumericWithHelper[N](
       a.value.asInstanceOf[N],
@@ -202,18 +204,18 @@ object Result {
     )
   }
 
-  case class Unit[TA, VA]() extends Result[TA, VA] {
+  case class Unit() extends Result {
     override def succinct(depth: Int) = "Unit"
   }
 
-  sealed trait Primitive[TA, VA, T] extends Result[TA, VA] {
+  sealed trait Primitive[T] extends Result {
     def value: T
     def isNumeric                     = false
     override def succinct(depth: Int) = s"Primitive($value)"
   }
 
   object Primitive {
-    sealed trait Numeric[TA, VA, T] extends Primitive[TA, VA, T] {
+    sealed trait Numeric[T] extends Primitive[T] {
       override def isNumeric = false
       def numericType: Numeric.Type
       def value: T
@@ -231,26 +233,26 @@ object Result {
       }
     }
 
-    case class Int[TA, VA](value: scala.Int) extends Numeric[TA, VA, scala.Int] {
+    case class Int(value: scala.Int) extends Numeric[scala.Int] {
       val numericType           = Numeric.Type.Int
       lazy val numericHelper    = implicitly[scala.Numeric[scala.Int]]
       lazy val fractionalHelper = None
       lazy val integralHelper   = Some(implicitly[scala.Integral[scala.Int]])
     }
-    case class Long[TA, VA](value: scala.Long) extends Numeric[TA, VA, scala.Long] {
+    case class Long(value: scala.Long) extends Numeric[scala.Long] {
       val numericType           = Numeric.Type.Long
       lazy val numericHelper    = implicitly[scala.Numeric[scala.Long]]
       lazy val fractionalHelper = None
       lazy val integralHelper   = Some(implicitly[scala.Integral[scala.Long]])
     }
     // A Morphir/ELM Float is the same as a Java Double
-    case class Float[TA, VA](value: scala.Double) extends Numeric[TA, VA, scala.Double] {
+    case class Float(value: scala.Double) extends Numeric[scala.Double] {
       val numericType           = Numeric.Type.Float
       lazy val numericHelper    = implicitly[scala.Numeric[scala.Double]]
       lazy val fractionalHelper = Some(implicitly[scala.Fractional[scala.Double]])
       lazy val integralHelper   = None
     }
-    case class BigDecimal[TA, VA](value: scala.BigDecimal) extends Numeric[TA, VA, scala.BigDecimal] {
+    case class BigDecimal(value: scala.BigDecimal) extends Numeric[scala.BigDecimal] {
       val numericType           = Numeric.Type.BigDecimal
       lazy val numericHelper    = implicitly[scala.Numeric[scala.BigDecimal]]
       lazy val fractionalHelper = Some(implicitly[scala.Fractional[scala.BigDecimal]])
@@ -258,7 +260,7 @@ object Result {
     }
 
     object DecimalBounded {
-      def unapply(resultValue: Result.Primitive.Numeric[_, _, _]): Option[scala.BigDecimal] =
+      def unapply(resultValue: Result.Primitive.Numeric[_]): Option[scala.BigDecimal] =
         resultValue match {
           case Primitive.Float(v)      => Some(scala.BigDecimal(v.toDouble))
           case Primitive.Int(v)        => Some(scala.BigDecimal(v))
@@ -268,7 +270,7 @@ object Result {
     }
 
     object LongBounded {
-      def unapply[TA, VA](resultValue: Result[TA, VA]): Option[scala.Long] =
+      def unapply(resultValue: Result): Option[scala.Long] =
         resultValue match {
           case Primitive.Long(v) => Some(v)
           case Primitive.Int(v)  => Some(v.toLong)
@@ -276,119 +278,119 @@ object Result {
         }
     }
 
-    case class Boolean[TA, VA](value: scala.Boolean)   extends Primitive[TA, VA, scala.Boolean]
-    case class String[TA, VA](value: java.lang.String) extends Primitive[TA, VA, java.lang.String]
-    case class Char[TA, VA](value: scala.Char)         extends Primitive[TA, VA, scala.Char]
+    case class Boolean(value: scala.Boolean)   extends Primitive[scala.Boolean]
+    case class String(value: java.lang.String) extends Primitive[java.lang.String]
+    case class Char(value: scala.Char)         extends Primitive[scala.Char]
 
-    def unapply(prim: Primitive[_, _, _]): Option[Any] =
+    def unapply(prim: Primitive[_]): Option[Any] =
       Some(prim.value)
 
-    def makeOrFail[TA, VA, T](value: T): Primitive[TA, VA, T] =
-      make[TA, VA, T](value) match {
+    def makeOrFail[T](value: T): Primitive[T] =
+      make[T](value) match {
         case Some(value) => value
         case None => throw new UnexpectedType(
             s"Cannot unwrap value `$value` into a primitive. It is a ${value.getClass}. Valid Primitive values are: Int, Long, String, Boolean, Char, Double, BigDecimal, Float"
           )
       }
 
-    def make[TA, VA, T](value: T): Option[Primitive[TA, VA, T]] =
+    def make[T](value: T): Option[Primitive[T]] =
       value match {
-        case v: scala.Int        => Some(Primitive.Int[TA, VA](v).asInstanceOf[Primitive[TA, VA, T]])
-        case v: scala.Long       => Some(Primitive.Long[TA, VA](v).asInstanceOf[Primitive[TA, VA, T]])
-        case v: java.lang.String => Some(Primitive.String[TA, VA](v).asInstanceOf[Primitive[TA, VA, T]])
-        case v: scala.Boolean    => Some(Primitive.Boolean[TA, VA](v).asInstanceOf[Primitive[TA, VA, T]])
-        case v: scala.Char       => Some(Primitive.Char[TA, VA](v).asInstanceOf[Primitive[TA, VA, T]])
-        case v: scala.BigDecimal => Some(Primitive.BigDecimal[TA, VA](v).asInstanceOf[Primitive[TA, VA, T]])
-        case v: scala.Float      => Some(Primitive.Float[TA, VA](v.toDouble).asInstanceOf[Primitive[TA, VA, T]])
-        case v: scala.Double     => Some(Primitive.Float[TA, VA](v).asInstanceOf[Primitive[TA, VA, T]])
+        case v: scala.Int        => Some(Primitive.Int(v).asInstanceOf[Primitive[T]])
+        case v: scala.Long       => Some(Primitive.Long(v).asInstanceOf[Primitive[T]])
+        case v: java.lang.String => Some(Primitive.String(v).asInstanceOf[Primitive[T]])
+        case v: scala.Boolean    => Some(Primitive.Boolean(v).asInstanceOf[Primitive[T]])
+        case v: scala.Char       => Some(Primitive.Char(v).asInstanceOf[Primitive[T]])
+        case v: scala.BigDecimal => Some(Primitive.BigDecimal(v).asInstanceOf[Primitive[T]])
+        case v: scala.Float      => Some(Primitive.Float(v.toDouble).asInstanceOf[Primitive[T]])
+        case v: scala.Double     => Some(Primitive.Float(v).asInstanceOf[Primitive[T]])
         case _                   => None
       }
   }
 
-  case class LocalDate[TA, VA](value: java.time.LocalDate) extends Result[TA, VA] {
+  case class LocalDate(value: java.time.LocalDate) extends Result {
     override def succinct(depth: Int) = s"LocalDate($value)"
   }
 
-  case class LocalTime[TA, VA](value: java.time.LocalTime) extends Result[TA, VA] {
+  case class LocalTime(value: java.time.LocalTime) extends Result {
     override def succinct(depth: Int) = s"LocalTime($value)"
   }
 
-  case class Tuple[TA, VA](elements: List[Result[TA, VA]]) extends Result[TA, VA] {
+  case class Tuple(elements: List[Result]) extends Result {
     override def succinct(depth: Int) = if (depth == 0) "Tuple(...)"
     else {
       s"Tuple(${elements.map(_.succinct(depth - 1)).mkString(", ")})"
     }
   }
   object Tuple {
-    def apply[TA, VA](elements: Result[TA, VA]*) = new Result.Tuple[TA, VA](elements.toList)
+    def apply(elements: Result*) = new Result.Tuple(elements.toList)
   }
 
-  case class SetResult[TA, VA](elements: mutable.LinkedHashSet[Result[TA, VA]]) extends Result[TA, VA] {
+  case class SetResult(elements: mutable.LinkedHashSet[Result]) extends Result {
     override def succinct(depth: Int) = if (depth == 0) "Set(..)"
     else {
       s"Set(${elements.map(value => value.succinct(depth - 1)).mkString(", ")})"
     }
   }
 
-  case class Record[TA, VA](elements: Map[Name, Result[TA, VA]]) extends Result[TA, VA] {
+  case class Record(elements: Map[Name, Result]) extends Result {
     override def succinct(depth: Int) = if (depth == 0) "Record(..)"
     else {
       s"Record(${elements.map { case (key, value) => s"$key -> ${value.succinct(depth - 1)}" }.mkString(", ")})"
     }
   }
 
-  case class ListResult[TA, VA](elements: List[Result[TA, VA]]) extends Result[TA, VA] {
+  case class ListResult(elements: List[Result]) extends Result {
     override def succinct(depth: Int) = if (depth == 0) "List(..)"
     else {
       s"List(${elements.map(value => value.succinct(depth - 1)).mkString(", ")})"
     }
   }
 
-  case class MapResult[TA, VA](elements: mutable.LinkedHashMap[Result[TA, VA], Result[TA, VA]]) extends Result[TA, VA] {
+  case class MapResult(elements: mutable.LinkedHashMap[Result, Result]) extends Result {
     override def succinct(depth: Int) = if (depth == 0) "Dict(..)"
     else {
       s"Dict(${elements.map { case (key, value) => s"${key.succinct(depth - 1)} -> ${value.succinct(depth - 1)}" }.mkString(", ")})"
     }
   }
-  case class Applied[TA, VA](
-      body: Value[TA, VA],
-      curried: List[(Name, Result[TA, VA])],
-      closingContext: CallStackFrame[TA, VA]
+  case class Applied(
+      body: RuntimeValue,
+      curried: List[(Name, Result)],
+      closingContext: CallStackFrame
   )
 
-  case class FieldFunction[TA, VA](fieldName: Name) extends Result[TA, VA]
+  case class FieldFunction(fieldName: Name) extends Result
 
-  case class LambdaFunction[TA, VA](body: Value[TA, VA], pattern: Pattern[VA], closingContext: CallStackFrame[TA, VA])
-      extends Result[TA, VA]
+  case class LambdaFunction(body: RuntimeValue, pattern: Pattern[ValueAttribs], closingContext: CallStackFrame)
+      extends Result
 
-  case class DefinitionFunction[TA, VA](
-      body: Value[TA, VA],
-      arguments: List[(Name, VA, Type.Type[TA])],
-      curried: List[(Name, Result[TA, VA])],
-      closingContext: CallStackFrame[TA, VA]
-  ) extends Result[TA, VA]
+  case class DefinitionFunction(
+      body: RuntimeValue,
+      arguments: List[(Name, ValueAttribs, Type[TypeAttribs])],
+      curried: List[(Name, Result)],
+      closingContext: CallStackFrame
+  ) extends Result
 
-  case class ConstructorFunction[TA, VA](name: FQName, arguments: List[VA], curried: List[Result[TA, VA]])
-      extends Result[TA, VA]
+  case class ConstructorFunction(name: FQName, arguments: List[ValueAttribs], curried: List[Result])
+      extends Result
 
-  case class ConstructorResult[TA, VA](name: FQName, values: List[Result[TA, VA]]) extends Result[TA, VA] {
+  case class ConstructorResult(name: FQName, values: List[Result]) extends Result {
     override def succinct(depth: Int) = if (depth == 0) s"${name.toString}(..)"
     else {
       s"${name.toString}(${values.map(value => value.succinct(depth - 1)).mkString(", ")})"
     }
   }
 
-  sealed trait NativeFunctionResult[TA, VA] extends Result[TA, VA]
+  sealed trait NativeFunctionResult extends Result
 
-  case class NativeFunction[TA, VA](
+  case class NativeFunction(
       arguments: Int,
-      curried: List[Result[TA, VA]],
-      function: NativeFunctionSignature[TA, VA]
-  ) extends NativeFunctionResult[TA, VA] {}
+      curried: List[Result],
+      function: NativeFunctionSignature
+  ) extends NativeFunctionResult {}
 
-  case class NativeInnerFunction[TA, VA](
+  case class NativeInnerFunction(
       arguments: Int,
-      curried: List[Result[TA, VA]],
-      function: NativeFunctionSignatureAdv[TA, VA]
-  ) extends NativeFunctionResult[TA, VA] {}
+      curried: List[Result],
+      function: NativeFunctionSignatureAdv
+  ) extends NativeFunctionResult {}
 }

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Result.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Result.scala
@@ -13,6 +13,8 @@ import org.finos.morphir.runtime.UnexpectedType
 
 import scala.collection.mutable
 
+// Represents a Morphir-Evaluator result. Typed on TypedMorphirRuntime.TypeAttribs, TypedMorphirRuntime.ValueAttribs
+// instead of a a Generic VA/TA since the latter is not necessary.
 sealed trait Result {
   def succinct(depth: Int): String = s"${this.getClass} (Default implementation)"
   def succinct: String             = succinct(2)

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -11,9 +11,7 @@ import zio.test.TestAspect.{ignore, tag}
 import zio.{Console, ZIO, ZLayer}
 
 object EvaluatorMDMTests extends MorphirBaseSpec {
-  type MorphirRuntimeTyped = MorphirRuntime[Unit, Type.UType]
-
-  val morphirRuntimeLayer: ZLayer[Any, Throwable, MorphirRuntime[Unit, Type.UType]] =
+  val morphirRuntimeLayer: ZLayer[Any, Throwable, TypedMorphirRuntime] =
     ZLayer(for {
       irFilePath <- ZIO.succeed(os.pwd / "examples" / "morphir-elm-projects" / "evaluator-tests" / "morphir-ir.json")
       _          <- Console.printLine(s"Loading distribution from $irFilePath")
@@ -45,7 +43,7 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
   def checkEvaluation(
       moduleName: String,
       functionName: String
-  )(expected: => Data): ZIO[MorphirRuntimeTyped, Throwable, TestResult] =
+  )(expected: => Data): ZIO[TypedMorphirRuntime, Throwable, TestResult] =
     runTest(moduleName, functionName).map { actual =>
       assertTrue(actual == expected)
     }
@@ -54,7 +52,7 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
       moduleName: String,
       functionName: String,
       values: List[Any]
-  )(expected: => Data): ZIO[MorphirRuntimeTyped, Throwable, TestResult] =
+  )(expected: => Data): ZIO[TypedMorphirRuntime, Throwable, TestResult] =
     runTest(moduleName, functionName, values).map { actual =>
       assertTrue(actual == expected)
     }
@@ -74,15 +72,15 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
       checkEvaluation(moduleName, functionName, values)(expected)
     }
 
-  def runTest(moduleName: String, functionName: String): ZIO[MorphirRuntimeTyped, Throwable, Data] =
+  def runTest(moduleName: String, functionName: String): ZIO[TypedMorphirRuntime, Throwable, Data] =
     runTest(moduleName, functionName, List(()))
 
   def runTest(
       moduleName: String,
       functionName: String,
       values: List[Any]
-  ): ZIO[MorphirRuntimeTyped, Throwable, Data] =
-    ZIO.serviceWithZIO[MorphirRuntimeTyped] { runtime =>
+  ): ZIO[TypedMorphirRuntime, Throwable, Data] =
+    ZIO.serviceWithZIO[TypedMorphirRuntime] { runtime =>
       val fullName = s"Morphir.Examples.App:$moduleName:$functionName"
       val data     = values.map(deriveData(_))
 

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
@@ -16,9 +16,7 @@ import zio.{Console, ZIO, ZLayer}
 import org.finos.morphir.ir.Value.RawValueExtensions
 
 object TypeCheckerTests extends MorphirBaseSpec {
-  type MorphirRuntimeTyped = MorphirRuntime[Unit, UType]
-
-  val morphirRuntimeLayer: ZLayer[Any, Throwable, MorphirRuntime[Unit, UType]] =
+  val morphirRuntimeLayer: ZLayer[Any, Throwable, TypedMorphirRuntime] =
     ZLayer(for {
       irFilePath <- ZIO.succeed(os.pwd / "examples" / "morphir-elm-projects" / "evaluator-tests" / "morphir-ir.json")
       _          <- Console.printLine(s"Loading distribution from $irFilePath")


### PR DESCRIPTION
* Removing type parameters from various EvaluatorQuick constructs `Loop`, `Native`, `Result`, `SDKValue`, etc...
* This can be done because MorphirEvaluator now has TA/VA as type members instead of type parameters.
* TypedMorphirEvaluator now has an object to define `TypeAttribs`,` ValueAttribs` that are used throughout the evaluator