### PR TITLE
Type checker additional tests

### DIFF
--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -457,7 +457,7 @@ final class TypeChecker(dists: Distributions) {
         case Left(err) =>  List(new DefinitionMissing(err))
         case Right(definition) =>{
           val spec = definition.toSpecification
-          val curried = Utils.curryTypeFunction(spec.toSpecification.output, spec.toSpecification.inputs)
+          val curried = Utils.curryTypeFunction(spec.output, spec.inputs)
           conformsTo(curried, tpe, context)
 
         }

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -118,7 +118,7 @@ final class TypeChecker(dists: Distributions) {
     loop(tpe, None, context)
   }
   def checkAllDefinitions() : List[TypeError] = {
-    GatherReferences.fromDistributions(dists.getDists.values:_*).flatMap(checkDefinitionBody(_))
+    GatherReferences.fromDistributions(dists.getDists.values.toList:_*).definitions.toList.flatMap(checkDefinitionBody(_))
   }
   def checkDefinitionBody(fqn : FQName) : List[TypeError] = {
     val maybeDefinition = dists.lookupValueDefinition(fqn)

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -16,6 +16,7 @@ import org.finos.morphir.ir.sdk.Basics
 import org.finos.morphir.ir.Field
 import org.finos.morphir.runtime.TypeError.CannotDealias
 import org.finos.morphir.runtime.exports.*
+import org.finos.morphir.runtime.quick.GatherReferences
 import zio.Chunk
 import TypeError.*
 

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -117,6 +117,14 @@ final class TypeChecker(dists: Distributions) {
     loop(tpe, None, context)
   }
 
+  def checkDefinitionBody(fqn : FQName) : List[TypeError] = {
+    val maybeDefinition = dists.lookupValueDefinition(fqn)
+    maybeDefinition match{
+      Left(error) => List(new DefinitionMissing(error))
+      Right(definition) => 
+    }
+  }
+
   def conformsTo(valueType: UType, declaredType: UType): List[TypeError] =
     conformsTo(valueType, declaredType, Context.empty)
   def conformsTo(valueType: UType, declaredType: UType, context: Context): List[TypeError] = {

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -453,11 +453,14 @@ final class TypeChecker(dists: Distributions) {
   def handleReference(tpe: UType, fqn: FQName, context: Context): TypeCheckerResult = {
     val fromChildren = List()
     val fromType = if (!Utils.isNative(fqn)) {
-      dists.lookupValueSpecification(fqn) match {
-        case Left(err) => List(new DefinitionMissing(err))
-        case Right(spec) =>
-          val curried = Utils.curryTypeFunction(spec.output, spec.inputs)
+      dists.lookupValueDefinition(fqn) match {
+        case Left(err) =>  List(new DefinitionMissing(err))
+        case Right(definition) =>{
+          val spec = definition.toSpecification
+          val curried = Utils.curryTypeFunction(spec.toSpecification.output, spec.toSpecification.inputs)
           conformsTo(curried, tpe, context)
+
+        }
       }
     } else List() // TODO: Handle native type references
     fromChildren ++ fromType

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -120,8 +120,8 @@ final class TypeChecker(dists: Distributions) {
   def checkDefinitionBody(fqn : FQName) : List[TypeError] = {
     val maybeDefinition = dists.lookupValueDefinition(fqn)
     maybeDefinition match{
-      Left(error) => List(new DefinitionMissing(error))
-      Right(definition) => 
+      case Left(error) => List(new DefinitionMissing(error))
+      case Right(definition) => check(definitio.body)
     }
   }
 

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -241,6 +241,7 @@ final class TypeChecker(dists: Distributions) {
       case (BoolLiteral(_), BoolRef())       => List()
       case (WholeNumberLiteral(_), IntRef()) => List() // TODO: "WholeNumberRef" extractor
       case (DecimalLiteral(_), DecimalRef()) => List()
+      case (_, Type.Variable(_, _))         => List() //TODO: Type variable handling
       case (otherLit, otherTpe)              => List(new LiteralTypeMismatch(otherLit, otherTpe))
     }
     fromChildren ++ matchErrors
@@ -322,7 +323,8 @@ final class TypeChecker(dists: Distributions) {
           case None           => List(new TypeLacksField(tpe, name, "Referenced by field none"))
           case Some(fieldTpe) => conformsTo(fieldTpe, tpe, context)
         }
-      case other => List(new ImproperType(other, s"Record type expected"))
+      case Right(other) => List(new ImproperType(other, s"Record type expected"))
+      case Left(err) => List(err)
     }
     fromChildren ++ fromTpe
   }

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -116,7 +116,9 @@ final class TypeChecker(dists: Distributions) {
       }
     loop(tpe, None, context)
   }
-
+  def checkAllDefinitions() : List[TypeError] = {
+    GatherReferences.fromDistributions(dists.getDists.values).flatMap(checkDefinitionBody(_))
+  }
   def checkDefinitionBody(fqn : FQName) : List[TypeError] = {
     val maybeDefinition = dists.lookupValueDefinition(fqn)
     maybeDefinition match{

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -118,7 +118,7 @@ final class TypeChecker(dists: Distributions) {
     loop(tpe, None, context)
   }
   def checkAllDefinitions() : List[TypeError] = {
-    GatherReferences.fromDistributions(dists.getDists.values).flatMap(checkDefinitionBody(_))
+    GatherReferences.fromDistributions(dists.getDists.values:_*).flatMap(checkDefinitionBody(_))
   }
   def checkDefinitionBody(fqn : FQName) : List[TypeError] = {
     val maybeDefinition = dists.lookupValueDefinition(fqn)

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -316,13 +316,13 @@ final class TypeChecker(dists: Distributions) {
   }
   def handleFieldValue(tpe: UType, recordValue: TypedValue, name: Name, context: Context): TypeCheckerResult = {
     val fromChildren = check(recordValue, context)
-    val fromTpe = recordValue.attributes match {
-      case Type.Record(_, fields) =>
+    val fromTpe = dealias(recordValue.attributes, context) match {
+      case Right(Type.Record(_, fields)) =>
         fields.map(field => field.name -> field.data).toMap.get(name) match {
           case None           => List(new TypeLacksField(tpe, name, "Referenced by field none"))
           case Some(fieldTpe) => conformsTo(fieldTpe, tpe, context)
         }
-      case other => List(new ImproperType(other, s"Reference type expected"))
+      case other => List(new ImproperType(other, s"Record type expected"))
     }
     fromChildren ++ fromTpe
   }

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -121,7 +121,7 @@ final class TypeChecker(dists: Distributions) {
     val maybeDefinition = dists.lookupValueDefinition(fqn)
     maybeDefinition match{
       case Left(error) => List(new DefinitionMissing(error))
-      case Right(definition) => check(definitio.body)
+      case Right(definition) => check(definition.body)
     }
   }
 

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -117,13 +117,14 @@ final class TypeChecker(dists: Distributions) {
       }
     loop(tpe, None, context)
   }
-  def checkAllDefinitions() : List[TypeError] = {
-    GatherReferences.fromDistributions(dists.getDists.values.toList:_*).definitions.toList.filter(!Utils.isNative(_)).flatMap(checkDefinitionBody(_))
-  }
-  def checkDefinitionBody(fqn : FQName) : List[TypeError] = {
+  def checkAllDefinitions(): List[TypeError] =
+    GatherReferences.fromDistributions(dists.getDists.values.toList: _*).definitions.toList.filter(
+      !Utils.isNative(_)
+    ).flatMap(checkDefinitionBody(_))
+  def checkDefinitionBody(fqn: FQName): List[TypeError] = {
     val maybeDefinition = dists.lookupValueDefinition(fqn)
-    maybeDefinition match{
-      case Left(error) => List(new DefinitionMissing(error))
+    maybeDefinition match {
+      case Left(error)       => List(new DefinitionMissing(error))
       case Right(definition) => check(definition.body)
     }
   }
@@ -241,7 +242,7 @@ final class TypeChecker(dists: Distributions) {
       case (BoolLiteral(_), BoolRef())       => List()
       case (WholeNumberLiteral(_), IntRef()) => List() // TODO: "WholeNumberRef" extractor
       case (DecimalLiteral(_), DecimalRef()) => List()
-      case (_, Type.Variable(_, _))         => List() //TODO: Type variable handling
+      case (_, Type.Variable(_, _))          => List() // TODO: Type variable handling
       case (otherLit, otherTpe)              => List(new LiteralTypeMismatch(otherLit, otherTpe))
     }
     fromChildren ++ matchErrors
@@ -324,7 +325,7 @@ final class TypeChecker(dists: Distributions) {
           case Some(fieldTpe) => conformsTo(fieldTpe, tpe, context)
         }
       case Right(other) => List(new ImproperType(other, s"Record type expected"))
-      case Left(err) => List(err)
+      case Left(err)    => List(err)
     }
     fromChildren ++ fromTpe
   }
@@ -454,13 +455,12 @@ final class TypeChecker(dists: Distributions) {
     val fromChildren = List()
     val fromType = if (!Utils.isNative(fqn)) {
       dists.lookupValueDefinition(fqn) match {
-        case Left(err) =>  List(new DefinitionMissing(err))
-        case Right(definition) =>{
-          val spec = definition.toSpecification
+        case Left(err) => List(new DefinitionMissing(err))
+        case Right(definition) =>
+          val spec    = definition.toSpecification
           val curried = Utils.curryTypeFunction(spec.output, spec.inputs)
           conformsTo(curried, tpe, context)
 
-        }
       }
     } else List() // TODO: Handle native type references
     fromChildren ++ fromType

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -118,7 +118,7 @@ final class TypeChecker(dists: Distributions) {
     loop(tpe, None, context)
   }
   def checkAllDefinitions() : List[TypeError] = {
-    GatherReferences.fromDistributions(dists.getDists.values.toList:_*).definitions.toList.flatMap(checkDefinitionBody(_))
+    GatherReferences.fromDistributions(dists.getDists.values.toList:_*).definitions.toList.filter(!Utils.isNative(_)).flatMap(checkDefinitionBody(_))
   }
   def checkDefinitionBody(fqn : FQName) : List[TypeError] = {
     val maybeDefinition = dists.lookupValueDefinition(fqn)

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
@@ -89,6 +89,9 @@ object TypeCheckerTests extends MorphirBaseSpec {
       suite("Happy Paths Tests")(
         test("Lookup single definition"){
           checkDefinition(FQName.fromString("Morphir/Examples/App:TypeCheckerTests:intToInt"))
+        },
+        test("Check all definitions") {
+          checkAllDefinitions()
         }
       ),
       suite("Apply Node")(

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
@@ -44,8 +44,8 @@ object TypeCheckerTests extends MorphirBaseSpec {
       for {
         errors <- ZIO.succeed(checker.checkDefinitionBody(fqn))
         errorMsgs = errors.map(error => s"\n\t${error.getMsg}").mkString("")
-        assert <- if (errors.length == expectedErrors) assertCompletes
-        else assertTrue(errorMsgs == s"Expected $expectedErrors errors")
+        assert <- if (errors.length == 0) assertCompletes
+        else assertTrue(errorMsgs == s"Expected no errors")
       } yield assert // TODO: Cleaner "fails" impl
     }
   }

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
@@ -39,7 +39,7 @@ object TypeCheckerTests extends MorphirBaseSpec {
         else assertTrue(errorMsgs == s"Expected $expectedErrors errors")
       } yield assert
     }
-  def checkDefinition(fqn : FQName) : ZIO[TypeChecker, Throwable, TestResult] = {
+  def checkDefinition(fqn: FQName): ZIO[TypeChecker, Throwable, TestResult] =
     ZIO.serviceWithZIO[TypeChecker] { checker =>
       for {
         errors <- ZIO.succeed(checker.checkDefinitionBody(fqn))
@@ -48,9 +48,8 @@ object TypeCheckerTests extends MorphirBaseSpec {
         else assertTrue(errorMsgs == s"Expected no errors")
       } yield assert // TODO: Cleaner "fails" impl
     }
-  }
 
-  def checkAllDefinitions(): ZIO[TypeChecker, Throwable, TestResult] = {
+  def checkAllDefinitions(): ZIO[TypeChecker, Throwable, TestResult] =
     ZIO.serviceWithZIO[TypeChecker] { checker =>
       for {
         errors <- ZIO.succeed(checker.checkAllDefinitions())
@@ -59,7 +58,6 @@ object TypeCheckerTests extends MorphirBaseSpec {
         else assertTrue(errorMsgs == s"Expected no errors")
       } yield assert // TODO: Cleaner "fails" impl
     }
-  }
   def testTypeCheck(value: TypedValue)(expectedErrors: Int): ZIO[TypeChecker, Throwable, TestResult] =
     ZIO.serviceWithZIO[TypeChecker] { checker =>
       for {
@@ -87,7 +85,7 @@ object TypeCheckerTests extends MorphirBaseSpec {
   def spec =
     suite("Type Checker Tests")(
       suite("Happy Paths Tests")(
-        test("Lookup single definition"){
+        test("Lookup single definition") {
           checkDefinition(FQName.fromString("Morphir/Examples/App:TypeCheckerTests:intToInt"))
         },
         test("Check all definitions") {

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
@@ -39,6 +39,9 @@ object TypeCheckerTests extends MorphirBaseSpec {
         else assertTrue(errorMsgs == s"Expected $expectedErrors errors")
       } yield assert
     }
+  def checkDefinition(fqn : FQName) : ZIO[TypeChecker, Throwable, TestResult] = {
+
+  }
   def testTypeCheck(value: TypedValue)(expectedErrors: Int): ZIO[TypeChecker, Throwable, TestResult] =
     ZIO.serviceWithZIO[TypeChecker] { checker =>
       for {

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
@@ -49,6 +49,17 @@ object TypeCheckerTests extends MorphirBaseSpec {
       } yield assert // TODO: Cleaner "fails" impl
     }
   }
+
+  def checkAllDefinitions(): ZIO[TypeChecker, Throwable, TestResult] = {
+    ZIO.serviceWithZIO[TypeChecker] { checker =>
+      for {
+        errors <- ZIO.succeed(checker.checkAllDefinitions())
+        errorMsgs = errors.map(error => s"\n\t${error.getMsg}").mkString("")
+        assert <- if (errors.length == 0) assertCompletes
+        else assertTrue(errorMsgs == s"Expected no errors")
+      } yield assert // TODO: Cleaner "fails" impl
+    }
+  }
   def testTypeCheck(value: TypedValue)(expectedErrors: Int): ZIO[TypeChecker, Throwable, TestResult] =
     ZIO.serviceWithZIO[TypeChecker] { checker =>
       for {

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
@@ -40,7 +40,14 @@ object TypeCheckerTests extends MorphirBaseSpec {
       } yield assert
     }
   def checkDefinition(fqn : FQName) : ZIO[TypeChecker, Throwable, TestResult] = {
-
+    ZIO.serviceWithZIO[TypeChecker] { checker =>
+      for {
+        errors <- ZIO.succeed(checker.checkDefinitionBody(fqn))
+        errorMsgs = errors.map(error => s"\n\t${error.getMsg}").mkString("")
+        assert <- if (errors.length == expectedErrors) assertCompletes
+        else assertTrue(errorMsgs == s"Expected $expectedErrors errors")
+      } yield assert // TODO: Cleaner "fails" impl
+    }
   }
   def testTypeCheck(value: TypedValue)(expectedErrors: Int): ZIO[TypeChecker, Throwable, TestResult] =
     ZIO.serviceWithZIO[TypeChecker] { checker =>

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
@@ -76,7 +76,9 @@ object TypeCheckerTests extends MorphirBaseSpec {
   def spec =
     suite("Type Checker Tests")(
       suite("Happy Paths Tests")(
-
+        test("Lookup single definition"){
+          checkDefinition(FQName.fromString("Morphir/Examples/App:TypeCheckerTests:intToInt"))
+        }
       ),
       suite("Apply Node")(
         test("Apply to non function") {

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
@@ -75,6 +75,9 @@ object TypeCheckerTests extends MorphirBaseSpec {
   )
   def spec =
     suite("Type Checker Tests")(
+      suite("Happy Paths Tests")(
+
+      ),
       suite("Apply Node")(
         test("Apply to non function") {
           val badApply: TypedValue = V.apply(Basics.intType, V.intTyped(1), V.intTyped(1))


### PR DESCRIPTION
Previously the type checker was only running agains the entry point, i.e., checking that arguments were well-formed and matched the definition of the entry point function. This is probably all we want in terms of live performance, but it meantthe tests for the type checker were less rigorous than might be hoped.

This PR adds additional type checker functionality to bulk test all definitions within a set of distributions, and adds such to the type checker test spec. This uncovered a few more minor type checker bugs, which are also fixed here.