### PR TITLE
Library morphir-cli command

### DIFF
--- a/morphir/main/src/org/finos/morphir/cli/MorphirCliMain.scala
+++ b/morphir/main/src/org/finos/morphir/cli/MorphirCliMain.scala
@@ -151,6 +151,20 @@ object MorphirCliMain extends ZIOCliDefault {
         }
       }
 
+      val library = {
+        val irFiles =
+          Args.file("ir-files").atLeast(1) ?? "Bundle Morphir IR file(s) to be split into Library Morphir IR File(s)"
+        val outputDir = Options.directory("output").alias("o").withDefault(
+          Paths.get(".")
+        ) ?? "Target directory where Library Morphir IR file(s) will be created."
+
+        Command("library", outputDir, irFiles).withHelp(
+          "Split Bundle Morphir IR model(s) into Library Morphir IR model(s) using the Morphir Runtime."
+        ).map { (output, files) =>
+          MorphirCommand.Library(output, files)
+        }
+      }
+
       val setup = Command("setup").withHelp("Setup morphir-cli for use.").map { _ =>
         val morphirHomeDir = Paths.get("~")
         MorphirCommand.Setup(morphirHomeDir)

--- a/morphir/main/src/org/finos/morphir/cli/MorphirCliMain.scala
+++ b/morphir/main/src/org/finos/morphir/cli/MorphirCliMain.scala
@@ -123,11 +123,11 @@ object MorphirCliMain extends ZIOCliDefault {
 
       val bundle = {
         val irFiles = Args.file("ir-files").atLeast(1) ?? "Morphir IR files to bundle"
-        val outputBundleIRFilePath = Options.file("output").alias("o").withDefault(
+        val outputPath = Options.file("output").alias("o").withDefault(
           Paths.get("morphir-ir.json")
         ) ?? "Target file location where the Bundle Morphir IR file will be saved."
 
-        Command("bundle", outputBundleIRFilePath, irFiles).withHelp(
+        Command("bundle", outputPath, irFiles).withHelp(
           "Bundle Morphir IR models using the Morphir Runtime."
         ).map { (output, files) =>
           MorphirCommand.Bundle(output, files)

--- a/morphir/main/src/org/finos/morphir/cli/MorphirCliMain.scala
+++ b/morphir/main/src/org/finos/morphir/cli/MorphirCliMain.scala
@@ -25,6 +25,8 @@ object MorphirCliMain extends ZIOCliDefault {
       MorphirBundle.bundle(VPath(outputBundleIRFilePath), irFiles.map(VPath(_)))
     case MorphirCommand.Develop(port, host, projectDir, openInBrowser) =>
       MorphirElmDriver.develop(port, host, VPath(projectDir), openInBrowser)
+    case MorphirCommand.Library(outputDir, irFiles) =>
+      MorphirBundle.library(VPath(outputDir), irFiles.map(VPath(_)))
     case MorphirCommand.Setup(morphirHomeDir) => MorphirSetup.setup(VPath(morphirHomeDir))
     case MorphirCommand.Test(irFiles)         => MorphirRuntimeDriver.test()
     case MorphirCommand.ElmDevelop(port, host, projectDir, openInBrowser) =>
@@ -123,7 +125,7 @@ object MorphirCliMain extends ZIOCliDefault {
         val irFiles = Args.file("ir-files").atLeast(1) ?? "Morphir IR files to bundle"
         val outputBundleIRFilePath = Options.file("output").alias("o").withDefault(
           Paths.get("morphir-ir.json")
-        ) ?? "Target file location where the Morphir Bundle IR file will be saved."
+        ) ?? "Target file location where the Bundle Morphir IR file will be saved."
 
         Command("bundle", outputBundleIRFilePath, irFiles).withHelp(
           "Bundle Morphir IR models using the Morphir Runtime."
@@ -154,7 +156,7 @@ object MorphirCliMain extends ZIOCliDefault {
         MorphirCommand.Setup(morphirHomeDir)
       }
 
-      def root = Command("morphir-cli").subcommands(bundle, develop, Elm.root, setup, test)
+      def root = Command("morphir-cli").subcommands(bundle, develop, Elm.root, library, setup, test)
 
       val test = {
         val irFiles = Args.file("ir-files").repeat

--- a/morphir/main/src/org/finos/morphir/cli/MorphirCommand.scala
+++ b/morphir/main/src/org/finos/morphir/cli/MorphirCommand.scala
@@ -5,6 +5,7 @@ import java.nio.file.Path
 enum MorphirCommand {
   case Bundle(outputBundleIRFilePath: Path, irFiles: List[Path])
   case Develop(port: Int, host: String, projectDir: Path, openInBrowser: Boolean)
+  case Library(outputDir: Path, irFiles: List[Path])
   case Setup(morphirHomeDir: Path)
   case Test(irFiles: List[Path])
   case ElmDevelop(port: Int, host: String, projectDir: Path, openInBrowser: Boolean)

--- a/morphir/main/src/org/finos/morphir/cli/MorphirCommand.scala
+++ b/morphir/main/src/org/finos/morphir/cli/MorphirCommand.scala
@@ -3,7 +3,7 @@ import zio._
 import java.nio.file.Path
 
 enum MorphirCommand {
-  case Bundle(outputBundleIRFilePath: Path, irFiles: List[Path])
+  case Bundle(outputPath: Path, irFiles: List[Path])
   case Develop(port: Int, host: String, projectDir: Path, openInBrowser: Boolean)
   case Library(outputDir: Path, irFiles: List[Path])
   case Setup(morphirHomeDir: Path)

--- a/morphir/tools/js/src/org/finos/morphir/service/MorphirBundlePlatformSpecific.scala
+++ b/morphir/tools/js/src/org/finos/morphir/service/MorphirBundlePlatformSpecific.scala
@@ -1,7 +1,7 @@
 package org.finos.morphir.service
 
-import org.finos.morphir.util.vfile.*
-import zio.*
+import org.finos.morphir.util.vfile._
+import zio._
 
 trait MorphirBundlePlatformSpecific {
   val live: ULayer[MorphirBundle] = ZLayer.succeed(MorphirBundleLive)

--- a/morphir/tools/js/src/org/finos/morphir/service/MorphirBundlePlatformSpecific.scala
+++ b/morphir/tools/js/src/org/finos/morphir/service/MorphirBundlePlatformSpecific.scala
@@ -7,12 +7,20 @@ trait MorphirBundlePlatformSpecific {
   val live: ULayer[MorphirBundle] = ZLayer.succeed(MorphirBundleLive)
 
   object MorphirBundleLive extends MorphirBundle {
-    def bundle(outputBundleIRFilePath: VPath, irFiles: List[VPath]): Task[Unit] =
+    def bundle(outputPath: VPath, irFiles: List[VPath]): Task[Unit] =
       for {
         _ <- Console.printLine("Bundle command executing")
-        _ <- Console.printLine(s"\toutputBundleIRFilePath: $outputBundleIRFilePath")
+        _ <- Console.printLine(s"\toutputPath: $outputPath")
         _ <- Console.printLine(s"\tirFiles: $irFiles")
         _ <- Console.printLine("Bundle command executed")
+      } yield ()
+
+    def library(outputDir: VPath, irFiles: List[VPath]): Task[Unit] =
+      for {
+        _ <- Console.printLine("Library command executing")
+        _ <- Console.printLine(s"\toutputDir: $outputDir")
+        _ <- Console.printLine(s"\tirFiles: $irFiles")
+        _ <- Console.printLine("Library command executed")
       } yield ()
   }
 }

--- a/morphir/tools/js/src/org/finos/morphir/service/MorphirBundlePlatformSpecific.scala
+++ b/morphir/tools/js/src/org/finos/morphir/service/MorphirBundlePlatformSpecific.scala
@@ -16,7 +16,7 @@ trait MorphirBundlePlatformSpecific {
         _ <- Console.printLine("Bundle command executed")
       } yield ()
 
-    def bundle(outputPath: VPath, irFiles: List[VPath]): Task[Unit] =
+    def bundle(outputPath: Path, irFiles: List[Path]): Task[Unit] =
       for {
         _ <- Console.printLine("Bundle command executing")
         _ <- Console.printLine(s"\toutputPath: $outputPath")

--- a/morphir/tools/js/src/org/finos/morphir/service/MorphirBundlePlatformSpecific.scala
+++ b/morphir/tools/js/src/org/finos/morphir/service/MorphirBundlePlatformSpecific.scala
@@ -1,5 +1,6 @@
 package org.finos.morphir.service
 
+import java.nio.file.Path
 import org.finos.morphir.util.vfile._
 import zio._
 
@@ -7,6 +8,9 @@ trait MorphirBundlePlatformSpecific {
   val live: ULayer[MorphirBundle] = ZLayer.succeed(MorphirBundleLive)
 
   object MorphirBundleLive extends MorphirBundle {
+    def bundle(outputPath: VPath, irFiles: List[VPath]): Task[Unit] =
+      bundle(outputPath.path.toNioPath, irFiles.map(_.path.toNioPath))
+
     def bundle(outputPath: VPath, irFiles: List[VPath]): Task[Unit] =
       for {
         _ <- Console.printLine("Bundle command executing")
@@ -16,6 +20,9 @@ trait MorphirBundlePlatformSpecific {
       } yield ()
 
     def library(outputDir: VPath, irFiles: List[VPath]): Task[Unit] =
+      library(outputDir.path.toNioPath, irFiles.map(_.path.toNioPath))
+
+    def library(outputDir: Path, irFiles: List[Path]): Task[Unit] =
       for {
         _ <- Console.printLine("Library command executing")
         _ <- Console.printLine(s"\toutputDir: $outputDir")

--- a/morphir/tools/js/src/org/finos/morphir/service/MorphirBundlePlatformSpecific.scala
+++ b/morphir/tools/js/src/org/finos/morphir/service/MorphirBundlePlatformSpecific.scala
@@ -9,7 +9,12 @@ trait MorphirBundlePlatformSpecific {
 
   object MorphirBundleLive extends MorphirBundle {
     def bundle(outputPath: VPath, irFiles: List[VPath]): Task[Unit] =
-      bundle(outputPath.path.toNioPath, irFiles.map(_.path.toNioPath))
+      for {
+        _ <- Console.printLine("Bundle command executing")
+        _ <- Console.printLine(s"\toutputPath: $outputPath")
+        _ <- Console.printLine(s"\tirFiles: $irFiles")
+        _ <- Console.printLine("Bundle command executed")
+      } yield ()
 
     def bundle(outputPath: VPath, irFiles: List[VPath]): Task[Unit] =
       for {
@@ -20,7 +25,12 @@ trait MorphirBundlePlatformSpecific {
       } yield ()
 
     def library(outputDir: VPath, irFiles: List[VPath]): Task[Unit] =
-      library(outputDir.path.toNioPath, irFiles.map(_.path.toNioPath))
+      for {
+        _ <- Console.printLine("Library command executing")
+        _ <- Console.printLine(s"\toutputDir: $outputDir")
+        _ <- Console.printLine(s"\tirFiles: $irFiles")
+        _ <- Console.printLine("Library command executed")
+      } yield ()
 
     def library(outputDir: Path, irFiles: List[Path]): Task[Unit] =
       for {

--- a/morphir/tools/jvm-native/src/org/finos/morphir/service/MorphirBundlePlatformSpecific.scala
+++ b/morphir/tools/jvm-native/src/org/finos/morphir/service/MorphirBundlePlatformSpecific.scala
@@ -27,6 +27,17 @@ trait MorphirBundlePlatformSpecific {
         _             <- Console.printLine("Bundle command executed")
       } yield ()
 
+    def library(outputDir: VPath, irFiles: List[VPath]): Task[Unit] =
+      for {
+        _             <- Console.printLine("Library command executing")
+        _             <- Console.printLine(s"\toutputDir: $outputDir")
+      } yield ()
+
+    def createPathsForLibs(libraries: List[Distribution], outputDir: VPath): List[(Distribution, VPath)] =
+      libraries.zip(LazyList.from(1)).map { (library, index) =>
+        (library, outputDir / s"morphir-ir${index}.json")
+      }
+
     // TODO: Possibly refactor when FileIO operations are completed
     def loadDistributionFromFileZIO(fileName: String): Task[Distribution] =
       for {

--- a/morphir/tools/jvm-native/src/org/finos/morphir/service/MorphirBundlePlatformSpecific.scala
+++ b/morphir/tools/jvm-native/src/org/finos/morphir/service/MorphirBundlePlatformSpecific.scala
@@ -27,6 +27,9 @@ trait MorphirBundlePlatformSpecific {
         _             <- Console.printLine("Bundle command executed")
       } yield ()
 
+    def bundle(outputPath: Path, irFiles: List[Path]): Task[Unit] =
+      bundle(VPath(outputPath), irFiles.map(VPath(_)))
+
     def library(outputDir: VPath, irFiles: List[VPath]): Task[Unit] =
       for {
         _             <- Console.printLine("Library command executing")
@@ -39,6 +42,9 @@ trait MorphirBundlePlatformSpecific {
         _             <- ZIO.foreach(paths) { path => Console.printLine(s"\tLibrary Morphir IR file created: $path") }
         _             <- Console.printLine("Library command executed")
       } yield ()
+
+    def library(outputDir: Path, irFiles: List[Path]): Task[Unit] =
+      library(VPath(outputDir), irFiles.map(VPath(_)))
 
     def createPathsForLibs(libraries: List[Distribution], outputDir: VPath): List[(Distribution, VPath)] =
       libraries.zip(LazyList.from(1)).map { case (library: Distribution, index: Int) =>

--- a/morphir/tools/jvm-native/src/org/finos/morphir/service/MorphirBundlePlatformSpecific.scala
+++ b/morphir/tools/jvm-native/src/org/finos/morphir/service/MorphirBundlePlatformSpecific.scala
@@ -3,12 +3,12 @@ package org.finos.morphir.service
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
 import org.finos.morphir.ir.distribution.Distribution
-import org.finos.morphir.ir.json.MorphirJsonSupport.*
+import org.finos.morphir.ir.json.MorphirJsonSupport._
 import org.finos.morphir.ir.MorphirIRFile
 import org.finos.morphir.ir.MorphirIRVersion
-import org.finos.morphir.util.vfile.*
-import zio.*
-import zio.json.*
+import org.finos.morphir.util.vfile._
+import zio._
+import zio.json._
 
 trait MorphirBundlePlatformSpecific {
   val live: ULayer[MorphirBundle] = ZLayer.succeed(MorphirBundleLive)

--- a/morphir/tools/jvm-native/src/org/finos/morphir/service/MorphirBundlePlatformSpecific.scala
+++ b/morphir/tools/jvm-native/src/org/finos/morphir/service/MorphirBundlePlatformSpecific.scala
@@ -35,13 +35,13 @@ trait MorphirBundlePlatformSpecific {
         distributions <- ZIO.collectAll { irFiles.map { irFile => loadDistributionFromFileZIO(irFile.toString) } }
         libraries     <- ZIO.attempt { Distribution.toLibraries(distributions: _*) }
         libsWithPaths <- ZIO.attempt(createPathsForLibs(libraries, outputDir))
-        paths         <- ZIO.foreach(libsWithPaths) { (lib, path) => writeDistributionToFileZIO(lib, path) }
+        paths         <- ZIO.foreach(libsWithPaths) { case (lib, path) => writeDistributionToFileZIO(lib, path) }
         _             <- ZIO.foreach(paths) { path => Console.printLine(s"\tLibrary Morphir IR file created: $path") }
         _             <- Console.printLine("Library command executed")
       } yield ()
 
     def createPathsForLibs(libraries: List[Distribution], outputDir: VPath): List[(Distribution, VPath)] =
-      libraries.zip(LazyList.from(1)).map { (library, index) =>
+      libraries.zip(LazyList.from(1)).map { case (library: Distribution, index: Int) =>
         (library, outputDir / s"morphir-ir${index}.json")
       }
 

--- a/morphir/tools/src/org/finos/morphir/service/MorphirBundle.scala
+++ b/morphir/tools/src/org/finos/morphir/service/MorphirBundle.scala
@@ -1,13 +1,20 @@
 package org.finos.morphir.service
 
+import java.nio.file.Path
 import org.finos.morphir.util.vfile.*
 import zio.*
 
 trait MorphirBundle {
-  def bundle(outputBundleIRFilePath: VPath, irFiles: List[VPath]): Task[Unit]
+  def bundle(outputPath: VPath, irFiles: List[VPath]): Task[Unit]
+  def bundle(outputPath: Path, irFiles: List[Path]): Task[Unit] =
+    bundle(VPath(outputPath), irFiles.map(VPath(_)))
+
 }
 
 object MorphirBundle extends MorphirBundlePlatformSpecific {
-  def bundle(outputBundleIRFilePath: VPath, irFiles: List[VPath]): ZIO[MorphirBundle, Throwable, Unit] =
-    ZIO.serviceWithZIO[MorphirBundle](_.bundle(outputBundleIRFilePath, irFiles))
+  def bundle(outputPath: VPath, irFiles: List[VPath]): ZIO[MorphirBundle, Throwable, Unit] =
+    ZIO.serviceWithZIO[MorphirBundle](_.bundle(outputPath, irFiles))
+
+  def bundle(outputPath: Path, irFiles: List[Path]): ZIO[MorphirBundle, Throwable, Unit] =
+    bundle(VPath(outputPath), irFiles.map(VPath(_)))
 }

--- a/morphir/tools/src/org/finos/morphir/service/MorphirBundle.scala
+++ b/morphir/tools/src/org/finos/morphir/service/MorphirBundle.scala
@@ -9,6 +9,10 @@ trait MorphirBundle {
   def bundle(outputPath: Path, irFiles: List[Path]): Task[Unit] =
     bundle(VPath(outputPath), irFiles.map(VPath(_)))
 
+  def library(outputDir: VPath, irFiles: List[VPath]): Task[Unit]
+  def library(outputDir: Path, irFiles: List[Path]): Task[Unit] =
+    library(VPath(outputDir), irFiles.map(VPath(_)))
+
 }
 
 object MorphirBundle extends MorphirBundlePlatformSpecific {
@@ -17,4 +21,10 @@ object MorphirBundle extends MorphirBundlePlatformSpecific {
 
   def bundle(outputPath: Path, irFiles: List[Path]): ZIO[MorphirBundle, Throwable, Unit] =
     bundle(VPath(outputPath), irFiles.map(VPath(_)))
+
+  def library(outputDir: VPath, irFiles: List[VPath]): ZIO[MorphirBundle, Throwable, Unit] =
+    ZIO.serviceWithZIO[MorphirBundle](_.library(outputDir, irFiles))
+
+  def library(outputDir: Path, irFiles: List[Path]): ZIO[MorphirBundle, Throwable, Unit] =
+    library(VPath(outputDir), irFiles.map(VPath(_)))
 }

--- a/morphir/tools/src/org/finos/morphir/service/MorphirBundle.scala
+++ b/morphir/tools/src/org/finos/morphir/service/MorphirBundle.scala
@@ -12,7 +12,6 @@ trait MorphirBundle {
   def library(outputDir: VPath, irFiles: List[VPath]): Task[Unit]
   def library(outputDir: Path, irFiles: List[Path]): Task[Unit] =
     library(VPath(outputDir), irFiles.map(VPath(_)))
-
 }
 
 object MorphirBundle extends MorphirBundlePlatformSpecific {

--- a/morphir/tools/src/org/finos/morphir/service/MorphirBundle.scala
+++ b/morphir/tools/src/org/finos/morphir/service/MorphirBundle.scala
@@ -1,8 +1,8 @@
 package org.finos.morphir.service
 
 import java.nio.file.Path
-import org.finos.morphir.util.vfile.*
-import zio.*
+import org.finos.morphir.util.vfile._
+import zio._
 
 trait MorphirBundle {
   def bundle(outputPath: VPath, irFiles: List[VPath]): Task[Unit]

--- a/morphir/tools/src/org/finos/morphir/service/MorphirBundle.scala
+++ b/morphir/tools/src/org/finos/morphir/service/MorphirBundle.scala
@@ -6,12 +6,10 @@ import zio._
 
 trait MorphirBundle {
   def bundle(outputPath: VPath, irFiles: List[VPath]): Task[Unit]
-  def bundle(outputPath: Path, irFiles: List[Path]): Task[Unit] =
-    bundle(VPath(outputPath), irFiles.map(VPath(_)))
+  def bundle(outputPath: Path, irFiles: List[Path]): Task[Unit]
 
   def library(outputDir: VPath, irFiles: List[VPath]): Task[Unit]
-  def library(outputDir: Path, irFiles: List[Path]): Task[Unit] =
-    library(VPath(outputDir), irFiles.map(VPath(_)))
+  def library(outputDir: Path, irFiles: List[Path]): Task[Unit]
 }
 
 object MorphirBundle extends MorphirBundlePlatformSpecific {
@@ -19,11 +17,11 @@ object MorphirBundle extends MorphirBundlePlatformSpecific {
     ZIO.serviceWithZIO[MorphirBundle](_.bundle(outputPath, irFiles))
 
   def bundle(outputPath: Path, irFiles: List[Path]): ZIO[MorphirBundle, Throwable, Unit] =
-    bundle(VPath(outputPath), irFiles.map(VPath(_)))
+    ZIO.serviceWithZIO[MorphirBundle](_.bundle(outputPath, irFiles))
 
   def library(outputDir: VPath, irFiles: List[VPath]): ZIO[MorphirBundle, Throwable, Unit] =
     ZIO.serviceWithZIO[MorphirBundle](_.library(outputDir, irFiles))
 
   def library(outputDir: Path, irFiles: List[Path]): ZIO[MorphirBundle, Throwable, Unit] =
-    library(VPath(outputDir), irFiles.map(VPath(_)))
+    ZIO.serviceWithZIO[MorphirBundle](_.library(outputDir, irFiles))
 }


### PR DESCRIPTION
`libarary` command to split Bundle Morphir IR model(s) into Library Morphir IR model(s) using the Morphir Runtime