### PR TITLE
Print RTValue

### DIFF
--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
@@ -22,6 +22,7 @@ import org.finos.morphir.runtime.MorphirRuntimeError.{
   VariableNotFound,
   WrongNumberOfArguments
 }
+import org.finos.morphir.util.PrintRTValue
 
 private[morphir] case class Loop(globals: GlobalDefs) extends InvokeableEvaluator {
   def loop(ir: RuntimeValue, store: Store): RTValue = {
@@ -49,12 +50,7 @@ private[morphir] case class Loop(globals: GlobalDefs) extends InvokeableEvaluato
       case Variable(va, name)                      => handleVariable(va, name, store)
     }
     result match {
-      case v: RTValue.Primitive[_] =>
-        v.value match {
-          case _: Float => throw new RuntimeException(s"\n\n\nir: $ir")
-          case _        =>
-        }
-      case _ =>
+      case _ => println(s"Loop sees: ${PrintRTValue(result).plainText}")
     }
     result
   }

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
@@ -49,9 +49,6 @@ private[morphir] case class Loop(globals: GlobalDefs) extends InvokeableEvaluato
       case UpdateRecord(va, valueToUpdate, fields) => handleUpdateRecord(va, valueToUpdate, fields, store)
       case Variable(va, name)                      => handleVariable(va, name, store)
     }
-    result match {
-      case _ => println(s"Loop sees: ${PrintRTValue(result).plainText}")
-    }
     result
   }
 

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Native.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Native.scala
@@ -428,7 +428,7 @@ object Native {
       RTValue.LocalTime(time)
   }
 
-  val pi: SDKValue = SDKValue.SDKNativeValue(RTValue.Primitive.Float(3.toDouble))
+  val pi: SDKValue = SDKValue.SDKNativeValue(RTValue.Primitive.Float(Double.pi))
 
   val just: SDKConstructor    = SDKConstructor(List(Type.variable("contents")))
   val nothing: SDKConstructor = SDKConstructor(List())

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Native.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Native.scala
@@ -428,7 +428,7 @@ object Native {
       RTValue.LocalTime(time)
   }
 
-  val pi: SDKValue = SDKValue.SDKNativeValue(RTValue.Primitive.Float(Double.pi))
+  val pi: SDKValue = SDKValue.SDKNativeValue(RTValue.Primitive.Float(scala.math.Pi))
 
   val just: SDKConstructor    = SDKConstructor(List(Type.variable("contents")))
   val nothing: SDKConstructor = SDKConstructor(List())

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -1162,7 +1162,7 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
 //          val expected = Double.PositiveInfinity
 //          assertTrue(actual == expected)
 //        }, //No DDL equivalent
-        testEvaluation("Pi")("nativeReferenceTests", "nativeReferencePiTest")(Data.Float(3)),
+        testEvaluation("Pi")("nativeReferenceTests", "nativeReferencePiTest")(Data.Float(scala.math.Pi)),
         testEval("ModBy")("nativeReferenceTests", "nativeReferenceModByTest", 7)(
           Data.Int(1)
         )

--- a/morphir/src/org/finos/morphir/datamodel/Concept.scala
+++ b/morphir/src/org/finos/morphir/datamodel/Concept.scala
@@ -2,7 +2,8 @@ package org.finos.morphir.datamodel
 
 import org.finos.morphir.naming.FQName
 import org.finos.morphir.datamodel.Concept.Basic
-import org.finos.morphir.util.{DetailLevel, PrintMDM}
+import org.finos.morphir.util.PrintMDM
+import org.finos.morphir.util.PrintMDM.DetailLevel
 
 import scala.annotation.tailrec
 import zio.Chunk

--- a/morphir/src/org/finos/morphir/datamodel/Data.scala
+++ b/morphir/src/org/finos/morphir/datamodel/Data.scala
@@ -1,7 +1,8 @@
 package org.finos.morphir.datamodel
 
 import org.finos.morphir.naming.*
-import org.finos.morphir.util.{DetailLevel, PrintMDM}
+import org.finos.morphir.util.PrintMDM
+import org.finos.morphir.util.PrintMDM.DetailLevel
 
 import java.io.OutputStream
 import scala.collection.mutable

--- a/morphir/src/org/finos/morphir/ir/printing/PrintIR.scala
+++ b/morphir/src/org/finos/morphir/ir/printing/PrintIR.scala
@@ -19,6 +19,10 @@ object PrintIR {
       detailLevel: DetailLevel = DetailLevel.BirdsEye,
       defaultWidth: Int = 150
   ) = new PrintIR(detailLevel, defaultWidth).apply(any)
+  def make(
+      detailLevel: DetailLevel = DetailLevel.BirdsEye,
+      defaultWidth: Int = 150
+  ) = new PrintIR(detailLevel, defaultWidth)
 }
 
 case class DetailLevel(

--- a/morphir/src/org/finos/morphir/runtime/ErrorUtils.scala
+++ b/morphir/src/org/finos/morphir/runtime/ErrorUtils.scala
@@ -8,6 +8,7 @@ import org.finos.morphir.ir.Value.{Pattern, TypedValue, Value, USpecification as
 import org.finos.morphir.ir.Type.{Type, UType, USpecification as UTypeSpec}
 import org.finos.morphir.ir.printing.PrintIR
 import org.finos.morphir.util.PrintMDM
+import org.finos.morphir.util.PrintRTValue
 
 import java.util
 import scala.util.control.NonFatal
@@ -69,7 +70,7 @@ object ErrorUtils {
         barBlock(barIndentBlock(title, elmBody + irBody, barWidth = 10)) // Console likes to drop leading |?
       } else {
         // TODO: RTValue probably needs its own Printer
-        val astBody = barIndentBlock("AST", PrintIR(astLike).plainText)
+        val astBody = barIndentBlock("AST", PrintRTValue(astLike).plainText)
         barBlock(barIndentBlock(title, astBody, barWidth = 10)) // Console likes to drop leading |?
       }
     def isIR(any: Any): Boolean = any match {

--- a/morphir/src/org/finos/morphir/util/PrintMDM.scala
+++ b/morphir/src/org/finos/morphir/util/PrintMDM.scala
@@ -11,54 +11,6 @@ import org.finos.morphir.datamodel.Data.{Optional, Result}
 
 import java.util.function.UnaryOperator
 
-sealed trait DetailLevel {
-  def hideFQNames: Boolean
-  def compressNestedConcepts: Boolean
-  def compressData: Boolean
-  def compressConcept: Boolean
-  def hideInnerConcepts: Boolean
-}
-object DetailLevel {
-  object Detailed extends DetailLevel {
-    def hideFQNames            = false
-    def compressNestedConcepts = false
-    def compressData           = false
-    def compressConcept        = false
-    def hideInnerConcepts      = false
-  }
-  object Medium extends DetailLevel {
-    def hideFQNames            = true
-    def compressNestedConcepts = false
-    def compressData           = false
-    def compressConcept        = true
-    def hideInnerConcepts      = false
-  }
-  object BirdsEye extends DetailLevel {
-    def hideFQNames            = true
-    def compressNestedConcepts = false
-    def compressData           = true
-    def compressConcept        = true
-    def hideInnerConcepts      = true
-  }
-
-  object BirdsEye2 extends DetailLevel {
-    def hideFQNames            = false
-    def compressNestedConcepts = false
-    def compressData           = true
-    def compressConcept        = true
-    def showInnerConcepts      = false
-    def hideInnerConcepts      = true
-  }
-
-  object BirdsEye3 extends DetailLevel {
-    def hideFQNames            = false
-    def compressNestedConcepts = false
-    def compressData           = true
-    def compressConcept        = true
-    def showInnerConcepts      = false
-    def hideInnerConcepts      = false
-  }
-}
 
 object PrintMDM {
   def apply(
@@ -67,6 +19,55 @@ object PrintMDM {
       fieldNames: FieldNames = FieldNames.Hide,
       defaultWidth: Int = 150
   ) = new PrintIR(detailLevel, fieldNames, defaultWidth).apply(any)
+
+  sealed trait DetailLevel {
+    def hideFQNames: Boolean
+    def compressNestedConcepts: Boolean
+    def compressData: Boolean
+    def compressConcept: Boolean
+    def hideInnerConcepts: Boolean
+  }
+  object DetailLevel {
+    object Detailed extends DetailLevel {
+      def hideFQNames            = false
+      def compressNestedConcepts = false
+      def compressData           = false
+      def compressConcept        = false
+      def hideInnerConcepts      = false
+    }
+    object Medium extends DetailLevel {
+      def hideFQNames            = true
+      def compressNestedConcepts = false
+      def compressData           = false
+      def compressConcept        = true
+      def hideInnerConcepts      = false
+    }
+    object BirdsEye extends DetailLevel {
+      def hideFQNames            = true
+      def compressNestedConcepts = false
+      def compressData           = true
+      def compressConcept        = true
+      def hideInnerConcepts      = true
+    }
+
+    object BirdsEye2 extends DetailLevel {
+      def hideFQNames            = false
+      def compressNestedConcepts = false
+      def compressData           = true
+      def compressConcept        = true
+      def showInnerConcepts      = false
+      def hideInnerConcepts      = true
+    }
+
+    object BirdsEye3 extends DetailLevel {
+      def hideFQNames            = false
+      def compressNestedConcepts = false
+      def compressData           = true
+      def compressConcept        = true
+      def showInnerConcepts      = false
+      def hideInnerConcepts      = false
+    }
+  }
 }
 
 sealed trait FieldNames
@@ -76,7 +77,7 @@ object FieldNames {
 }
 
 class PrintIR(
-    detailLevel: DetailLevel,
+    detailLevel: PrintMDM.DetailLevel,
     fieldNames: FieldNames,
     val defaultWidth: Int
 ) extends pprint.Walker {

--- a/morphir/src/org/finos/morphir/util/PrintMDM.scala
+++ b/morphir/src/org/finos/morphir/util/PrintMDM.scala
@@ -11,7 +11,6 @@ import org.finos.morphir.datamodel.Data.{Optional, Result}
 
 import java.util.function.UnaryOperator
 
-
 object PrintMDM {
   def apply(
       any: Any,

--- a/morphir/src/org/finos/morphir/util/PrintRTValue.scala
+++ b/morphir/src/org/finos/morphir/util/PrintRTValue.scala
@@ -178,8 +178,6 @@ class PrintRTValue(
   }
 
   implicit class TreeOpts(tree: Tree.type) {
-    // Don't display full paths even for data-elements that have them,
-    // display all of that information in the concept-area
     def ofRT(d: RT)(children: List[Tree]) =
       Tree.Apply(d.printName, children.iterator)
 

--- a/morphir/src/org/finos/morphir/util/PrintRTValue.scala
+++ b/morphir/src/org/finos/morphir/util/PrintRTValue.scala
@@ -78,7 +78,7 @@ class PrintRTValue(
       v match {
         case v: RT.Primitive.Int =>
           val mInt = v.value
-          if mInt.isValidInt then {
+          if (mInt.isValidInt) {
             Tree.Literal(mInt.toInt.toString)
           } else {
             Tree.Literal(mInt.toString)

--- a/morphir/src/org/finos/morphir/util/PrintRTValue.scala
+++ b/morphir/src/org/finos/morphir/util/PrintRTValue.scala
@@ -1,0 +1,239 @@
+package org.finos.morphir.util
+
+import fansi.Str
+import pprint.{Renderer, Tree, Truncated}
+import _root_.org.finos.morphir.naming.*
+import java.util.function.UnaryOperator
+import org.finos.morphir.ir.printing.PrintIR
+import org.finos.morphir.runtime.RTValue as RT
+
+
+
+object PrintRTValue {
+  def apply(
+      any: Any,
+      detailLevel: PrintRTValue.DetailLevel = DetailLevel.BirdsEye,
+      fieldNames: FieldNames = FieldNames.Hide,
+      defaultWidth: Int = 150
+  ) = new PrintRTValue(detailLevel, fieldNames, defaultWidth).apply(any)
+
+  sealed trait DetailLevel {
+    def hideFQNames: Boolean
+  }
+  object DetailLevel {
+    object Detailed extends DetailLevel {
+      def hideFQNames            = false
+      // def compressNestedConcepts = false
+      // def compressData           = false
+      // def compressConcept        = false
+      // def hideInnerConcepts      = false
+    }
+    object Medium extends DetailLevel {
+      def hideFQNames            = true
+      // def compressNestedConcepts = false
+      // def compressData           = false
+      // def compressConcept        = true
+      // def hideInnerConcepts      = false
+    }
+    object BirdsEye extends DetailLevel {
+      def hideFQNames            = true
+      // def compressNestedConcepts = false
+      // def compressData           = true
+      // def compressConcept        = true
+      // def hideInnerConcepts      = true
+    }
+
+    object BirdsEye2 extends DetailLevel {
+      def hideFQNames            = false
+      // def compressNestedConcepts = false
+      // def compressData           = true
+      // def compressConcept        = true
+      // def showInnerConcepts      = false
+      // def hideInnerConcepts      = true
+    }
+
+    object BirdsEye3 extends DetailLevel {
+      def hideFQNames            = false
+      // def compressNestedConcepts = false
+      // def compressData           = true
+      // def compressConcept        = true
+      // def showInnerConcepts      = false
+      // def hideInnerConcepts      = false
+    }
+  }
+}
+
+
+
+class PrintRTValue(
+    detailLevel: PrintRTValue.DetailLevel,
+    fieldNames: FieldNames,
+    val defaultWidth: Int
+) extends pprint.Walker {
+  val showFieldNames                = fieldNames == FieldNames.Show
+  val escapeUnicode                 = false
+  val defaultHeight: Int            = Integer.MAX_VALUE
+  val defaultIndent: Int            = 2
+  val colorLiteral: fansi.Attrs     = fansi.Color.Green
+  val colorApplyPrefix: fansi.Attrs = fansi.Color.Yellow
+  var verbose: Boolean              = false
+
+  override def additionalHandlers: PartialFunction[Any, Tree] = PartialFunction.empty
+
+  def apply(x: Any, verbose: Boolean = false): fansi.Str = {
+    this.verbose = verbose
+    val tokenized = this.tokenize(x).toSeq
+    fansi.Str.join(tokenized)
+  }
+
+  def treeify(x: Any): Tree      = this.treeify(x, escapeUnicode, showFieldNames)
+  def treeifySuper(x: Any): Tree = 
+    {
+      super.treeify(x, escapeUnicode, showFieldNames)
+    }
+
+  override def treeify(x: Any, escapeUnicode: Boolean, showFieldNames: Boolean): Tree = x match {
+
+    case name: Name =>
+      Tree.Literal(name.toTitleCase)
+
+    case qn: FQName =>
+      if (detailLevel.hideFQNames)
+        Tree.Literal(qn.localName.toTitleCase)
+      else
+        Tree.Literal(qn.toStringTitleCase)
+
+    case rt : RT => PrintRTInner.of(rt)
+
+    case other => super.treeify(other, escapeUnicode, showFieldNames)
+  }
+
+  object PrintRTInner {
+    def of(v: RT): Tree =
+      v match {
+        case v : RT.Primitive.Int => {
+          val mInt = v.value
+          if mInt.isValidInt then {
+            Tree.Literal(mInt.toInt.toString)
+          } else {
+            Tree.Literal(mInt.toString)
+          }
+        }
+        case v : RT.Primitive.String => {
+          Tree.Literal(s""""${v.value}"""")
+        }
+        case v : RT.Primitive.Char => {
+          Tree.Literal(s"""'${v.value}'""")
+        }
+        case v: RT.Primitive[_] => Tree.Literal(v.value.toString)
+        case v : RT.LocalDate   => Tree.Literal(v.value.toString)
+        case v : RT.LocalTime   => Tree.Literal(v.value.toString)
+        case v : RT.Unit   => Tree.ofRT(v)(List())
+
+        case v: RT.Tuple =>
+          Tree.ofRT(v)(v.elements.map(treeify(_)))
+
+        case v: RT.Record =>
+          val body = v.elements.map { case (k, v) => Tree.KeyValue(k.toCamelCase, treeify(v)) }.toList
+          Tree.ofRT(v)(body)
+
+        case v: RT.List =>
+          Tree.ofRT(v)(v.elements.map(r => treeify(r)))
+
+        case v: RT.Map =>
+          val body = v.elements.map { case (k, v) => Tree.Infix(treeify(k), "->", treeify(v)) }.toList
+          Tree.ofRT(v)(body)
+
+        case v: RT.Set =>
+          Tree.ofRT(v)(v.elements.toList.map(r => treeify(r)))
+
+        case v : RT.Function=> {
+          val body = v match {
+            case RT.FieldFunction(name) => {
+              List(Tree.Literal(s".${name.toCamelCase}"))
+            }
+            case RT.LambdaFunction(body, pattern, _) => 
+              List(Tree.Infix(Tree.Literal(s"\\${pattern.toString}"), "->", Tree.Literal(body.toString)))
+            case RT.DefinitionFunction(body, arguments, curried, _) => {
+              val paramsTree = Tree.KeyValue("parameters", Tree.Apply("", arguments.map(arg => Tree.Literal(s"${arg._1.toCamelCase} : ${arg._2.toString}")).iterator))
+              val curriedTree = Tree.KeyValue("curried", Tree.Apply("", curried.map(arg => Tree.KeyValue(arg._1.toCamelCase, treeify(arg._2))).iterator))
+              val bodyTree = Tree.KeyValue("body", Tree.Literal(body.toString))
+              if (curried.length > 0) {
+                List(paramsTree, curriedTree, bodyTree)
+              } else {
+                List(paramsTree, bodyTree)
+              }
+            }
+            case RT.ConstructorFunction(name, arguments, curried) => {
+              val paramsTree = Tree.KeyValue("parameters", Tree.Apply("", arguments.map(arg => Tree.Literal(arg.toString)).iterator))
+              val curriedTree = Tree.KeyValue("curried", Tree.Apply("", curried.map(arg => treeify(arg)).iterator))
+              val nameTree = Tree.KeyValue("name", treeify(name))
+              if (curried.length > 0) {
+                List(paramsTree, curriedTree, nameTree)
+              } else {
+                List(paramsTree, nameTree)
+              }
+            }
+            //The function name is not included in the RTValue, so what we can print here is limited
+            case RT.NativeFunction(argCount, curried, signature) => {
+              val argCountTree = Tree.KeyValue("remaining args", treeify(argCount))
+              val totalArgsTree = Tree.KeyValue("expected args", treeify(signature.numArgs))
+              val curriedTree = Tree.KeyValue("curried", Tree.Apply("", curried.map(arg => treeify(arg)).iterator))
+              if (curried.length > 0) {
+                List(argCountTree, totalArgsTree, curriedTree)
+              } else {
+                List(argCountTree, totalArgsTree)
+              }
+            }
+            case RT.NativeInnerFunction(argCount, curried, signature) => {
+              val argCountTree = Tree.KeyValue("remaining args", treeify(argCount))
+              val totalArgsTree = Tree.KeyValue("expected args", treeify(signature.numArgs))
+              val curriedTree = Tree.KeyValue("curried", Tree.Apply("", curried.map(arg => treeify(arg)).iterator))
+              if (curried.length > 0) {
+                List(argCountTree, totalArgsTree, curriedTree)
+              } else {
+                List(argCountTree, totalArgsTree)
+              }
+            }
+
+          }
+          Tree.ofRT(v)(
+            body
+          )
+          
+        }
+        case v : RT.ConstructorResult => {
+          val fqnString = if (detailLevel.hideFQNames)
+            v.name.localName.toTitleCase
+          else
+            v.name.toStringTitleCase
+          Tree.Apply(fqnString, v.values.map(treeify(_)).iterator)
+        }
+      }
+  }
+
+  
+
+  implicit class TreeOpts(tree: Tree.type) {
+    // Don't display full paths even for data-elements that have them,
+    // display all of that information in the concept-area
+    def ofRT(d: RT)(children: List[Tree]) =
+      Tree.Apply(d.printName, children.iterator)
+
+    
+  }
+
+  implicit class RTPrintOpts(v: RT) {
+    def printName: String =
+      v.getClass.getSimpleName
+      
+  }
+
+  def tokenize(x: Any): Iterator[fansi.Str] = {
+    val tree      = this.treeify(x)
+    val renderer  = new Renderer(defaultWidth, colorApplyPrefix, colorLiteral, defaultIndent)
+    val rendered  = renderer.rec(tree, 0, 0).iter
+    val truncated = new Truncated(rendered, defaultWidth, defaultHeight)
+    truncated
+  }
+}


### PR DESCRIPTION
This PR adds a pretty printer for RTValues, to improve readability of error messages and failed tests.

This included a minor refactor to PrintMDM, as different DetailLevel traits are required for each.

Additionally, added extra digits of precision to the value of Pi, in response to feedback.