### PR TITLE
fix for dealiasing extractor

### DIFF
--- a/morphir/runtime/src/org/finos/morphir/runtime/Extractors.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/Extractors.scala
@@ -149,9 +149,9 @@ object Extractors {
         tpe match {
           case NativeRef(_, _) => None
           case Type.Reference(_, typeName, typeArgs) =>
-            val lookedUp = dists.lookupTypeSpecification(typeName.packagePath, typeName.modulePath, typeName.localName)
+            val lookedUp = dists.lookupTypeDefinition(typeName.packagePath, typeName.modulePath, typeName.localName)
             lookedUp match {
-              case Right(T.Specification.TypeAliasSpecification(typeParams, expr)) =>
+              case Right(T.Definition.TypeAlias(typeParams, expr)) =>
                 val newBindings = typeParams.zip(typeArgs).toMap
                 Some(Utils.applyBindings(expr, newBindings))
               case _ => None // Missing name, but failing extractors cause problems

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
@@ -22,6 +22,7 @@ object TypeCheckerTests extends MorphirBaseSpec {
       irFilePath <- ZIO.succeed(os.pwd / "examples" / "morphir-elm-projects" / "evaluator-tests" / "morphir-ir.json")
       _          <- Console.printLine(s"Loading distribution from $irFilePath")
       dist       <- EvaluationLibrary.loadDistributionFromFileZIO(irFilePath.toString)
+
     } yield MorphirRuntime.quick(dist))
 
   val typeCheckerLayer: ZLayer[Any, Throwable, TypeChecker] =
@@ -29,7 +30,8 @@ object TypeCheckerTests extends MorphirBaseSpec {
       irFilePath <- ZIO.succeed(os.pwd / "examples" / "morphir-elm-projects" / "evaluator-tests" / "morphir-ir.json")
       _          <- Console.printLine(s"Loading distribution from $irFilePath")
       dist       <- EvaluationLibrary.loadDistributionFromFileZIO(irFilePath.toString)
-    } yield new TypeChecker(Distributions(dist)))
+      unitTestDist <- EvaluationLibrary.loadDistributionFromFileZIO("morphir-elm/sdks/morphir-unit-test/morphir-ir.json")
+    } yield new TypeChecker(Distributions(dist, unitTestDist)))
 
   def testTypeConforms(tpe1: UType, tpe2: UType)(expectedErrors: Int): ZIO[TypeChecker, Throwable, TestResult] =
     ZIO.serviceWithZIO[TypeChecker] { checker =>

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/TypeCheckerTests.scala.scala
@@ -30,7 +30,8 @@ object TypeCheckerTests extends MorphirBaseSpec {
       irFilePath <- ZIO.succeed(os.pwd / "examples" / "morphir-elm-projects" / "evaluator-tests" / "morphir-ir.json")
       _          <- Console.printLine(s"Loading distribution from $irFilePath")
       dist       <- EvaluationLibrary.loadDistributionFromFileZIO(irFilePath.toString)
-      unitTestDist <- EvaluationLibrary.loadDistributionFromFileZIO("morphir-elm/sdks/morphir-unit-test/morphir-ir.json")
+      unitTestDist <-
+        EvaluationLibrary.loadDistributionFromFileZIO("morphir-elm/sdks/morphir-unit-test/morphir-ir.json")
     } yield new TypeChecker(Distributions(dist, unitTestDist)))
 
   def testTypeConforms(tpe1: UType, tpe2: UType)(expectedErrors: Int): ZIO[TypeChecker, Throwable, TestResult] =


### PR DESCRIPTION
Fix (and added additional testing) for a bug relating to type dealiasing

A prior PR addressed an issue where opaque types were being rejected on entry points due to the use of `lookupTypeSpecification` rather than `lookupTypeDefinition`. This fix was not applied to the extractor utility functions which are used by the type checker. Because these are only used in deeper type checking (which is currently only called by tests), it was not immediately caught.

This PR applies that fix to the extractor utility. Additionally, it expands the distributions the type checker covers to include some which use opaque types (so that this or similar bugs will be caught in the future).