### PR TITLE
Fixed mis-named function and added comments

### DIFF
--- a/morphir/src/org/finos/morphir/runtime/sdk/DecimalSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/DecimalSDK.scala
@@ -40,7 +40,7 @@ object DecimalSDK {
   val div = DynamicNativeFunction2("div") {
     (_: NativeContext) => (dec1: RTDecimal, dec2: RTDecimal) =>
       val result = tryOption(dec1.value / dec2.value).map(RTDecimal(_))
-      MaybeSDK.resultToMaybe(result)
+      MaybeSDK.optionToMaybe(result)
   }
 
   val divWithDefault = DynamicNativeFunction3("divWithDefault") {
@@ -66,7 +66,7 @@ object DecimalSDK {
   val fromString = DynamicNativeFunction1("fromString") {
     (_: NativeContext) => (str: RT.Primitive.String) =>
       val result = tryOption(BigDecimal(str.value)).map(RTDecimal(_))
-      MaybeSDK.resultToMaybe(result)
+      MaybeSDK.optionToMaybe(result)
   }
 
   val gt = DynamicNativeFunction2("gt") {

--- a/morphir/src/org/finos/morphir/runtime/sdk/ListSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/ListSDK.scala
@@ -79,7 +79,7 @@ object ListSDK {
         case head :: rest => Some(rest.foldLeft(head)(unsafeRTValueOrd.max))
       }
 
-      MaybeSDK.resultToMaybe(result)
+      MaybeSDK.optionToMaybe(result)
   }
 
   val minimum = DynamicNativeFunction1("minimum") {
@@ -89,7 +89,7 @@ object ListSDK {
         case head :: rest => Some(rest.foldLeft(head)(unsafeRTValueOrd.min))
       }
 
-      MaybeSDK.resultToMaybe(result)
+      MaybeSDK.optionToMaybe(result)
   }
 
   val partition = DynamicNativeFunction2("partition") {
@@ -179,7 +179,7 @@ object ListSDK {
       val out = list.elements.map { elem =>
         val maybeOutputRaw = context.evaluator.handleApplyResult(Type.UType.Unit(()), f, elem)
         val maybeOutputCr  = RTValue.coerceConstructorResult(maybeOutputRaw)
-        MaybeSDK.eitherToOption(maybeOutputCr)
+        MaybeSDK.maybeToOption(maybeOutputCr)
       }.flatten
       RTValue.List(out)
   }
@@ -214,7 +214,7 @@ object ListSDK {
   }
 
   val head = DynamicNativeFunction1("head") {
-    (_: NativeContext) => (list: RTValue.List) => MaybeSDK.resultToMaybe(list.value.headOption)
+    (_: NativeContext) => (list: RTValue.List) => MaybeSDK.optionToMaybe(list.value.headOption)
   }
 
   val indexedMap = DynamicNativeFunction2("indexedMap") {
@@ -252,7 +252,7 @@ object ListSDK {
   val tail = DynamicNativeFunction1("tail") {
     (context: NativeContext) => (list: RTValue.List) =>
       val result = if (list.elements.isEmpty) None else Some(RTValue.List(list.elements.tail))
-      MaybeSDK.resultToMaybe(result)
+      MaybeSDK.optionToMaybe(result)
   }
 
   val take = DynamicNativeFunction2("take") {

--- a/morphir/src/org/finos/morphir/runtime/sdk/LocalDateSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/LocalDateSDK.scala
@@ -48,7 +48,7 @@ object LocalDateSDK {
           val maybeLocalDate   = tryOption(java.time.LocalDate.of(year, month, day))
           val maybeLocalDateRt = maybeLocalDate.map(RTValue.LocalDate.apply)
 
-          MaybeSDK.resultToMaybe(maybeLocalDateRt)
+          MaybeSDK.optionToMaybe(maybeLocalDateRt)
         }
   }
 
@@ -117,7 +117,7 @@ object LocalDateSDK {
         val isoStr           = isoArg.value
         val maybeLocalDate   = elmCompatIsoParse(isoStr)
         val maybeLocalDateRT = maybeLocalDate.map(RTValue.LocalDate.apply)
-        MaybeSDK.resultToMaybe(maybeLocalDateRT)
+        MaybeSDK.optionToMaybe(maybeLocalDateRT)
       }
   }
 

--- a/morphir/src/org/finos/morphir/runtime/sdk/LocalTimeSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/LocalTimeSDK.scala
@@ -44,7 +44,7 @@ object LocalTimeSDK {
           try Some(JLocalTime.parse(isoArg.value, JDateTimeFormatter.ISO_LOCAL_TIME))
           catch { case NonFatal(_) => None }
         val maybeLocalTimeRT = maybeLocalTime.map(RTValue.LocalTime.apply)
-        MaybeSDK.resultToMaybe(maybeLocalTimeRT)
+        MaybeSDK.optionToMaybe(maybeLocalTimeRT)
       }
   }
 

--- a/morphir/src/org/finos/morphir/runtime/sdk/MaybeSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/MaybeSDK.scala
@@ -34,7 +34,16 @@ import org.finos.morphir.naming._
  *   - Change toOption(arg) calls to arg.value and toMaybe(result) calls to RT.Maybe(result)
  */
 object MaybeSDK {
-  private[sdk] def eitherToOption(arg: RT.ConstructorResult): Option[RT] =
+
+  /**
+   * Converts a "Maybe" - i.e., a ConstructorResult representing a morphir-elm Maybe value - to a Scala Option
+   *
+   * @param arg
+   *   A ConstructorResult representing a morphir-elm Maybe value (Just or Nothing)
+   * @return
+   *   An Option representing the argument in Scala terms - `Some(x)` if arg was `Just x`, `None` if arg was `Nothing`
+   */
+  private[sdk] def maybeToOption(arg: RT.ConstructorResult): Option[RT] =
     arg match {
       case RTValue.ConstructorResult(fqn, List(value)) if fqn == FQName.fromString("Morphir.SDK:Maybe:Just") =>
         Some(value)
@@ -46,7 +55,17 @@ object MaybeSDK {
           "Expected due to use in a native function"
         )
     }
-  private[sdk] def resultToMaybe(arg: Option[RT]): RT.ConstructorResult =
+
+  /**
+   * Converts a Scala Option to a "Maybe" - i.e., a ConstructorResult representing a morphir-elm Maybe value
+   *
+   * @param arg
+   *   A Scala Option
+   * @return
+   *   A ConstructorResult representing the argument in Morphir terms - `Just x` if arg was `Some(x)`, `Nothing` if arg
+   *   was `None`
+   */
+  private[sdk] def optionToMaybe(arg: Option[RT]): RT.ConstructorResult =
     arg match {
       case Some(value) => RTValue.ConstructorResult(FQName.fromString("Morphir.SDK:Maybe:Just"), List(value))
       case None        => RTValue.ConstructorResult(FQName.fromString("Morphir.SDK:Maybe:Nothing"), List())
@@ -55,25 +74,25 @@ object MaybeSDK {
   val map = DynamicNativeFunction2("map") {
     (ctx: NativeContext) => (f: RT.Function, maybeRaw: RT.ConstructorResult) =>
       {
-        val out = eitherToOption(maybeRaw).map(elem => ctx.evaluator.handleApplyResult(Type.variable("a"), f, elem))
-        resultToMaybe(out)
+        val out = maybeToOption(maybeRaw).map(elem => ctx.evaluator.handleApplyResult(Type.variable("a"), f, elem))
+        optionToMaybe(out)
       }
   }
 
   val withDefault = DynamicNativeFunction2("withDefault") {
     (ctx: NativeContext) => (default: RT, maybeRaw: RT.ConstructorResult) =>
-      eitherToOption(maybeRaw).getOrElse(default)
+      maybeToOption(maybeRaw).getOrElse(default)
   }
 
   val andThen = DynamicNativeFunction2("andThen") {
     (ctx: NativeContext) => (callback: RT.Function, maybeRaw: RT.ConstructorResult) =>
       {
-        val out = eitherToOption(maybeRaw).flatMap { elem =>
+        val out = maybeToOption(maybeRaw).flatMap { elem =>
           val fromCallbackRaw = ctx.evaluator.handleApplyResult(Type.variable("a"), callback, elem)
           val fromCallbackCr  = RT.coerceConstructorResult(fromCallbackRaw)
-          eitherToOption(fromCallbackCr)
+          maybeToOption(fromCallbackCr)
         }
-        resultToMaybe(out)
+        optionToMaybe(out)
       }
   }
 

--- a/morphir/src/org/finos/morphir/runtime/sdk/MaybeSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/MaybeSDK.scala
@@ -100,10 +100,10 @@ object MaybeSDK {
     (ctx: NativeContext) => (f: RT.Function, maybeRaw1: RT.ConstructorResult, maybeRaw2: RT.ConstructorResult) =>
       {
         val out = for {
-          elem1 <- eitherToOption(maybeRaw1)
-          elem2 <- eitherToOption(maybeRaw2)
+          elem1 <- maybeToOption(maybeRaw1)
+          elem2 <- maybeToOption(maybeRaw2)
         } yield ctx.evaluator.handleApplyResult2(Type.variable("a"), f, elem1, elem2)
-        resultToMaybe(out)
+        optionToMaybe(out)
       }
   }
 
@@ -116,11 +116,11 @@ object MaybeSDK {
     ) =>
       {
         val out = for {
-          elem1 <- eitherToOption(maybeRaw1)
-          elem2 <- eitherToOption(maybeRaw2)
-          elem3 <- eitherToOption(maybeRaw3)
+          elem1 <- maybeToOption(maybeRaw1)
+          elem2 <- maybeToOption(maybeRaw2)
+          elem3 <- maybeToOption(maybeRaw3)
         } yield ctx.evaluator.handleApplyResult3(Type.variable("a"), f, elem1, elem2, elem3)
-        resultToMaybe(out)
+        optionToMaybe(out)
       }
   }
 
@@ -134,17 +134,17 @@ object MaybeSDK {
     ) =>
       {
         val out = for {
-          elem1 <- eitherToOption(maybeRaw1)
-          elem2 <- eitherToOption(maybeRaw2)
-          elem3 <- eitherToOption(maybeRaw3)
-          elem4 <- eitherToOption(maybeRaw4)
+          elem1 <- maybeToOption(maybeRaw1)
+          elem2 <- maybeToOption(maybeRaw2)
+          elem3 <- maybeToOption(maybeRaw3)
+          elem4 <- maybeToOption(maybeRaw4)
         } yield ctx.evaluator.handleApplyResult4(Type.variable("a"), f, elem1, elem2, elem3, elem4)
-        resultToMaybe(out)
+        optionToMaybe(out)
       }
   }
 
   val hasValue = DynamicNativeFunction1("hasValue") {
     (_: NativeContext) => (maybeRaw: RT.ConstructorResult) =>
-      RT.Primitive.Boolean(eitherToOption(maybeRaw).isDefined)
+      RT.Primitive.Boolean(maybeToOption(maybeRaw).isDefined)
   }
 }

--- a/morphir/src/org/finos/morphir/runtime/sdk/StringSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/StringSDK.scala
@@ -123,7 +123,7 @@ object StringSDK {
   val toFloat = DynamicNativeFunction1("toFloat") {
     (context: NativeContext) => (str: RTString) =>
       val result = str.value.toFloatOption.flatMap(RT.Primitive.make(_))
-      MaybeSDK.resultToMaybe(result)
+      MaybeSDK.optionToMaybe(result)
   }
 
   val toLower = DynamicNativeFunction1("toLower") {


### PR DESCRIPTION
This PR addresses https://github.com/finos/morphir-scala/issues/575 by renaming some mis-named helper functions in MaybeSDK