### PR TITLE
Fix a broken link to Contribution Guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Watch for updates.
 
 1. Fork it (<https://github.com/finos/morphir-scala/fork>)
 2. Create your feature branch (`git checkout -b feature/fooBar`)
-3. Read our [contribution guidelines](.github/CONTRIBUTING.md) and [Community Code of Conduct](https://www.finos.org/code-of-conduct)
+3. Read our [contribution guidelines](CONTRIBUTING.md) and [Community Code of Conduct](https://www.finos.org/code-of-conduct)
 4. Commit your changes (`git commit -am 'Add some fooBar'`)
 5. Push to the branch (`git push origin feature/fooBar`)
 6. Create a new Pull Request


### PR DESCRIPTION
Fixes a broken link to the [Contribution Guidelines](https://github.com/finos/morphir-scala/blob/main/CONTRIBUTING.md).

