### PR TITLE
Add missing functionality to BasicSDK.Float

### DIFF
--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/SdkBasicsTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/SdkBasicsTests.elm
@@ -1206,6 +1206,7 @@ basicsXorTest : Bool -> Bool -> Bool
 basicsXorTest x y =
     xor x y
 
+
 {-| Test: SdkBasics/basicsRoundTest
 expected(1.6) = 2
 expected(1.4) = 1

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/SdkBasicsTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/SdkBasicsTests.elm
@@ -507,10 +507,6 @@ sdkTurnsTest ctx =
         f (1 / 2)
 
 
-
------------------ Unimplemented and not run -----------------
-
-
 {-| Test: SdkBasics/toPolar
 Expected: (5,0.9272952180016122)
 -}
@@ -525,7 +521,7 @@ sdkToPolarTest ctx =
 
 
 {-| Test: SdkBasics/fromPolar
-Expected: ~(1, 1)
+Expected: (1.2247448713915892, 0.7071067811865475)
 -}
 sdkFromPolarTest : TestContext -> ( Float, Float )
 sdkFromPolarTest ctx =
@@ -534,11 +530,7 @@ sdkFromPolarTest ctx =
             f x =
                 fromPolar x
         in
-        f ( sqrt 2, degrees 45 )
-
-
-
------
+        f ( sqrt 2, degrees 30 )
 
 
 {-| Test: SdkBasics/equal

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/SdkBasicsTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/SdkBasicsTests.elm
@@ -1213,3 +1213,11 @@ expected(false, false) = false
 basicsXorTest : Bool -> Bool -> Bool
 basicsXorTest x y =
     xor x y
+
+{-| Test: SdkBasics/basicsRoundTest
+expected(1.6) = 2
+expected(1.4) = 1
+-}
+basicsRoundTest : Float -> Int
+basicsRoundTest v =
+    round v

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -3088,7 +3088,9 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           testEval("Truncate 2")("sdkBasicsTests", "basicsTruncateTest", -1.2)(Data.Int(-1)),
           testEval("Truncate 3")("sdkBasicsTests", "basicsTruncateTest", .4)(Data.Int(0)),
           testEval("Truncate 4")("sdkBasicsTests", "basicsTruncateTest", -.4)(Data.Int(0)),
-          testEval("Abs")("sdkBasicsTests", "basicsAbsTest", Data.Float(-5.0))(Data.Float(5.0))
+          testEval("Abs")("sdkBasicsTests", "basicsAbsTest", Data.Float(-5.0))(Data.Float(5.0)),
+          testEval("Round up")("sdkBasicsTests", "basicsRoundTest", Data.Float(1.6))(Data.Int(2)),
+          testEval("Round down")("sdkBasicsTests", "basicsRoundTest", Data.Float(1.4))(Data.Int(1))
         ),
         suite("Int")(
           testEvaluation("Plus")("sdkBasicsTests", "sdkAddTest")(Data.Int(3)),

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -3080,6 +3080,10 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           testEvaluation("degrees")("sdkBasicsTests", "sdkDegreesTest")(Data.Float(3.141592653589793)),
           testEvaluation("radians")("sdkBasicsTests", "sdkRadiansTest")(Data.Float(3.141592653589793)),
           testEvaluation("turns")("sdkBasicsTests", "sdkTurnsTest")(Data.Float(3.141592653589793)),
+          testEvaluation("toPolar")("sdkBasicsTests", "sdkToPolarTest")(Data.Tuple(
+            Data.Float(5),
+            Data.Float(0.9272952180016122)
+          )),
           testEval("Ceiling")("sdkBasicsTests", "basicsCeilingTest", 3.88)(Data.Int(4)),
           testEval("Ceiling whole number")("sdkBasicsTests", "basicsCeilingTest", 3.0)(Data.Int(3)),
           testEval("Floor")("sdkBasicsTests", "basicsFloorTest", 3.88)(Data.Int(3)),

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -3084,6 +3084,10 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
             Data.Float(5),
             Data.Float(0.9272952180016122)
           )),
+          testEvaluation("fromPolar")("sdkBasicsTests", "sdkFromPolarTest")(Data.Tuple(
+            Data.Float(1.2247448713915892),
+            Data.Float(0.7071067811865475)
+          )),
           testEval("Ceiling")("sdkBasicsTests", "basicsCeilingTest", 3.88)(Data.Int(4)),
           testEval("Ceiling whole number")("sdkBasicsTests", "basicsCeilingTest", 3.0)(Data.Int(3)),
           testEval("Floor")("sdkBasicsTests", "basicsFloorTest", 3.88)(Data.Int(3)),

--- a/morphir/src/org/finos/morphir/runtime/Coercer.scala
+++ b/morphir/src/org/finos/morphir/runtime/Coercer.scala
@@ -83,4 +83,8 @@ object Coercer {
   implicit val localTimeCoercer: Coercer[RTValue.LocalTime] = new Coercer[RTValue.LocalTime] {
     def coerce(result: RTValue): RTValue.LocalTime = RTValue.coerceLocalTime(result)
   }
+
+  implicit val tupleCoercer: Coercer[RTValue.Tuple] = new Coercer[RTValue.Tuple] {
+    def coerce(result: RTValue): RTValue.Tuple = RTValue.coerceTuple(result)
+  }
 }

--- a/morphir/src/org/finos/morphir/runtime/NativeSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/NativeSDK.scala
@@ -109,7 +109,8 @@ object NativeSDK {
           NativeFunctionAdapter.Fun1(BasicsSDK.degrees),
           NativeFunctionAdapter.Fun1(BasicsSDK.radians),
           NativeFunctionAdapter.Fun1(BasicsSDK.turns),
-          NativeFunctionAdapter.Fun1(BasicsSDK.round)
+          NativeFunctionAdapter.Fun1(BasicsSDK.round),
+          NativeFunctionAdapter.Fun1(BasicsSDK.toPolar)
         )
 
         private val enumSDKConstructor = SDKConstructor(scala.List())

--- a/morphir/src/org/finos/morphir/runtime/NativeSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/NativeSDK.scala
@@ -110,6 +110,7 @@ object NativeSDK {
           NativeFunctionAdapter.Fun1(BasicsSDK.radians),
           NativeFunctionAdapter.Fun1(BasicsSDK.turns),
           NativeFunctionAdapter.Fun1(BasicsSDK.round),
+          NativeFunctionAdapter.Fun1(BasicsSDK.fromPolar),
           NativeFunctionAdapter.Fun1(BasicsSDK.toPolar)
         )
 

--- a/morphir/src/org/finos/morphir/runtime/NativeSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/NativeSDK.scala
@@ -108,7 +108,8 @@ object NativeSDK {
           NativeFunctionAdapter.Fun2(BasicsSDK.atan2),
           NativeFunctionAdapter.Fun1(BasicsSDK.degrees),
           NativeFunctionAdapter.Fun1(BasicsSDK.radians),
-          NativeFunctionAdapter.Fun1(BasicsSDK.turns)
+          NativeFunctionAdapter.Fun1(BasicsSDK.turns),
+          NativeFunctionAdapter.Fun1(BasicsSDK.round)
         )
 
         private val enumSDKConstructor = SDKConstructor(scala.List())

--- a/morphir/src/org/finos/morphir/runtime/sdk/BasicsSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/BasicsSDK.scala
@@ -8,6 +8,7 @@ import org.finos.morphir.runtime.internal._
 import org.finos.morphir.runtime.RTValue
 import org.finos.morphir.runtime.RTValue.Comparable
 import org.finos.morphir.runtime.MorphirRuntimeError.IllegalValue
+import org.finos.morphir.runtime.ErrorUtils.tryOption
 
 object BasicsSDK {
   type AnyNum = Any
@@ -240,5 +241,10 @@ object BasicsSDK {
   val turns = DynamicNativeFunction1("turns") {
     (_: NativeContext) => (a: Primitive.Float) =>
       Primitive.Float(a.value * 2 * scala.math.Pi)
+  }
+
+  val round = DynamicNativeFunction1("round") {
+    (_: NativeContext) => (a: Primitive.Float) =>
+      Primitive.Int(scala.math.round(a.value))
   }
 }

--- a/morphir/src/org/finos/morphir/runtime/sdk/BasicsSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/BasicsSDK.scala
@@ -4,7 +4,7 @@ import org.finos.morphir.ir.Type
 import org.finos.morphir.Hints
 import org.finos.morphir.runtime.RTValue.{Comparable, Primitive, coerceFloat}
 import org.finos.morphir.runtime.SDKValue
-import org.finos.morphir.runtime.internal.*
+import org.finos.morphir.runtime.internal._
 import org.finos.morphir.runtime.RTValue
 import org.finos.morphir.runtime.MorphirRuntimeError.{FailedCoercion, IllegalValue, TypeError}
 import org.finos.morphir.runtime.ErrorUtils.tryOption

--- a/morphir/src/org/finos/morphir/runtime/sdk/BasicsSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/BasicsSDK.scala
@@ -8,7 +8,6 @@ import org.finos.morphir.runtime.internal._
 import org.finos.morphir.runtime.RTValue
 import org.finos.morphir.runtime.MorphirRuntimeError.{FailedCoercion, IllegalValue, TypeError}
 import org.finos.morphir.runtime.ErrorUtils.tryOption
-import org.finos.morphir.runtime.sdk.BasicsSDK.radians
 
 object BasicsSDK {
   type AnyNum = Any

--- a/morphir/src/org/finos/morphir/runtime/sdk/BasicsSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/BasicsSDK.scala
@@ -248,6 +248,17 @@ object BasicsSDK {
       Primitive.Int(scala.math.round(a.value))
   }
 
+  val fromPolar = DynamicNativeFunction1("fromPolar") {
+    (_: NativeContext) => (a: RTValue.Tuple) =>
+      val (distance, radians) = a.value.size match {
+        case 2 => (coerceFloat(a.value.head).value, coerceFloat(a.value(1)).value)
+        case s => throw new TypeError.SizeMismatch(s, 2, "Tuple did not contain exactly 2 items")
+      }
+      val x = distance * scala.math.cos(radians)
+      val y = distance * scala.math.sin(radians)
+      RTValue.Tuple(Primitive.Float(x), Primitive.Float(y))
+  }
+
   val toPolar = DynamicNativeFunction1("toPolar") {
     (_: NativeContext) => (a: RTValue.Tuple) =>
       val (x, y) = a.value.size match {


### PR DESCRIPTION
Adds missing functionality for Float function as defined [here](https://github.com/finos/morphir/blob/main/docs/scala/support.md)