### PR TITLE
Implicit record support

### DIFF
--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ConstructorTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ConstructorTests.elm
@@ -2,10 +2,16 @@ module Morphir.Examples.App.ConstructorTests exposing (..)
 
 import Morphir.Examples.App.TestUtils exposing (..)
 
-type alias SomeRecord = {name : String, number : Int}
+
+type alias SomeRecord =
+    { name : String, number : Int }
+
 
 implicitConstructorTest : String -> SomeRecord
-implicitConstructorTest name = SomeRecord name 5
+implicitConstructorTest name =
+    SomeRecord name 5
+
+
 
 {-
    Partially-applied constructors are debateably still "Data"

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ConstructorTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ConstructorTests.elm
@@ -2,7 +2,10 @@ module Morphir.Examples.App.ConstructorTests exposing (..)
 
 import Morphir.Examples.App.TestUtils exposing (..)
 
+type alias SomeRecord = {name : String, number : Int}
 
+implicitConstructorTest : String -> SomeRecord
+implicitConstructorTest name = SomeRecord name 5
 
 {-
    Partially-applied constructors are debateably still "Data"

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -321,6 +321,12 @@ final class TypeChecker(dists: Distributions) {
                 List(new ImproperTypeDef(name, other, s"Type union expected"))
               case Left(err) => List(err.withContext(s"Needed looking for constructor ${fqn.toStringTitleCase}"))
             }
+          // The following is for implicit record constructors
+          case Type.Record(_, fields) => checkList(
+              args.toList,
+              fields.map(_.data),
+              context.withPrefix(s"Comparing $fqn implicit constructor value to looked up type ${PrintIR(tpe)}")
+            )
           case NativeRef(_, _) => List() // TODO: check native constructor calls
           case other           => List(new ImproperType(other, s"Reference to type union expected"))
         }

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -319,14 +319,28 @@ final class TypeChecker(dists: Distributions) {
                 missedName ++ fromCtor
               case Right(other) =>
                 List(new ImproperTypeDef(name, other, s"Type union expected"))
-              case Left(err) => List(err.withContext(s"Needed looking for constructor ${fqn.toStringTitleCase}"))
+              case Left(err) =>
+                List(err.withContext(s"Needed looking for implicit constructor ${fqn.toStringTitleCase}"))
             }
           // The following is for implicit record constructors
-          case Type.Record(_, fields) => checkList(
+          case Type.Record(_, fields) =>
+            val argErrors = checkList(
               args.toList,
               fields.map(_.data),
               context.withPrefix(s"Comparing $fqn implicit constructor value to looked up type ${PrintIR(tpe)}")
             )
+            val nameMismatch = dists.lookupTypeDefinition(fqn) match {
+              case Right(T.Definition.TypeAlias(_, aliasedRecordType)) => conformsTo(aliasedRecordType, ret, context)
+              case Right(other) => List(ImproperTypeDef(
+                  fqn,
+                  other,
+                  s"I think this is an implicit record constructor because the return type is a record, but the function points to something else"
+                ))
+              case Left(err) =>
+                List(err.withContext(s"Needed looking for implicit constructor ${fqn.toStringTitleCase}"))
+            }
+            argErrors ++ nameMismatch
+
           case NativeRef(_, _) => List() // TODO: check native constructor calls
           case other           => List(new ImproperType(other, s"Reference to type union expected"))
         }

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -342,7 +342,8 @@ final class TypeChecker(dists: Distributions) {
             argErrors ++ nameMismatch
 
           case NativeRef(_, _) => List() // TODO: check native constructor calls
-          case other           => List(new ImproperType(other, s"Reference to type union expected"))
+          case other =>
+            List(new ImproperType(other, s"Reference to type union or implicit record constructor expected"))
         }
     }
   }

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Native.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Native.scala
@@ -409,13 +409,13 @@ object Native {
   val pi: SDKValue = SDKValue.SDKNativeValue(RTValue.Primitive.Float(scala.math.Pi))
   val e: SDKValue  = SDKValue.SDKNativeValue(RTValue.Primitive.Float(scala.math.E))
 
-  val just: SDKConstructor    = SDKConstructor(List(Type.variable("contents")))
-  val nothing: SDKConstructor = SDKConstructor(List())
-  val ok: SDKConstructor      = SDKConstructor(List(Type.variable("contents")))
-  val err: SDKConstructor     = SDKConstructor(List(Type.variable("contents")))
-  val gt: SDKConstructor      = SDKConstructor(List())
-  val lt: SDKConstructor      = SDKConstructor(List())
-  val eq: SDKConstructor      = SDKConstructor(List())
+  val just: SDKConstructor    = SDKConstructor.Explicit(List(Type.variable("contents")))
+  val nothing: SDKConstructor = SDKConstructor.Explicit(List())
+  val ok: SDKConstructor      = SDKConstructor.Explicit(List(Type.variable("contents")))
+  val err: SDKConstructor     = SDKConstructor.Explicit(List(Type.variable("contents")))
+  val gt: SDKConstructor      = SDKConstructor.Explicit(List())
+  val lt: SDKConstructor      = SDKConstructor.Explicit(List())
+  val eq: SDKConstructor      = SDKConstructor.Explicit(List())
 
   val nativeCtors: Map[FQName, SDKConstructor] = Map(
     FQName.fromString("Morphir.SDK:Maybe:just")    -> just,

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -357,7 +357,14 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
             actual <- runTest("constructorTests", "lazyFunctionTest")
             expected = Data.Tuple(Data.Int(5), Data.Int(5))
           } yield assertTrue(actual == expected)
-        }
+        },
+        testEval("Implicit Constructor")("constructorTests", "implicitConstructorTest", "abcd")(
+          Data.Record(
+            FQName.fromString("Morphir.Examples.App:ConstructorTests:SomeRecord"),
+            (Label("name"), Data.String("abcd")),
+            (Label("number"), Data.Int(5))
+          )
+        )
       ),
       suite("Destructure Tests")(
         test("As") {

--- a/morphir/src/org/finos/morphir/runtime/NativeSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/NativeSDK.scala
@@ -111,7 +111,7 @@ object NativeSDK {
           NativeFunctionAdapter.Fun1(BasicsSDK.turns)
         )
 
-        private val enumSDKConstructor = SDKConstructor(scala.List())
+        private val enumSDKConstructor = SDKConstructor.Explicit(scala.List())
 
         override val ctors: Map[FQName, SDKConstructor] =
           RTValue.Order.allFqns.map(fqn => fqn -> enumSDKConstructor).toMap
@@ -235,7 +235,7 @@ object NativeSDK {
           NativeFunctionAdapter.Fun1(LocalDateSDK.toISOString)
         )
 
-        private val enumSDKConstructor = SDKConstructor(scala.List())
+        private val enumSDKConstructor = SDKConstructor.Explicit(scala.List())
 
         // Morphir.SDK:LocalDate:Month
         private val monthCtors = RTValue.Month.allFqns.map(fqn => fqn -> enumSDKConstructor).toMap

--- a/morphir/src/org/finos/morphir/runtime/RTValue.scala
+++ b/morphir/src/org/finos/morphir/runtime/RTValue.scala
@@ -1,6 +1,6 @@
 package org.finos.morphir.runtime
 
-import org.finos.morphir.ir.Type.Type
+import org.finos.morphir.ir.Type.{Type, FieldT}
 import org.finos.morphir.ir.Value.Value.{List as ListValue, Unit as UnitValue, *}
 import org.finos.morphir.ir.Value.{Pattern, Value, TypedValue}
 import org.finos.morphir.ir.{Module, Type}
@@ -668,6 +668,12 @@ object RTValue {
 
   case class ConstructorFunction(name: FQName, arguments: scala.List[UType], curried: scala.List[RTValue])
       extends Function
+
+  case class ImplicitConstructorFunction(
+      name: FQName,
+      arguments: scala.List[FieldT[scala.Unit]],
+      curried: collection.Map[Name, RTValue]
+  ) extends Function
 
   // TODO: We are currently using this for Maybe and Result types; those should be promoted to their own RTValues
   case class ConstructorResult(name: FQName, values: scala.List[RTValue]) extends RTValue {

--- a/morphir/src/org/finos/morphir/runtime/SDKValue.scala
+++ b/morphir/src/org/finos/morphir/runtime/SDKValue.scala
@@ -1,6 +1,6 @@
 package org.finos.morphir.runtime
 
-import org.finos.morphir.ir.Type.UType
+import org.finos.morphir.ir.Type.{FieldT, UType}
 import org.finos.morphir.ir.Value.Value.{List as ListValue, Unit as UnitValue, *}
 import org.finos.morphir.ir.Value.{Pattern, Value, TypedDefinition}
 import org.finos.morphir.ir.{Module, Type}
@@ -13,8 +13,11 @@ import org.finos.morphir.runtime.internal.NativeFunctionSignature.*
 import zio.Chunk
 
 sealed trait SDKValue
-
-case class SDKConstructor(arguments: List[UType])
+sealed trait SDKConstructor
+object SDKConstructor {
+  case class Implicit(fields: List[FieldT[Unit]]) extends SDKConstructor
+  case class Explicit(arguments: List[UType])     extends SDKConstructor
+}
 object SDKValue {
   case class SDKValueDefinition(definition: TypedDefinition) extends SDKValue
   case class SDKNativeFunction(function: NativeFunctionSignature) extends SDKValue {

--- a/morphir/src/org/finos/morphir/util/PrintRTValue.scala
+++ b/morphir/src/org/finos/morphir/util/PrintRTValue.scala
@@ -144,6 +144,16 @@ class PrintRTValue(
               } else {
                 List(paramsTree, nameTree)
               }
+            case RT.ImplicitConstructorFunction(name, arguments, curried) =>
+              val paramsTree =
+                Tree.KeyValue("parameters", Tree.Apply("", arguments.map(arg => Tree.Literal(arg.toString)).iterator))
+              val curriedTree = Tree.KeyValue("curried", Tree.Apply("", curried.map(arg => treeify(arg)).iterator))
+              val nameTree    = Tree.KeyValue("name", treeify(name))
+              if (curried.size > 0) {
+                List(paramsTree, curriedTree, nameTree)
+              } else {
+                List(paramsTree, nameTree)
+              }
 
             case RT.NativeFunction(argCount, curried, signature, loc) =>
               val locString     = Tree.Literal(loc.toString)


### PR DESCRIPTION
This closes a bug in which Implicit Record Constructors were not properly supported in the morphir-scala evaluator.