### PR TITLE
Add Aggregate.aggregateMap functions

### DIFF
--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/AggregateTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/AggregateTests.elm
@@ -14,17 +14,17 @@ type alias TestInput1 =
 {-| Test: Aggregate/groupBy
 expected =
     Dict.fromList
-    [ ( "k1_1"
-        , [ TestInput1 "k1_1" "k2_1" 1
-        , TestInput1 "k1_1" "k2_1" 2
-        , TestInput1 "k1_1" "k2_2" 3
-        , TestInput1 "k1_1" "k2_2" 4
+    [ ( "k1_1",
+        [ ("k1_1", 1)
+        , ("k1_1", 2)
+        , ("k1_1", 3)
+        , ("k1_1", 4)
         ]
     , ( "k1_2",
-        , [ TestInput1 "k1_2" "k2_1" 5
-        , TestInput1 "k1_2" "k2_1" 6
-        , TestInput1 "k1_2" "k2_2" 7
-        , TestInput1 "k1_2" "k2_2" 8
+        [ ("k1_2", 5)
+        , ("k1_2", 6)
+        , ("k1_2", 7)
+        , ("k1_2", 8)
         ]
     ]
 -}
@@ -90,144 +90,141 @@ aggregateGroupByTest ctx =
 
 {-| Test: Aggregate/aggregateMap
 expected =
-    [ ( ("k1_1", 1), 10 / 1 )
-    , ( ("k1_1", 2), 10 / 2 )
-    , ( ("k1_1", 3), 10 / 3 )
-    , ( ("k1_1", 4), 10 / 4 )
-    , ( ("k1_2", 5), 26 / 5 )
-    , ( ("k1_2", 6), 26 / 6 )
-    , ( ("k1_2", 7), 26 / 7 )
-    , ( ("k1_2", 8), 26 / 8 )
+    [ ( ("k1_1", 1.0), 10.0 / 1.0 )
+    , ( ("k1_1", 2.0), 10.0 / 2.0 )
+    , ( ("k1_1", 3.0), 10.0 / 3.0 )
+    , ( ("k1_1", 4.0), 10.0 / 4.0 )
+    , ( ("k1_2", 5.0), 26.0 / 5.0 )
+    , ( ("k1_2", 6.0), 26.0 / 6.0 )
+    , ( ("k1_2", 7.0), 26.0 / 7.0 )
+    , ( ("k1_2", 8.0), 26.0 / 8.0 )
     ]
 -}
 aggregateAggregateMapTest : TestContext -> List ((String, Float), Float)
 aggregateAggregateMapTest ctx =
     let
         testDataSet =
-            [ ("k1_1", 1)
-            , ("k1_1", 2)
-            , ("k1_1", 3)
-            , ("k1_1", 4)
-            , ("k1_2", 5)
-            , ("k1_2", 6)
-            , ("k1_2", 7)
-            , ("k1_2", 8)
+            [ ("k1_1", 1.0)
+            , ("k1_1", 2.0)
+            , ("k1_1", 3.0)
+            , ("k1_1", 4.0)
+            , ("k1_2", 5.0)
+            , ("k1_2", 6.0)
+            , ("k1_2", 7.0)
+            , ("k1_2", 8.0)
             ]
     in
-    testDataSet
-        |> aggregateMap 
-            (count |> byKey <| second)
-            (\totalValue input ->
-                ( input, totalValue / (second input) )
-            )
+    test ctx <|
+        testDataSet
+            |> aggregateMap
+                ((sumOf <| second) |> (byKey <| first))
+                (\sumValue input ->
+                    ( input, sumValue / (second input) )
+                )
 
 
---{-| Test: Aggregate/aggregateMap2
---expected =
---    [ ( TestInput1 "k1_1" "k2_1" 1, 10 * 6 / 1 )
---    , ( TestInput1 "k1_1" "k2_1" 2, 10 * 6 / 2 )
---    , ( TestInput1 "k1_1" "k2_2" 3, 10 * 8 / 3 )
---    , ( TestInput1 "k1_1" "k2_2" 4, 10 * 8 / 4 )
---    , ( TestInput1 "k1_2" "k2_1" 5, 26 * 6 / 5 )
---    , ( TestInput1 "k1_2" "k2_1" 6, 26 * 6 / 6 )
---    , ( TestInput1 "k1_2" "k2_2" 7, 26 * 8 / 7 )
---    , ( TestInput1 "k1_2" "k2_2" 8, 26 * 8 / 8 )
---    ]
----}
---aggregateAggregateMap2Test : TestContext -> List b
---aggregateAggregateMap2Test ctx =
---    let
---        testDataSet =
---            [ TestInput1 "k1_1" "k2_1" 1
---            , TestInput1 "k1_1" "k2_1" 2
---            , TestInput1 "k1_1" "k2_2" 3
---            , TestInput1 "k1_1" "k2_2" 4
---            , TestInput1 "k1_2" "k2_1" 5
---            , TestInput1 "k1_2" "k2_1" 6
---            , TestInput1 "k1_2" "k2_2" 7
---            , TestInput1 "k1_2" "k2_2" 8
---            ]
---    in
---    testDataSet
---        |> aggregateMap2
---            (sumOf .value |> byKey .key1)
---            (maximumOf .value |> byKey .key2)
---            (\totalValue maxValue input ->
---                ( input, totalValue * maxValue / input.value )
---            )
+{-| Test: Aggregate/aggregateMap2
+expected =
+   [ (("k1_1", 1.0), 10.0 * 4.0 / 1.0 )
+   , (("k1_1", 2.0), 10.0 * 4.0 / 2.0 )
+   , (("k1_1", 3.0), 10.0 * 8.0 / 3.0 )
+   , (("k1_1", 4.0), 10.0 * 8.0 / 4.0 )
+   , (("k1_2", 5.0), 26.0 * 4.0 / 5.0 )
+   , (("k1_2", 6.0), 26.0 * 4.0 / 6.0 )
+   , (("k1_2", 7.0), 26.0 * 8.0 / 7.0 )
+   , (("k1_2", 8.0), 26.0 * 8.0 / 8.0 )
+   ]
+-}
+aggregateAggregateMap2Test : TestContext -> List ((String, Float), Float)
+aggregateAggregateMap2Test ctx =
+   let
+       testDataSet =
+           [ ("k1_1", 1.0)
+           , ("k1_1", 2.0)
+           , ("k1_1", 3.0)
+           , ("k1_1", 4.0)
+           , ("k1_2", 5.0)
+           , ("k1_2", 6.0)
+           , ("k1_2", 7.0)
+           , ("k1_2", 8.0)
+           ]
+   in
+   testDataSet
+       |> aggregateMap2
+           ((sumOf <| second) |> (byKey <| first))
+           ((maximumOf <| second) |> (byKey <| first))
+           (\sumValue maxValue input ->
+               ( input, sumValue * maxValue / (second input))
+           )
 
 
---{-| Test: Aggregate/aggregateMap3
---expected =
---    [ ( TestInput1 "k1_1" "k2_1" 1, 10 * 6 / 1 + 1 )
---    , ( TestInput1 "k1_1" "k2_1" 2, 10 * 6 / 2 + 1 )
---    , ( TestInput1 "k1_1" "k2_2" 3, 10 * 8 / 3 + 3 )
---    , ( TestInput1 "k1_1" "k2_2" 4, 10 * 8 / 4 + 3 )
---    , ( TestInput1 "k1_2" "k2_1" 5, 26 * 6 / 5 + 5 )
---    , ( TestInput1 "k1_2" "k2_1" 6, 26 * 6 / 6 + 5 )
---    , ( TestInput1 "k1_2" "k2_2" 7, 26 * 8 / 7 + 7 )
---    , ( TestInput1 "k1_2" "k2_2" 8, 26 * 8 / 8 + 7 )
---    ]
----}
---aggregateAggregateMap3Test : TestContext -> List b
---aggregateAggregateMap3Test ctx =
---    let
---        testDataSet =
---            [ TestInput1 "k1_1" "k2_1" 1
---            , TestInput1 "k1_1" "k2_1" 2
---            , TestInput1 "k1_1" "k2_2" 3
---            , TestInput1 "k1_1" "k2_2" 4
---            , TestInput1 "k1_2" "k2_1" 5
---            , TestInput1 "k1_2" "k2_1" 6
---            , TestInput1 "k1_2" "k2_2" 7
---            , TestInput1 "k1_2" "k2_2" 8
---            ]
---    in
---    testDataSet
---        |> aggregateMap3
---            (sumOf .value |> byKey .key1)
---            (maximumOf .value |> byKey .key2)
---            (minimumOf .value |> byKey (key2 .key1 .key2))
---            (\totalValue maxValue minValue input ->
---                ( input, totalValue * maxValue / input.value + minValue )
---            )
+{-| Test: Aggregate/aggregateMap3
+expected =
+   [ ( TestInput1 "k1_1" "k2_1" 1, 10 * 6 / 1 + 1 )
+   , ( TestInput1 "k1_1" "k2_1" 2, 10 * 6 / 2 + 1 )
+   , ( TestInput1 "k1_1" "k2_2" 3, 10 * 8 / 3 + 1 )
+   , ( TestInput1 "k1_1" "k2_2" 4, 10 * 8 / 4 + 1 )
+   , ( TestInput1 "k1_2" "k2_1" 5, 26 * 6 / 5 + 5 )
+   , ( TestInput1 "k1_2" "k2_1" 6, 26 * 6 / 6 + 5 )
+   , ( TestInput1 "k1_2" "k2_2" 7, 26 * 8 / 7 + 5 )
+   , ( TestInput1 "k1_2" "k2_2" 8, 26 * 8 / 8 + 5 )
+   ]
+-}
+aggregateAggregateMap3Test : TestContext -> List ((String, Float), Float)
+aggregateAggregateMap3Test ctx =
+   let
+       testDataSet =
+           [ ("k1_1", 1.0)
+           , ("k1_1", 2.0)
+           , ("k1_1", 3.0)
+           , ("k1_1", 4.0)
+           , ("k1_2", 5.0)
+           , ("k1_2", 6.0)
+           , ("k1_2", 7.0)
+           , ("k1_2", 8.0)
+           ]
+   in
+   testDataSet
+       |> aggregateMap3
+           ((sumOf <| second) |> (byKey <| first))
+           ((maximumOf <| second) |> (byKey <| first))
+           ((minimumOf <| second) |> (byKey <| first))
+           (\totalValue maxValue minValue input ->
+               ( input, totalValue * maxValue / (second input) + minValue )
+           )
 
 
---{-| Test: Aggregate/aggregateMap4
---expected =
---    [ ( TestInput1 "k1_1" "k2_1" 1, 10 * 6 / 1 + 1 + 1.5 )
---    , ( TestInput1 "k1_1" "k2_1" 2, 10 * 6 / 2 + 1 + 1.5 )
---    , ( TestInput1 "k1_1" "k2_2" 3, 10 * 8 / 3 + 3 + 3.5 )
---    , ( TestInput1 "k1_1" "k2_2" 4, 10 * 8 / 4 + 3 + 3.5 )
---    , ( TestInput1 "k1_2" "k2_1" 5, 26 * 6 / 5 + 5 + 5.5 )
---    , ( TestInput1 "k1_2" "k2_1" 6, 26 * 6 / 6 + 5 + 5.5 )
---    , ( TestInput1 "k1_2" "k2_2" 7, 26 * 8 / 7 + 7 + 7.5 )
---    , ( TestInput1 "k1_2" "k2_2" 8, 26 * 8 / 8 + 7 + 7.5 )
---    ]
----}
---aggregateAggregateMap4Test : TestContext -> List b
---aggregateAggregateMap4Test ctx =
---    let
---        testDataSet =
---            [ TestInput1 "k1_1" "k2_1" 1
---            , TestInput1 "k1_1" "k2_1" 2
---            , TestInput1 "k1_1" "k2_2" 3
---            , TestInput1 "k1_1" "k2_2" 4
---            , TestInput1 "k1_2" "k2_1" 5
---            , TestInput1 "k1_2" "k2_1" 6
---            , TestInput1 "k1_2" "k2_2" 7
---            , TestInput1 "k1_2" "k2_2" 8
---            ]
---    in
---    testDataSet
---        |> aggregateMap4
---            (sumOf .value |> byKey .key1)
---            (maximumOf .value |> byKey .key2)
---            (minimumOf .value |> byKey (key2 .key1 .key2))
---            (averageOf .value |> byKey (key2 .key1 .key2))
---            (\totalValue maxValue minValue average input ->
---                ( input, totalValue * maxValue / input.value + minValue + average )
---            )
+{-| Test: Aggregate/aggregateMap4
+expected =
+   [ ( TestInput1 "k1_1" "k2_1" 1, 10 * 6 / 1 + 1 + 2.5 )
+   , ( TestInput1 "k1_1" "k2_1" 2, 10 * 6 / 2 + 1 + 2.5 )
+   , ( TestInput1 "k1_1" "k2_2" 3, 10 * 8 / 3 + 3 + 2.5 )
+   , ( TestInput1 "k1_1" "k2_2" 4, 10 * 8 / 4 + 3 + 2.5 )
+   ]
+-}
+aggregateAggregateMap4Test : TestContext -> List ((String, Float), Float)
+aggregateAggregateMap4Test ctx =
+   let
+       testDataSet =
+           [ ("k1_1", 1.0)
+           , ("k1_1", 2.0)
+           , ("k1_1", 3.0)
+           , ("k1_1", 4.0)
+           , ("k1_2", 5.0)
+           , ("k1_2", 6.0)
+           , ("k1_2", 7.0)
+           , ("k1_2", 8.0)
+           ]
+   in
+   testDataSet
+       |> aggregateMap4
+           ((sumOf <| second) |> (byKey <| first))
+           ((maximumOf <| second) |> (byKey <| first))
+           ((minimumOf <| second) |> (byKey <| first))
+           ((averageOf <| second) |> (withFilter (\a -> (first a) == "k1_1")))
+           (\totalValue maxValue minValue average input ->
+               ( input, totalValue * maxValue / (second input) + minValue + average )
+           )
 
 
 {-| Test: Aggregate/count
@@ -321,12 +318,12 @@ aggregateWeightedAverageOfTest ctx =
 
 
 {-| Test: Aggregate/byKey
-expected = [3.0, 3.0, 3.0, 2.0, 2.0, 1.0]
+expected = [3.0, 3.0, 3.0, 2.0, 2.0]
 -}
 aggregateByKeyTest : TestContext -> List Float
 aggregateByKeyTest ctx =
     let
-        testDataSet = [1.0, 1.0, 1.0, 2.0, 2.0, 3.0]
+        testDataSet = [1.0, 1.0, 1.0, 2.0, 2.0]
     in
     test ctx <|
         testDataSet |>
@@ -336,7 +333,7 @@ aggregateByKeyTest ctx =
 
 
 {-| Test: Aggregate/withFilter
-expected = [3.0, 2.0, 1.0]
+expected = [6.0, 6.0, 6.0, 6.0, 6.0, 6.0]
 -}
 aggregateWithFilterTest : TestContext -> List Float
 aggregateWithFilterTest ctx =

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/AggregateTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/AggregateTests.elm
@@ -3,9 +3,16 @@ module Morphir.Examples.App.AggregateTests exposing (..)
 import Dict exposing (Dict)
 import Morphir.SDK.Aggregate exposing (..)
 import Morphir.Examples.App.TestUtils exposing (..)
+import Tuple exposing (..)
+
+type alias TestInput1 =
+    { key1 : String
+    , key2 : String
+    , value : Float
+    }
 
 {-| Test: Aggregate/groupBy
-expected = 
+expected =
     Dict.fromList
     [ ( "k1_1"
         , [ TestInput1 "k1_1" "k2_1" 1
@@ -21,199 +28,203 @@ expected =
         ]
     ]
 -}
-aggregateGroupByTest : TestContext -> Dict key (List a)
+aggregateGroupByTest : TestContext -> Dict String (List (String, Int))
 aggregateGroupByTest ctx =
     let
         testDataSet =
-            [ TestInput1 "k1_1" "k2_1" 1
-            , TestInput1 "k1_1" "k2_1" 2
-            , TestInput1 "k1_1" "k2_2" 3
-            , TestInput1 "k1_1" "k2_2" 4
-            , TestInput1 "k1_2" "k2_1" 5
-            , TestInput1 "k1_2" "k2_1" 6
-            , TestInput1 "k1_2" "k2_2" 7
-            , TestInput1 "k1_2" "k2_2" 8
+            [ ("k2_1", 1)
+            , ("k2_1", 2)
+            , ("k2_2", 3)
+            , ("k2_2", 4)
+            , ("k2_1", 5)
+            , ("k2_1", 6)
+            , ("k2_2", 7)
+            , ("k2_2", 8)
             ]
     in
     test ctx <|
         testDataSet
-            |> groupBy .key1
+            |> groupBy <|
+                first
 
 
-{-| Test: Aggregate/aggregate
-expected = 
-    [ { key = "k1_1", count = 4, sum = 10, max = 4, min = 1 }
-    , { key = "k1_2", count = 2, sum = 26, max = 8, min = 5 }
-    ]
--}
-aggregateAggregateTest : TestContext -> List b
-aggregateAggregateTest ctx =
-    let
-        grouped =
-            Dict.fromList
-                [ ( "k1_1"
-                , [ TestInput1 "k1_1" "k2_1" 1
-                    , TestInput1 "k1_1" "k2_1" 2
-                    , TestInput1 "k1_1" "k2_2" 3
-                    , TestInput1 "k1_1" "k2_2" 4
-                    ]
-                , ( "k1_2",
-                , [ TestInput1 "k1_2" "k2_1" 5
-                    , TestInput1 "k1_2" "k2_1" 6
-                    , TestInput1 "k1_2" "k2_2" 7
-                    , TestInput1 "k1_2" "k2_2" 8
-                    ]
-                ]
-    in
-    grouped
-        |> aggregate
-            (\key inputs ->
-                { key = key
-                , count = inputs (count |> withFilter (\a -> a.value < 7))
-                , sum = inputs (sumOf .value)
-                , max = inputs (maximumOf .value)
-                , min = inputs (minimumOf .value)
-                }
-            )
+--{-| Test: Aggregate/aggregate
+--expected =
+--    [ { key = "k1_1", count = 4, sum = 10, max = 4, min = 1 }
+--    , { key = "k1_2", count = 2, sum = 26, max = 8, min = 5 }
+--    ]
+---}
+--aggregateAggregateTest : TestContext -> List b
+--aggregateAggregateTest ctx =
+--    let
+--        grouped =
+--            Dict.fromList
+--                [ ( "k1_1",
+--                    [ TestInput1 "k1_1" "k2_1" 1
+--                    , TestInput1 "k1_1" "k2_1" 2
+--                    , TestInput1 "k1_1" "k2_2" 3
+--                    , TestInput1 "k1_1" "k2_2" 4
+--                    ]
+--                    )
+--                , ( "k1_2",
+--                    [ TestInput1 "k1_2" "k2_1" 5
+--                    , TestInput1 "k1_2" "k2_1" 6
+--                    , TestInput1 "k1_2" "k2_2" 7
+--                    , TestInput1 "k1_2" "k2_2" 8
+--                    ]
+--                    )
+--                ]
+--    in
+--    test ctx <|
+--        grouped
+--            |> aggregate
+--                (\key inputs ->
+--                    { key = key
+--                    , count = inputs (count |> withFilter (\a -> a.value < 7))
+--                    , sum = inputs (sumOf .value)
+--                    , max = inputs (maximumOf .value)
+--                    , min = inputs (minimumOf .value)
+--                    }
+--                )
 
 
 {-| Test: Aggregate/aggregateMap
-expected = 
-    [ ( TestInput1 "k1_1" "k2_1" 1, 10 / 1 )
-    , ( TestInput1 "k1_1" "k2_1" 2, 10 / 2 )
-    , ( TestInput1 "k1_1" "k2_2" 3, 10 / 3 )
-    , ( TestInput1 "k1_1" "k2_2" 4, 10 / 4 )
-    , ( TestInput1 "k1_2" "k2_1" 5, 26 / 5 )
-    , ( TestInput1 "k1_2" "k2_1" 6, 26 / 6 )
-    , ( TestInput1 "k1_2" "k2_2" 7, 26 / 7 )
-    , ( TestInput1 "k1_2" "k2_2" 8, 26 / 8 )
+expected =
+    [ ( ("k1_1", 1), 10 / 1 )
+    , ( ("k1_1", 2), 10 / 2 )
+    , ( ("k1_1", 3), 10 / 3 )
+    , ( ("k1_1", 4), 10 / 4 )
+    , ( ("k1_2", 5), 26 / 5 )
+    , ( ("k1_2", 6), 26 / 6 )
+    , ( ("k1_2", 7), 26 / 7 )
+    , ( ("k1_2", 8), 26 / 8 )
     ]
 -}
-aggregateAggregateMapTest : TestContext -> List b
+aggregateAggregateMapTest : TestContext -> List ((String, Float), Float)
 aggregateAggregateMapTest ctx =
     let
         testDataSet =
-            [ TestInput1 "k1_1" "k2_1" 1
-            , TestInput1 "k1_1" "k2_1" 2
-            , TestInput1 "k1_1" "k2_2" 3
-            , TestInput1 "k1_1" "k2_2" 4
-            , TestInput1 "k1_2" "k2_1" 5
-            , TestInput1 "k1_2" "k2_1" 6
-            , TestInput1 "k1_2" "k2_2" 7
-            , TestInput1 "k1_2" "k2_2" 8
+            [ ("k1_1", 1)
+            , ("k1_1", 2)
+            , ("k1_1", 3)
+            , ("k1_1", 4)
+            , ("k1_2", 5)
+            , ("k1_2", 6)
+            , ("k1_2", 7)
+            , ("k1_2", 8)
             ]
     in
     testDataSet
-        |> aggregateMap
-            (sumOf .value |> byKey .key1)
-                (\\totalValue input ->
-                    ( input, totalValue / input.value )
-                )
-
-
-{-| Test: Aggregate/aggregateMap2
-expected = 
-    [ ( TestInput1 "k1_1" "k2_1" 1, 10 * 6 / 1 )
-    , ( TestInput1 "k1_1" "k2_1" 2, 10 * 6 / 2 )
-    , ( TestInput1 "k1_1" "k2_2" 3, 10 * 8 / 3 )
-    , ( TestInput1 "k1_1" "k2_2" 4, 10 * 8 / 4 )
-    , ( TestInput1 "k1_2" "k2_1" 5, 26 * 6 / 5 )
-    , ( TestInput1 "k1_2" "k2_1" 6, 26 * 6 / 6 )
-    , ( TestInput1 "k1_2" "k2_2" 7, 26 * 8 / 7 )
-    , ( TestInput1 "k1_2" "k2_2" 8, 26 * 8 / 8 )
-    ]
--}
-aggregateAggregateMap2Test : TestContext -> List b
-aggregateAggregateMap2Test ctx =
-    let
-        testDataSet =
-            [ TestInput1 "k1_1" "k2_1" 1
-            , TestInput1 "k1_1" "k2_1" 2
-            , TestInput1 "k1_1" "k2_2" 3
-            , TestInput1 "k1_1" "k2_2" 4
-            , TestInput1 "k1_2" "k2_1" 5
-            , TestInput1 "k1_2" "k2_1" 6
-            , TestInput1 "k1_2" "k2_2" 7
-            , TestInput1 "k1_2" "k2_2" 8
-            ]
-    in
-    testDataSet
-        |> aggregateMap2
-            (sumOf .value |> byKey .key1)
-            (maximumOf .value |> byKey .key2)
-            (\totalValue maxValue input ->
-                ( input, totalValue * maxValue / input.value )
+        |> aggregateMap 
+            (count |> byKey <| second)
+            (\totalValue input ->
+                ( input, totalValue / (second input) )
             )
 
 
-{-| Test: Aggregate/aggregateMap3
-expected = 
-    [ ( TestInput1 "k1_1" "k2_1" 1, 10 * 6 / 1 + 1 )
-    , ( TestInput1 "k1_1" "k2_1" 2, 10 * 6 / 2 + 1 )
-    , ( TestInput1 "k1_1" "k2_2" 3, 10 * 8 / 3 + 3 )
-    , ( TestInput1 "k1_1" "k2_2" 4, 10 * 8 / 4 + 3 )
-    , ( TestInput1 "k1_2" "k2_1" 5, 26 * 6 / 5 + 5 )
-    , ( TestInput1 "k1_2" "k2_1" 6, 26 * 6 / 6 + 5 )
-    , ( TestInput1 "k1_2" "k2_2" 7, 26 * 8 / 7 + 7 )
-    , ( TestInput1 "k1_2" "k2_2" 8, 26 * 8 / 8 + 7 )
-    ]
--}
-aggregateAggregateMap3Test : TestContext -> List b
-aggregateAggregateMap3Test ctx =
-    let
-        testDataSet =
-            [ TestInput1 "k1_1" "k2_1" 1
-            , TestInput1 "k1_1" "k2_1" 2
-            , TestInput1 "k1_1" "k2_2" 3
-            , TestInput1 "k1_1" "k2_2" 4
-            , TestInput1 "k1_2" "k2_1" 5
-            , TestInput1 "k1_2" "k2_1" 6
-            , TestInput1 "k1_2" "k2_2" 7
-            , TestInput1 "k1_2" "k2_2" 8
-            ]
-    in
-    testDataSet
-        |> aggregateMap3
-            (sumOf .value |> byKey .key1)
-            (maximumOf .value |> byKey .key2)
-            (minimumOf .value |> byKey (key2 .key1 .key2))
-            (\totalValue maxValue minValue input ->
-                ( input, totalValue * maxValue / input.value + minValue )
-            )
+--{-| Test: Aggregate/aggregateMap2
+--expected =
+--    [ ( TestInput1 "k1_1" "k2_1" 1, 10 * 6 / 1 )
+--    , ( TestInput1 "k1_1" "k2_1" 2, 10 * 6 / 2 )
+--    , ( TestInput1 "k1_1" "k2_2" 3, 10 * 8 / 3 )
+--    , ( TestInput1 "k1_1" "k2_2" 4, 10 * 8 / 4 )
+--    , ( TestInput1 "k1_2" "k2_1" 5, 26 * 6 / 5 )
+--    , ( TestInput1 "k1_2" "k2_1" 6, 26 * 6 / 6 )
+--    , ( TestInput1 "k1_2" "k2_2" 7, 26 * 8 / 7 )
+--    , ( TestInput1 "k1_2" "k2_2" 8, 26 * 8 / 8 )
+--    ]
+---}
+--aggregateAggregateMap2Test : TestContext -> List b
+--aggregateAggregateMap2Test ctx =
+--    let
+--        testDataSet =
+--            [ TestInput1 "k1_1" "k2_1" 1
+--            , TestInput1 "k1_1" "k2_1" 2
+--            , TestInput1 "k1_1" "k2_2" 3
+--            , TestInput1 "k1_1" "k2_2" 4
+--            , TestInput1 "k1_2" "k2_1" 5
+--            , TestInput1 "k1_2" "k2_1" 6
+--            , TestInput1 "k1_2" "k2_2" 7
+--            , TestInput1 "k1_2" "k2_2" 8
+--            ]
+--    in
+--    testDataSet
+--        |> aggregateMap2
+--            (sumOf .value |> byKey .key1)
+--            (maximumOf .value |> byKey .key2)
+--            (\totalValue maxValue input ->
+--                ( input, totalValue * maxValue / input.value )
+--            )
 
 
-{-| Test: Aggregate/aggregateMap4
-expected = 
-    [ ( TestInput1 "k1_1" "k2_1" 1, 10 * 6 / 1 + 1 + 1.5 )
-    , ( TestInput1 "k1_1" "k2_1" 2, 10 * 6 / 2 + 1 + 1.5 )
-    , ( TestInput1 "k1_1" "k2_2" 3, 10 * 8 / 3 + 3 + 3.5 )
-    , ( TestInput1 "k1_1" "k2_2" 4, 10 * 8 / 4 + 3 + 3.5 )
-    , ( TestInput1 "k1_2" "k2_1" 5, 26 * 6 / 5 + 5 + 5.5 )
-    , ( TestInput1 "k1_2" "k2_1" 6, 26 * 6 / 6 + 5 + 5.5 )
-    , ( TestInput1 "k1_2" "k2_2" 7, 26 * 8 / 7 + 7 + 7.5 )
-    , ( TestInput1 "k1_2" "k2_2" 8, 26 * 8 / 8 + 7 + 7.5 )
-    ]
--}
-aggregateAggregateMap4Test : TestContext -> List b
-aggregateAggregateMap4Test ctx =
-    let
-        testDataSet =
-            [ TestInput1 "k1_1" "k2_1" 1
-            , TestInput1 "k1_1" "k2_1" 2
-            , TestInput1 "k1_1" "k2_2" 3
-            , TestInput1 "k1_1" "k2_2" 4
-            , TestInput1 "k1_2" "k2_1" 5
-            , TestInput1 "k1_2" "k2_1" 6
-            , TestInput1 "k1_2" "k2_2" 7
-            , TestInput1 "k1_2" "k2_2" 8
-            ]
-    in
-    testDataSet
-        |> aggregateMap4
-            (sumOf .value |> byKey .key1)
-            (maximumOf .value |> byKey .key2)
-            (minimumOf .value |> byKey (key2 .key1 .key2))
-            (averageOf .value |> byKey (key2 .key1 .key2))
-            (\totalValue maxValue minValue average input ->
-                ( input, totalValue * maxValue / input.value + minValue + average )
-            )
+--{-| Test: Aggregate/aggregateMap3
+--expected =
+--    [ ( TestInput1 "k1_1" "k2_1" 1, 10 * 6 / 1 + 1 )
+--    , ( TestInput1 "k1_1" "k2_1" 2, 10 * 6 / 2 + 1 )
+--    , ( TestInput1 "k1_1" "k2_2" 3, 10 * 8 / 3 + 3 )
+--    , ( TestInput1 "k1_1" "k2_2" 4, 10 * 8 / 4 + 3 )
+--    , ( TestInput1 "k1_2" "k2_1" 5, 26 * 6 / 5 + 5 )
+--    , ( TestInput1 "k1_2" "k2_1" 6, 26 * 6 / 6 + 5 )
+--    , ( TestInput1 "k1_2" "k2_2" 7, 26 * 8 / 7 + 7 )
+--    , ( TestInput1 "k1_2" "k2_2" 8, 26 * 8 / 8 + 7 )
+--    ]
+---}
+--aggregateAggregateMap3Test : TestContext -> List b
+--aggregateAggregateMap3Test ctx =
+--    let
+--        testDataSet =
+--            [ TestInput1 "k1_1" "k2_1" 1
+--            , TestInput1 "k1_1" "k2_1" 2
+--            , TestInput1 "k1_1" "k2_2" 3
+--            , TestInput1 "k1_1" "k2_2" 4
+--            , TestInput1 "k1_2" "k2_1" 5
+--            , TestInput1 "k1_2" "k2_1" 6
+--            , TestInput1 "k1_2" "k2_2" 7
+--            , TestInput1 "k1_2" "k2_2" 8
+--            ]
+--    in
+--    testDataSet
+--        |> aggregateMap3
+--            (sumOf .value |> byKey .key1)
+--            (maximumOf .value |> byKey .key2)
+--            (minimumOf .value |> byKey (key2 .key1 .key2))
+--            (\totalValue maxValue minValue input ->
+--                ( input, totalValue * maxValue / input.value + minValue )
+--            )
+
+
+--{-| Test: Aggregate/aggregateMap4
+--expected =
+--    [ ( TestInput1 "k1_1" "k2_1" 1, 10 * 6 / 1 + 1 + 1.5 )
+--    , ( TestInput1 "k1_1" "k2_1" 2, 10 * 6 / 2 + 1 + 1.5 )
+--    , ( TestInput1 "k1_1" "k2_2" 3, 10 * 8 / 3 + 3 + 3.5 )
+--    , ( TestInput1 "k1_1" "k2_2" 4, 10 * 8 / 4 + 3 + 3.5 )
+--    , ( TestInput1 "k1_2" "k2_1" 5, 26 * 6 / 5 + 5 + 5.5 )
+--    , ( TestInput1 "k1_2" "k2_1" 6, 26 * 6 / 6 + 5 + 5.5 )
+--    , ( TestInput1 "k1_2" "k2_2" 7, 26 * 8 / 7 + 7 + 7.5 )
+--    , ( TestInput1 "k1_2" "k2_2" 8, 26 * 8 / 8 + 7 + 7.5 )
+--    ]
+---}
+--aggregateAggregateMap4Test : TestContext -> List b
+--aggregateAggregateMap4Test ctx =
+--    let
+--        testDataSet =
+--            [ TestInput1 "k1_1" "k2_1" 1
+--            , TestInput1 "k1_1" "k2_1" 2
+--            , TestInput1 "k1_1" "k2_2" 3
+--            , TestInput1 "k1_1" "k2_2" 4
+--            , TestInput1 "k1_2" "k2_1" 5
+--            , TestInput1 "k1_2" "k2_1" 6
+--            , TestInput1 "k1_2" "k2_2" 7
+--            , TestInput1 "k1_2" "k2_2" 8
+--            ]
+--    in
+--    testDataSet
+--        |> aggregateMap4
+--            (sumOf .value |> byKey .key1)
+--            (maximumOf .value |> byKey .key2)
+--            (minimumOf .value |> byKey (key2 .key1 .key2))
+--            (averageOf .value |> byKey (key2 .key1 .key2))
+--            (\totalValue maxValue minValue average input ->
+--                ( input, totalValue * maxValue / input.value + minValue + average )
+--            )

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/AggregateTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/AggregateTests.elm
@@ -1,10 +1,11 @@
 module Morphir.Examples.App.AggregateTests exposing (..)
 
 import Dict exposing (Dict)
-import Morphir.SDK.Aggregate exposing (..)
-import Morphir.Examples.App.TestUtils exposing (..)
-import Tuple exposing (..)
 import List exposing (sortBy)
+import Morphir.Examples.App.TestUtils exposing (..)
+import Morphir.SDK.Aggregate exposing (..)
+import Tuple exposing (..)
+
 
 type alias TestInput1 =
     { key1 : String
@@ -12,67 +13,97 @@ type alias TestInput1 =
     , value : Float
     }
 
+
 {-| Test: Aggregate/groupBy
 expected =
-    Dict.fromList
-    [ ( "k1_1",
-        [ ("k1_1", 1)
-        , ("k1_1", 2)
-        , ("k1_1", 3)
-        , ("k1_1", 4)
-        ]
-    , ( "k1_2",
-        [ ("k1_2", 5)
-        , ("k1_2", 6)
-        , ("k1_2", 7)
-        , ("k1_2", 8)
-        ]
-    ]
+Dict.fromList
+[ ( "k1\_1",
+[ ("k1\_1", 1)
+, ("k1\_1", 2)
+, ("k1\_1", 3)
+, ("k1\_1", 4)
+][ ("k1_1", 1)
+, ("k1_1", 2)
+, ("k1_1", 3)
+, ("k1_1", 4)
+]
+, ( "k1\_2",
+[ ("k1\_2", 5)
+, ("k1\_2", 6)
+, ("k1\_2", 7)
+, ("k1\_2", 8)
+][ ("k1_2", 5)
+, ("k1_2", 6)
+, ("k1_2", 7)
+, ("k1_2", 8)
+]
+][ ( "k1_1",
+[ ("k1_1", 1)
+, ("k1_1", 2)
+, ("k1_1", 3)
+, ("k1_1", 4)
+]
+, ( "k1_2",
+[ ("k1_2", 5)
+, ("k1_2", 6)
+, ("k1_2", 7)
+, ("k1_2", 8)
+]
+]
 -}
-aggregateGroupByTest : TestContext -> Dict String (List (String, Int))
+aggregateGroupByTest : TestContext -> Dict String (List ( String, Int ))
 aggregateGroupByTest ctx =
     let
         testDataSet =
-            [ ("k2_1", 1)
-            , ("k2_1", 2)
-            , ("k2_2", 3)
-            , ("k2_2", 4)
-            , ("k2_1", 5)
-            , ("k2_1", 6)
-            , ("k2_2", 7)
-            , ("k2_2", 8)
+            [ ( "k2_1", 1 )
+            , ( "k2_1", 2 )
+            , ( "k2_2", 3 )
+            , ( "k2_2", 4 )
+            , ( "k2_1", 5 )
+            , ( "k2_1", 6 )
+            , ( "k2_2", 7 )
+            , ( "k2_2", 8 )
             ]
     in
     test ctx <|
         testDataSet
-            |> groupBy <|
-                first
+            |> groupBy
+        <|
+            first
 
 
 {-| Test: Aggregate/aggregateMap
 expected =
-    [ ( ("k1_1", 1.0), 10.0 / 1.0 )
-    , ( ("k1_1", 2.0), 10.0 / 2.0 )
-    , ( ("k1_1", 3.0), 10.0 / 3.0 )
-    , ( ("k1_1", 4.0), 10.0 / 4.0 )
-    , ( ("k1_2", 5.0), 26.0 / 5.0 )
-    , ( ("k1_2", 6.0), 26.0 / 6.0 )
-    , ( ("k1_2", 7.0), 26.0 / 7.0 )
-    , ( ("k1_2", 8.0), 26.0 / 8.0 )
-    ]
+[ ( ("k1\_1", 1.0), 10.0 / 1.0 )
+, ( ("k1\_1", 2.0), 10.0 / 2.0 )
+, ( ("k1\_1", 3.0), 10.0 / 3.0 )
+, ( ("k1\_1", 4.0), 10.0 / 4.0 )
+, ( ("k1\_2", 5.0), 26.0 / 5.0 )
+, ( ("k1\_2", 6.0), 26.0 / 6.0 )
+, ( ("k1\_2", 7.0), 26.0 / 7.0 )
+, ( ("k1\_2", 8.0), 26.0 / 8.0 )
+][ ( ("k1_1", 1.0), 10.0 / 1.0 )
+, ( ("k1_1", 2.0), 10.0 / 2.0 )
+, ( ("k1_1", 3.0), 10.0 / 3.0 )
+, ( ("k1_1", 4.0), 10.0 / 4.0 )
+, ( ("k1_2", 5.0), 26.0 / 5.0 )
+, ( ("k1_2", 6.0), 26.0 / 6.0 )
+, ( ("k1_2", 7.0), 26.0 / 7.0 )
+, ( ("k1_2", 8.0), 26.0 / 8.0 )
+]
 -}
-aggregateAggregateMapTest : TestContext -> List ((String, Float), Float)
+aggregateAggregateMapTest : TestContext -> List ( ( String, Float ), Float )
 aggregateAggregateMapTest ctx =
     let
         testDataSet =
-            [ ("k1_1", 1.0)
-            , ("k1_1", 2.0)
-            , ("k1_1", 3.0)
-            , ("k1_1", 4.0)
-            , ("k1_2", 5.0)
-            , ("k1_2", 6.0)
-            , ("k1_2", 7.0)
-            , ("k1_2", 8.0)
+            [ ( "k1_1", 1.0 )
+            , ( "k1_1", 2.0 )
+            , ( "k1_1", 3.0 )
+            , ( "k1_1", 4.0 )
+            , ( "k1_2", 5.0 )
+            , ( "k1_2", 6.0 )
+            , ( "k1_2", 7.0 )
+            , ( "k1_2", 8.0 )
             ]
     in
     test ctx <|
@@ -80,109 +111,129 @@ aggregateAggregateMapTest ctx =
             |> aggregateMap
                 ((sumOf <| second) |> (byKey <| first))
                 (\sumValue input ->
-                    ( input, sumValue / (second input) )
+                    ( input, sumValue / second input )
                 )
-                |> sortBy (\a -> (second (first a)))
+            |> sortBy (\a -> second (first a))
         )
 
 
 {-| Test: Aggregate/aggregateMap2
 expected =
-   [ ( ("k1_1", 1.0), 10.0 * 4.0 / 1.0 )
-   , ( ("k1_1", 2.0), 10.0 * 4.0 / 2.0 )
-   , ( ("k1_1", 3.0), 10.0 * 8.0 / 3.0 )
-   , ( ("k1_1", 4.0), 10.0 * 8.0 / 4.0 )
-   , ( ("k1_2", 5.0), 26.0 * 4.0 / 5.0 )
-   , ( ("k1_2", 6.0), 26.0 * 4.0 / 6.0 )
-   , ( ("k1_2", 7.0), 26.0 * 8.0 / 7.0 )
-   , ( ("k1_2", 8.0), 26.0 * 8.0 / 8.0 )
-   ]
+[ ( ("k1\_1", 1.0), 10.0 \* 4.0 / 1.0 )
+, ( ("k1\_1", 2.0), 10.0 \* 4.0 / 2.0 )
+, ( ("k1\_1", 3.0), 10.0 \* 8.0 / 3.0 )
+, ( ("k1\_1", 4.0), 10.0 \* 8.0 / 4.0 )
+, ( ("k1\_2", 5.0), 26.0 \* 4.0 / 5.0 )
+, ( ("k1\_2", 6.0), 26.0 \* 4.0 / 6.0 )
+, ( ("k1\_2", 7.0), 26.0 \* 8.0 / 7.0 )
+, ( ("k1\_2", 8.0), 26.0 \* 8.0 / 8.0 )
+][ ( ("k1_1", 1.0), 10.0 * 4.0 / 1.0 )
+, ( ("k1_1", 2.0), 10.0 * 4.0 / 2.0 )
+, ( ("k1_1", 3.0), 10.0 * 8.0 / 3.0 )
+, ( ("k1_1", 4.0), 10.0 * 8.0 / 4.0 )
+, ( ("k1_2", 5.0), 26.0 * 4.0 / 5.0 )
+, ( ("k1_2", 6.0), 26.0 * 4.0 / 6.0 )
+, ( ("k1_2", 7.0), 26.0 * 8.0 / 7.0 )
+, ( ("k1_2", 8.0), 26.0 * 8.0 / 8.0 )
+]
 -}
-aggregateAggregateMap2Test : TestContext -> List ((String, Float), Float)
+aggregateAggregateMap2Test : TestContext -> List ( ( String, Float ), Float )
 aggregateAggregateMap2Test ctx =
-   let
-       testDataSet =
-           [ ("k1_1", 1.0)
-           , ("k1_1", 2.0)
-           , ("k1_1", 3.0)
-           , ("k1_1", 4.0)
-           , ("k1_2", 5.0)
-           , ("k1_2", 6.0)
-           , ("k1_2", 7.0)
-           , ("k1_2", 8.0)
-           ]
-   in
+    let
+        testDataSet =
+            [ ( "k1_1", 1.0 )
+            , ( "k1_1", 2.0 )
+            , ( "k1_1", 3.0 )
+            , ( "k1_1", 4.0 )
+            , ( "k1_2", 5.0 )
+            , ( "k1_2", 6.0 )
+            , ( "k1_2", 7.0 )
+            , ( "k1_2", 8.0 )
+            ]
+    in
     test ctx <|
         (testDataSet
             |> aggregateMap2
                 ((sumOf <| second) |> (byKey <| first))
                 ((maximumOf <| second) |> (byKey <| first))
                 (\sumValue maxValue input ->
-                    ( input, sumValue * maxValue / (second input))
+                    ( input, sumValue * maxValue / second input )
                 )
-                |> sortBy (\a -> (second (first a)))
+            |> sortBy (\a -> second (first a))
         )
 
 
 {-| Test: Aggregate/aggregateMap3
 expected =
-   [ ( ("k1_1", 1), 10 * 6 / 1 + 1 )
-   , ( ("k1_1", 2), 10 * 6 / 2 + 1 )
-   , ( ("k1_1", 3), 10 * 8 / 3 + 1 )
-   , ( ("k1_1", 4), 10 * 8 / 4 + 1 )
-   , ( ("k1_2", 5), 26 * 6 / 5 + 5 )
-   , ( ("k1_2", 6), 26 * 6 / 6 + 5 )
-   , ( ("k1_2", 7), 26 * 8 / 7 + 5 )
-   , ( ("k1_2", 8), 26 * 8 / 8 + 5 )
-   ]
+[ ( ("k1\_1", 1), 10 \* 6 / 1 + 1 )
+, ( ("k1\_1", 2), 10 \* 6 / 2 + 1 )
+, ( ("k1\_1", 3), 10 \* 8 / 3 + 1 )
+, ( ("k1\_1", 4), 10 \* 8 / 4 + 1 )
+, ( ("k1\_2", 5), 26 \* 6 / 5 + 5 )
+, ( ("k1\_2", 6), 26 \* 6 / 6 + 5 )
+, ( ("k1\_2", 7), 26 \* 8 / 7 + 5 )
+, ( ("k1\_2", 8), 26 \* 8 / 8 + 5 )
+][ ( ("k1_1", 1), 10 * 6 / 1 + 1 )
+, ( ("k1_1", 2), 10 * 6 / 2 + 1 )
+, ( ("k1_1", 3), 10 * 8 / 3 + 1 )
+, ( ("k1_1", 4), 10 * 8 / 4 + 1 )
+, ( ("k1_2", 5), 26 * 6 / 5 + 5 )
+, ( ("k1_2", 6), 26 * 6 / 6 + 5 )
+, ( ("k1_2", 7), 26 * 8 / 7 + 5 )
+, ( ("k1_2", 8), 26 * 8 / 8 + 5 )
+]
 -}
-aggregateAggregateMap3Test : TestContext -> List ((String, Float), Float)
+aggregateAggregateMap3Test : TestContext -> List ( ( String, Float ), Float )
 aggregateAggregateMap3Test ctx =
-   let
-       testDataSet =
-           [ ("k1_1", 1.0)
-           , ("k1_1", 2.0)
-           , ("k1_1", 3.0)
-           , ("k1_1", 4.0)
-           , ("k1_2", 5.0)
-           , ("k1_2", 6.0)
-           , ("k1_2", 7.0)
-           , ("k1_2", 8.0)
-           ]
-   in
+    let
+        testDataSet =
+            [ ( "k1_1", 1.0 )
+            , ( "k1_1", 2.0 )
+            , ( "k1_1", 3.0 )
+            , ( "k1_1", 4.0 )
+            , ( "k1_2", 5.0 )
+            , ( "k1_2", 6.0 )
+            , ( "k1_2", 7.0 )
+            , ( "k1_2", 8.0 )
+            ]
+    in
     test ctx <|
         (testDataSet
             |> aggregateMap3
-                    ((sumOf <| second) |> (byKey <| first))
-                    ((maximumOf <| second) |> (byKey <| first))
-                    ((minimumOf <| second) |> (byKey <| first))
-                    (\totalValue maxValue minValue input ->
-                        ( input, totalValue * maxValue / (second input) + minValue )
-                    )
-                    |> sortBy (\a -> (second (first a)))
+                ((sumOf <| second) |> (byKey <| first))
+                ((maximumOf <| second) |> (byKey <| first))
+                ((minimumOf <| second) |> (byKey <| first))
+                (\totalValue maxValue minValue input ->
+                    ( input, totalValue * maxValue / second input + minValue )
+                )
+            |> sortBy (\a -> second (first a))
         )
 
 
 {-| Test: Aggregate/aggregateMap4
 expected =
-   [ ( ("k1_1", 1), 10 * 6 / 1 + 1 + 2.5 )
-   , ( ("k1_1", 2), 10 * 6 / 2 + 1 + 2.5 )
-   , ( ("k1_1", 3), 10 * 8 / 3 + 3 + 2.5 )
-   , ( ("k1_1", 4), 10 * 8 / 4 + 3 + 2.5 )
-   ]
+[ ( ("k1\_1", 1), 10 \* 6 / 1 + 1 + 2.5 )
+, ( ("k1\_1", 2), 10 \* 6 / 2 + 1 + 2.5 )
+, ( ("k1\_1", 3), 10 \* 8 / 3 + 3 + 2.5 )
+, ( ("k1\_1", 4), 10 \* 8 / 4 + 3 + 2.5 )
+][ ( ("k1_1", 1), 10 * 6 / 1 + 1 + 2.5 )
+, ( ("k1_1", 2), 10 * 6 / 2 + 1 + 2.5 )
+, ( ("k1_1", 3), 10 * 8 / 3 + 3 + 2.5 )
+, ( ("k1_1", 4), 10 * 8 / 4 + 3 + 2.5 )
+]
 -}
-aggregateAggregateMap4Test : TestContext -> List ((String, Float), Float)
+aggregateAggregateMap4Test : TestContext -> List ( ( String, Float ), Float )
 aggregateAggregateMap4Test ctx =
     let
         testDataSet =
-            [ ("k1_1", 1.0)
-            , ("k1_1", 2.0)
-            , ("k1_1", 3.0)
-            , ("k1_1", 4.0)
-            , ("k1_2", 5.0)
-            , ("k1_2", 6.0)
-            , ("k1_2", 7.0)
-            , ("k1_2", 8.0)
+            [ ( "k1_1", 1.0 )
+            , ( "k1_1", 2.0 )
+            , ( "k1_1", 3.0 )
+            , ( "k1_1", 4.0 )
+            , ( "k1_2", 5.0 )
+            , ( "k1_2", 6.0 )
+            , ( "k1_2", 7.0 )
+            , ( "k1_2", 8.0 )
             ]
     in
     test ctx <|
@@ -191,11 +242,11 @@ aggregateAggregateMap4Test ctx =
                 ((sumOf <| second) |> (byKey <| first))
                 ((maximumOf <| second) |> (byKey <| first))
                 ((minimumOf <| second) |> (byKey <| first))
-                ((averageOf <| second) |> (withFilter (\a -> (first a) == "k1_1")))
+                ((averageOf <| second) |> withFilter (\a -> first a == "k1_1"))
                 (\totalValue maxValue minValue average input ->
-                    ( input, totalValue * maxValue / (second input) + minValue + average )
+                    ( input, totalValue * maxValue / second input + minValue + average )
                 )
-                |> sortBy (\a -> (second (first a)))
+            |> sortBy (\a -> second (first a))
         )
 
 
@@ -205,11 +256,12 @@ expected = [4.0, 5.0, 6.0]
 aggregateCountTest : TestContext -> List Float
 aggregateCountTest ctx =
     let
-        testDataSet = [1.0, 2.0, 3.0]
+        testDataSet =
+            [ 1.0, 2.0, 3.0 ]
     in
     test ctx <|
-        testDataSet |>
-            aggregateMap 
+        testDataSet
+            |> aggregateMap
                 count
                 (\total input -> input + total)
 
@@ -220,11 +272,12 @@ expected = [7.0, 8.0, 9.0]
 aggregateSumOfTest : TestContext -> List Float
 aggregateSumOfTest ctx =
     let
-        testDataSet = [1.0, 2.0, 3.0]
+        testDataSet =
+            [ 1.0, 2.0, 3.0 ]
     in
     test ctx <|
-        testDataSet |>
-            aggregateMap 
+        testDataSet
+            |> aggregateMap
                 (sumOf (\a -> a))
                 (\total input -> input + total)
 
@@ -235,11 +288,12 @@ expected = [2.0, 3.0, 4.0]
 aggregateMinimumOfTest : TestContext -> List Float
 aggregateMinimumOfTest ctx =
     let
-        testDataSet = [1.0, 2.0, 3.0]
+        testDataSet =
+            [ 1.0, 2.0, 3.0 ]
     in
     test ctx <|
-        testDataSet |>
-            aggregateMap 
+        testDataSet
+            |> aggregateMap
                 (minimumOf (\a -> a))
                 (\total input -> input + total)
 
@@ -250,11 +304,12 @@ expected = [6.0, 7.0, 8.0]
 aggregateMaximumOfTest : TestContext -> List Float
 aggregateMaximumOfTest ctx =
     let
-        testDataSet = [2.0, 3.0, 4.0]
+        testDataSet =
+            [ 2.0, 3.0, 4.0 ]
     in
     test ctx <|
-        testDataSet |>
-            aggregateMap 
+        testDataSet
+            |> aggregateMap
                 (maximumOf (\a -> a))
                 (\total input -> input + total)
 
@@ -265,11 +320,12 @@ expected = [3.0, 4.0, 5.0]
 aggregateAverageOfTest : TestContext -> List Float
 aggregateAverageOfTest ctx =
     let
-        testDataSet = [1.0, 2.0, 3.0]
+        testDataSet =
+            [ 1.0, 2.0, 3.0 ]
     in
     test ctx <|
-        testDataSet |>
-            aggregateMap 
+        testDataSet
+            |> aggregateMap
                 (averageOf (\a -> a))
                 (\total input -> input + total)
 
@@ -280,11 +336,12 @@ expected = [3.0, 4.0, 5.0]
 aggregateWeightedAverageOfTest : TestContext -> List Float
 aggregateWeightedAverageOfTest ctx =
     let
-        testDataSet = [1.0, 2.0, 3.0]
+        testDataSet =
+            [ 1.0, 2.0, 3.0 ]
     in
     test ctx <|
-        testDataSet |>
-            aggregateMap 
+        testDataSet
+            |> aggregateMap
                 (weightedAverageOf (\a -> a) (\_ -> 1.0))
                 (\total input -> input + total)
 
@@ -295,11 +352,12 @@ expected = [3.0, 3.0, 3.0, 2.0, 2.0]
 aggregateByKeyTest : TestContext -> List Float
 aggregateByKeyTest ctx =
     let
-        testDataSet = [1.0, 1.0, 1.0, 2.0, 2.0]
+        testDataSet =
+            [ 1.0, 1.0, 1.0, 2.0, 2.0 ]
     in
     test ctx <|
-        testDataSet |>
-            aggregateMap
+        testDataSet
+            |> aggregateMap
                 (count |> byKey (\a -> a))
                 (\total _ -> total)
 
@@ -310,10 +368,11 @@ expected = [6.0, 6.0, 6.0, 6.0, 6.0, 6.0]
 aggregateWithFilterTest : TestContext -> List Float
 aggregateWithFilterTest ctx =
     let
-        testDataSet = [1.0, 1.0, 1.0, 2.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+        testDataSet =
+            [ 1.0, 1.0, 1.0, 2.0, 2.0, 3.0, 4.0, 5.0, 6.0 ]
     in
     test ctx <|
-        testDataSet |>
-            aggregateMap
+        testDataSet
+            |> aggregateMap
                 (count |> withFilter (\a -> a < 4.0))
                 (\total _ -> total)

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/AggregateTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/AggregateTests.elm
@@ -4,6 +4,7 @@ import Dict exposing (Dict)
 import Morphir.SDK.Aggregate exposing (..)
 import Morphir.Examples.App.TestUtils exposing (..)
 import Tuple exposing (..)
+import List exposing (sortBy)
 
 type alias TestInput1 =
     { key1 : String
@@ -115,24 +116,26 @@ aggregateAggregateMapTest ctx =
             ]
     in
     test ctx <|
-        testDataSet
+        (testDataSet
             |> aggregateMap
                 ((sumOf <| second) |> (byKey <| first))
                 (\sumValue input ->
                     ( input, sumValue / (second input) )
                 )
+                |> sortBy (\a -> (second (first a)))
+        )
 
 
 {-| Test: Aggregate/aggregateMap2
 expected =
-   [ (("k1_1", 1.0), 10.0 * 4.0 / 1.0 )
-   , (("k1_1", 2.0), 10.0 * 4.0 / 2.0 )
-   , (("k1_1", 3.0), 10.0 * 8.0 / 3.0 )
-   , (("k1_1", 4.0), 10.0 * 8.0 / 4.0 )
-   , (("k1_2", 5.0), 26.0 * 4.0 / 5.0 )
-   , (("k1_2", 6.0), 26.0 * 4.0 / 6.0 )
-   , (("k1_2", 7.0), 26.0 * 8.0 / 7.0 )
-   , (("k1_2", 8.0), 26.0 * 8.0 / 8.0 )
+   [ ( ("k1_1", 1.0), 10.0 * 4.0 / 1.0 )
+   , ( ("k1_1", 2.0), 10.0 * 4.0 / 2.0 )
+   , ( ("k1_1", 3.0), 10.0 * 8.0 / 3.0 )
+   , ( ("k1_1", 4.0), 10.0 * 8.0 / 4.0 )
+   , ( ("k1_2", 5.0), 26.0 * 4.0 / 5.0 )
+   , ( ("k1_2", 6.0), 26.0 * 4.0 / 6.0 )
+   , ( ("k1_2", 7.0), 26.0 * 8.0 / 7.0 )
+   , ( ("k1_2", 8.0), 26.0 * 8.0 / 8.0 )
    ]
 -}
 aggregateAggregateMap2Test : TestContext -> List ((String, Float), Float)
@@ -149,25 +152,28 @@ aggregateAggregateMap2Test ctx =
            , ("k1_2", 8.0)
            ]
    in
-   testDataSet
-       |> aggregateMap2
-           ((sumOf <| second) |> (byKey <| first))
-           ((maximumOf <| second) |> (byKey <| first))
-           (\sumValue maxValue input ->
-               ( input, sumValue * maxValue / (second input))
-           )
+    test ctx <|
+        (testDataSet
+            |> aggregateMap2
+                ((sumOf <| second) |> (byKey <| first))
+                ((maximumOf <| second) |> (byKey <| first))
+                (\sumValue maxValue input ->
+                    ( input, sumValue * maxValue / (second input))
+                )
+                |> sortBy (\a -> (second (first a)))
+        )
 
 
 {-| Test: Aggregate/aggregateMap3
 expected =
-   [ ( TestInput1 "k1_1" "k2_1" 1, 10 * 6 / 1 + 1 )
-   , ( TestInput1 "k1_1" "k2_1" 2, 10 * 6 / 2 + 1 )
-   , ( TestInput1 "k1_1" "k2_2" 3, 10 * 8 / 3 + 1 )
-   , ( TestInput1 "k1_1" "k2_2" 4, 10 * 8 / 4 + 1 )
-   , ( TestInput1 "k1_2" "k2_1" 5, 26 * 6 / 5 + 5 )
-   , ( TestInput1 "k1_2" "k2_1" 6, 26 * 6 / 6 + 5 )
-   , ( TestInput1 "k1_2" "k2_2" 7, 26 * 8 / 7 + 5 )
-   , ( TestInput1 "k1_2" "k2_2" 8, 26 * 8 / 8 + 5 )
+   [ ( ("k1_1", 1), 10 * 6 / 1 + 1 )
+   , ( ("k1_1", 2), 10 * 6 / 2 + 1 )
+   , ( ("k1_1", 3), 10 * 8 / 3 + 1 )
+   , ( ("k1_1", 4), 10 * 8 / 4 + 1 )
+   , ( ("k1_2", 5), 26 * 6 / 5 + 5 )
+   , ( ("k1_2", 6), 26 * 6 / 6 + 5 )
+   , ( ("k1_2", 7), 26 * 8 / 7 + 5 )
+   , ( ("k1_2", 8), 26 * 8 / 8 + 5 )
    ]
 -}
 aggregateAggregateMap3Test : TestContext -> List ((String, Float), Float)
@@ -184,47 +190,53 @@ aggregateAggregateMap3Test ctx =
            , ("k1_2", 8.0)
            ]
    in
-   testDataSet
-       |> aggregateMap3
-           ((sumOf <| second) |> (byKey <| first))
-           ((maximumOf <| second) |> (byKey <| first))
-           ((minimumOf <| second) |> (byKey <| first))
-           (\totalValue maxValue minValue input ->
-               ( input, totalValue * maxValue / (second input) + minValue )
-           )
+    test ctx <|
+        (testDataSet
+            |> aggregateMap3
+                    ((sumOf <| second) |> (byKey <| first))
+                    ((maximumOf <| second) |> (byKey <| first))
+                    ((minimumOf <| second) |> (byKey <| first))
+                    (\totalValue maxValue minValue input ->
+                        ( input, totalValue * maxValue / (second input) + minValue )
+                    )
+                    |> sortBy (\a -> (second (first a)))
+        )
 
 
 {-| Test: Aggregate/aggregateMap4
 expected =
-   [ ( TestInput1 "k1_1" "k2_1" 1, 10 * 6 / 1 + 1 + 2.5 )
-   , ( TestInput1 "k1_1" "k2_1" 2, 10 * 6 / 2 + 1 + 2.5 )
-   , ( TestInput1 "k1_1" "k2_2" 3, 10 * 8 / 3 + 3 + 2.5 )
-   , ( TestInput1 "k1_1" "k2_2" 4, 10 * 8 / 4 + 3 + 2.5 )
+   [ ( ("k1_1", 1), 10 * 6 / 1 + 1 + 2.5 )
+   , ( ("k1_1", 2), 10 * 6 / 2 + 1 + 2.5 )
+   , ( ("k1_1", 3), 10 * 8 / 3 + 3 + 2.5 )
+   , ( ("k1_1", 4), 10 * 8 / 4 + 3 + 2.5 )
    ]
 -}
 aggregateAggregateMap4Test : TestContext -> List ((String, Float), Float)
 aggregateAggregateMap4Test ctx =
-   let
-       testDataSet =
-           [ ("k1_1", 1.0)
-           , ("k1_1", 2.0)
-           , ("k1_1", 3.0)
-           , ("k1_1", 4.0)
-           , ("k1_2", 5.0)
-           , ("k1_2", 6.0)
-           , ("k1_2", 7.0)
-           , ("k1_2", 8.0)
-           ]
-   in
-   testDataSet
-       |> aggregateMap4
-           ((sumOf <| second) |> (byKey <| first))
-           ((maximumOf <| second) |> (byKey <| first))
-           ((minimumOf <| second) |> (byKey <| first))
-           ((averageOf <| second) |> (withFilter (\a -> (first a) == "k1_1")))
-           (\totalValue maxValue minValue average input ->
-               ( input, totalValue * maxValue / (second input) + minValue + average )
-           )
+    let
+        testDataSet =
+            [ ("k1_1", 1.0)
+            , ("k1_1", 2.0)
+            , ("k1_1", 3.0)
+            , ("k1_1", 4.0)
+            , ("k1_2", 5.0)
+            , ("k1_2", 6.0)
+            , ("k1_2", 7.0)
+            , ("k1_2", 8.0)
+            ]
+    in
+    test ctx <|
+        (testDataSet
+            |> aggregateMap4
+                ((sumOf <| second) |> (byKey <| first))
+                ((maximumOf <| second) |> (byKey <| first))
+                ((minimumOf <| second) |> (byKey <| first))
+                ((averageOf <| second) |> (withFilter (\a -> (first a) == "k1_1")))
+                (\totalValue maxValue minValue average input ->
+                    ( input, totalValue * maxValue / (second input) + minValue + average )
+                )
+                |> sortBy (\a -> (second (first a)))
+        )
 
 
 {-| Test: Aggregate/count

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/AggregateTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/AggregateTests.elm
@@ -1,64 +1,219 @@
 module Morphir.Examples.App.AggregateTests exposing (..)
 
 import Dict exposing (Dict)
-import Morphir.Examples.App.TestUtils exposing (..)
 import Morphir.SDK.Aggregate exposing (..)
-import Tuple exposing (..)
-
+import Morphir.Examples.App.TestUtils exposing (..)
 
 {-| Test: Aggregate/groupBy
-expected =
-Dict.fromList
-[ ( "k1\_1"
-, [ ("k1\_1", 1)
-, ("k1\_1", 2)
-, ("k1\_1", 3)
-, ("k1\_1", 4)
-][ ("k1_1", 1)
-, ("k1_1", 2)
-, ("k1_1", 3)
-, ("k1_1", 4)
-]
-, ( "k1\_2",
-, [ ("k1\_2", 5)
-, ("k1\_2", 6)
-, ("k1\_2", 7)
-, ("k1\_2", 8)
-][ ("k1_2", 5)
-, ("k1_2", 6)
-, ("k1_2", 7)
-, ("k1_2", 8)
-]
-][ ( "k1_1"
-, [ ("k1_1", 1)
-, ("k1_1", 2)
-, ("k1_1", 3)
-, ("k1_1", 4)
-]
-, ( "k1_2",
-, [ ("k1_2", 5)
-, ("k1_2", 6)
-, ("k1_2", 7)
-, ("k1_2", 8)
-]
-]
+expected = 
+    Dict.fromList
+    [ ( "k1_1"
+        , [ TestInput1 "k1_1" "k2_1" 1
+        , TestInput1 "k1_1" "k2_1" 2
+        , TestInput1 "k1_1" "k2_2" 3
+        , TestInput1 "k1_1" "k2_2" 4
+        ]
+    , ( "k1_2",
+        , [ TestInput1 "k1_2" "k2_1" 5
+        , TestInput1 "k1_2" "k2_1" 6
+        , TestInput1 "k1_2" "k2_2" 7
+        , TestInput1 "k1_2" "k2_2" 8
+        ]
+    ]
 -}
-aggregateGroupByTest : TestContext -> Dict String (List ( String, Int ))
+aggregateGroupByTest : TestContext -> Dict key (List a)
 aggregateGroupByTest ctx =
     let
         testDataSet =
-            [ ( "k2_1", 1 )
-            , ( "k2_1", 2 )
-            , ( "k2_2", 3 )
-            , ( "k2_2", 4 )
-            , ( "k2_1", 5 )
-            , ( "k2_1", 6 )
-            , ( "k2_2", 7 )
-            , ( "k2_2", 8 )
+            [ TestInput1 "k1_1" "k2_1" 1
+            , TestInput1 "k1_1" "k2_1" 2
+            , TestInput1 "k1_1" "k2_2" 3
+            , TestInput1 "k1_1" "k2_2" 4
+            , TestInput1 "k1_2" "k2_1" 5
+            , TestInput1 "k1_2" "k2_1" 6
+            , TestInput1 "k1_2" "k2_2" 7
+            , TestInput1 "k1_2" "k2_2" 8
             ]
     in
     test ctx <|
         testDataSet
-            |> groupBy
-        <|
-            first
+            |> groupBy .key1
+
+
+{-| Test: Aggregate/aggregate
+expected = 
+    [ { key = "k1_1", count = 4, sum = 10, max = 4, min = 1 }
+    , { key = "k1_2", count = 2, sum = 26, max = 8, min = 5 }
+    ]
+-}
+aggregateAggregateTest : TestContext -> List b
+aggregateAggregateTest ctx =
+    let
+        grouped =
+            Dict.fromList
+                [ ( "k1_1"
+                , [ TestInput1 "k1_1" "k2_1" 1
+                    , TestInput1 "k1_1" "k2_1" 2
+                    , TestInput1 "k1_1" "k2_2" 3
+                    , TestInput1 "k1_1" "k2_2" 4
+                    ]
+                , ( "k1_2",
+                , [ TestInput1 "k1_2" "k2_1" 5
+                    , TestInput1 "k1_2" "k2_1" 6
+                    , TestInput1 "k1_2" "k2_2" 7
+                    , TestInput1 "k1_2" "k2_2" 8
+                    ]
+                ]
+    in
+    grouped
+        |> aggregate
+            (\key inputs ->
+                { key = key
+                , count = inputs (count |> withFilter (\a -> a.value < 7))
+                , sum = inputs (sumOf .value)
+                , max = inputs (maximumOf .value)
+                , min = inputs (minimumOf .value)
+                }
+            )
+
+
+{-| Test: Aggregate/aggregateMap
+expected = 
+    [ ( TestInput1 "k1_1" "k2_1" 1, 10 / 1 )
+    , ( TestInput1 "k1_1" "k2_1" 2, 10 / 2 )
+    , ( TestInput1 "k1_1" "k2_2" 3, 10 / 3 )
+    , ( TestInput1 "k1_1" "k2_2" 4, 10 / 4 )
+    , ( TestInput1 "k1_2" "k2_1" 5, 26 / 5 )
+    , ( TestInput1 "k1_2" "k2_1" 6, 26 / 6 )
+    , ( TestInput1 "k1_2" "k2_2" 7, 26 / 7 )
+    , ( TestInput1 "k1_2" "k2_2" 8, 26 / 8 )
+    ]
+-}
+aggregateAggregateMapTest : TestContext -> List b
+aggregateAggregateMapTest ctx =
+    let
+        testDataSet =
+            [ TestInput1 "k1_1" "k2_1" 1
+            , TestInput1 "k1_1" "k2_1" 2
+            , TestInput1 "k1_1" "k2_2" 3
+            , TestInput1 "k1_1" "k2_2" 4
+            , TestInput1 "k1_2" "k2_1" 5
+            , TestInput1 "k1_2" "k2_1" 6
+            , TestInput1 "k1_2" "k2_2" 7
+            , TestInput1 "k1_2" "k2_2" 8
+            ]
+    in
+    testDataSet
+        |> aggregateMap
+            (sumOf .value |> byKey .key1)
+                (\\totalValue input ->
+                    ( input, totalValue / input.value )
+                )
+
+
+{-| Test: Aggregate/aggregateMap2
+expected = 
+    [ ( TestInput1 "k1_1" "k2_1" 1, 10 * 6 / 1 )
+    , ( TestInput1 "k1_1" "k2_1" 2, 10 * 6 / 2 )
+    , ( TestInput1 "k1_1" "k2_2" 3, 10 * 8 / 3 )
+    , ( TestInput1 "k1_1" "k2_2" 4, 10 * 8 / 4 )
+    , ( TestInput1 "k1_2" "k2_1" 5, 26 * 6 / 5 )
+    , ( TestInput1 "k1_2" "k2_1" 6, 26 * 6 / 6 )
+    , ( TestInput1 "k1_2" "k2_2" 7, 26 * 8 / 7 )
+    , ( TestInput1 "k1_2" "k2_2" 8, 26 * 8 / 8 )
+    ]
+-}
+aggregateAggregateMap2Test : TestContext -> List b
+aggregateAggregateMap2Test ctx =
+    let
+        testDataSet =
+            [ TestInput1 "k1_1" "k2_1" 1
+            , TestInput1 "k1_1" "k2_1" 2
+            , TestInput1 "k1_1" "k2_2" 3
+            , TestInput1 "k1_1" "k2_2" 4
+            , TestInput1 "k1_2" "k2_1" 5
+            , TestInput1 "k1_2" "k2_1" 6
+            , TestInput1 "k1_2" "k2_2" 7
+            , TestInput1 "k1_2" "k2_2" 8
+            ]
+    in
+    testDataSet
+        |> aggregateMap2
+            (sumOf .value |> byKey .key1)
+            (maximumOf .value |> byKey .key2)
+            (\totalValue maxValue input ->
+                ( input, totalValue * maxValue / input.value )
+            )
+
+
+{-| Test: Aggregate/aggregateMap3
+expected = 
+    [ ( TestInput1 "k1_1" "k2_1" 1, 10 * 6 / 1 + 1 )
+    , ( TestInput1 "k1_1" "k2_1" 2, 10 * 6 / 2 + 1 )
+    , ( TestInput1 "k1_1" "k2_2" 3, 10 * 8 / 3 + 3 )
+    , ( TestInput1 "k1_1" "k2_2" 4, 10 * 8 / 4 + 3 )
+    , ( TestInput1 "k1_2" "k2_1" 5, 26 * 6 / 5 + 5 )
+    , ( TestInput1 "k1_2" "k2_1" 6, 26 * 6 / 6 + 5 )
+    , ( TestInput1 "k1_2" "k2_2" 7, 26 * 8 / 7 + 7 )
+    , ( TestInput1 "k1_2" "k2_2" 8, 26 * 8 / 8 + 7 )
+    ]
+-}
+aggregateAggregateMap3Test : TestContext -> List b
+aggregateAggregateMap3Test ctx =
+    let
+        testDataSet =
+            [ TestInput1 "k1_1" "k2_1" 1
+            , TestInput1 "k1_1" "k2_1" 2
+            , TestInput1 "k1_1" "k2_2" 3
+            , TestInput1 "k1_1" "k2_2" 4
+            , TestInput1 "k1_2" "k2_1" 5
+            , TestInput1 "k1_2" "k2_1" 6
+            , TestInput1 "k1_2" "k2_2" 7
+            , TestInput1 "k1_2" "k2_2" 8
+            ]
+    in
+    testDataSet
+        |> aggregateMap3
+            (sumOf .value |> byKey .key1)
+            (maximumOf .value |> byKey .key2)
+            (minimumOf .value |> byKey (key2 .key1 .key2))
+            (\totalValue maxValue minValue input ->
+                ( input, totalValue * maxValue / input.value + minValue )
+            )
+
+
+{-| Test: Aggregate/aggregateMap4
+expected = 
+    [ ( TestInput1 "k1_1" "k2_1" 1, 10 * 6 / 1 + 1 + 1.5 )
+    , ( TestInput1 "k1_1" "k2_1" 2, 10 * 6 / 2 + 1 + 1.5 )
+    , ( TestInput1 "k1_1" "k2_2" 3, 10 * 8 / 3 + 3 + 3.5 )
+    , ( TestInput1 "k1_1" "k2_2" 4, 10 * 8 / 4 + 3 + 3.5 )
+    , ( TestInput1 "k1_2" "k2_1" 5, 26 * 6 / 5 + 5 + 5.5 )
+    , ( TestInput1 "k1_2" "k2_1" 6, 26 * 6 / 6 + 5 + 5.5 )
+    , ( TestInput1 "k1_2" "k2_2" 7, 26 * 8 / 7 + 7 + 7.5 )
+    , ( TestInput1 "k1_2" "k2_2" 8, 26 * 8 / 8 + 7 + 7.5 )
+    ]
+-}
+aggregateAggregateMap4Test : TestContext -> List b
+aggregateAggregateMap4Test ctx =
+    let
+        testDataSet =
+            [ TestInput1 "k1_1" "k2_1" 1
+            , TestInput1 "k1_1" "k2_1" 2
+            , TestInput1 "k1_1" "k2_2" 3
+            , TestInput1 "k1_1" "k2_2" 4
+            , TestInput1 "k1_2" "k2_1" 5
+            , TestInput1 "k1_2" "k2_1" 6
+            , TestInput1 "k1_2" "k2_2" 7
+            , TestInput1 "k1_2" "k2_2" 8
+            ]
+    in
+    testDataSet
+        |> aggregateMap4
+            (sumOf .value |> byKey .key1)
+            (maximumOf .value |> byKey .key2)
+            (minimumOf .value |> byKey (key2 .key1 .key2))
+            (averageOf .value |> byKey (key2 .key1 .key2))
+            (\totalValue maxValue minValue average input ->
+                ( input, totalValue * maxValue / input.value + minValue + average )
+            )

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/AggregateTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/AggregateTests.elm
@@ -49,46 +49,6 @@ aggregateGroupByTest ctx =
                 first
 
 
---{-| Test: Aggregate/aggregate
---expected =
---    [ { key = "k1_1", count = 4, sum = 10, max = 4, min = 1 }
---    , { key = "k1_2", count = 2, sum = 26, max = 8, min = 5 }
---    ]
----}
---aggregateAggregateTest : TestContext -> List b
---aggregateAggregateTest ctx =
---    let
---        grouped =
---            Dict.fromList
---                [ ( "k1_1",
---                    [ TestInput1 "k1_1" "k2_1" 1
---                    , TestInput1 "k1_1" "k2_1" 2
---                    , TestInput1 "k1_1" "k2_2" 3
---                    , TestInput1 "k1_1" "k2_2" 4
---                    ]
---                    )
---                , ( "k1_2",
---                    [ TestInput1 "k1_2" "k2_1" 5
---                    , TestInput1 "k1_2" "k2_1" 6
---                    , TestInput1 "k1_2" "k2_2" 7
---                    , TestInput1 "k1_2" "k2_2" 8
---                    ]
---                    )
---                ]
---    in
---    test ctx <|
---        grouped
---            |> aggregate
---                (\key inputs ->
---                    { key = key
---                    , count = inputs (count |> withFilter (\a -> a.value < 7))
---                    , sum = inputs (sumOf .value)
---                    , max = inputs (maximumOf .value)
---                    , min = inputs (minimumOf .value)
---                    }
---                )
-
-
 {-| Test: Aggregate/aggregateMap
 expected =
     [ ( ("k1_1", 1.0), 10.0 / 1.0 )

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/AggregateTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/AggregateTests.elm
@@ -228,3 +228,123 @@ aggregateAggregateMapTest ctx =
 --            (\totalValue maxValue minValue average input ->
 --                ( input, totalValue * maxValue / input.value + minValue + average )
 --            )
+
+
+{-| Test: Aggregate/count
+expected = [4.0, 5.0, 6.0]
+-}
+aggregateCountTest : TestContext -> List Float
+aggregateCountTest ctx =
+    let
+        testDataSet = [1.0, 2.0, 3.0]
+    in
+    test ctx <|
+        testDataSet |>
+            aggregateMap 
+                count
+                (\total input -> input + total)
+
+
+{-| Test: Aggregate/sumOf
+expected = [7.0, 8.0, 9.0]
+-}
+aggregateSumOfTest : TestContext -> List Float
+aggregateSumOfTest ctx =
+    let
+        testDataSet = [1.0, 2.0, 3.0]
+    in
+    test ctx <|
+        testDataSet |>
+            aggregateMap 
+                (sumOf (\a -> a))
+                (\total input -> input + total)
+
+
+{-| Test: Aggregate/minimumOf
+expected = [2.0, 3.0, 4.0]
+-}
+aggregateMinimumOfTest : TestContext -> List Float
+aggregateMinimumOfTest ctx =
+    let
+        testDataSet = [1.0, 2.0, 3.0]
+    in
+    test ctx <|
+        testDataSet |>
+            aggregateMap 
+                (minimumOf (\a -> a))
+                (\total input -> input + total)
+
+
+{-| Test: Aggregate/maximumOf
+expected = [6.0, 7.0, 8.0]
+-}
+aggregateMaximumOfTest : TestContext -> List Float
+aggregateMaximumOfTest ctx =
+    let
+        testDataSet = [2.0, 3.0, 4.0]
+    in
+    test ctx <|
+        testDataSet |>
+            aggregateMap 
+                (maximumOf (\a -> a))
+                (\total input -> input + total)
+
+
+{-| Test: Aggregate/averageOf
+expected = [3.0, 4.0, 5.0]
+-}
+aggregateAverageOfTest : TestContext -> List Float
+aggregateAverageOfTest ctx =
+    let
+        testDataSet = [1.0, 2.0, 3.0]
+    in
+    test ctx <|
+        testDataSet |>
+            aggregateMap 
+                (averageOf (\a -> a))
+                (\total input -> input + total)
+
+
+{-| Test: Aggregate/weightedAverageOf
+expected = [3.0, 4.0, 5.0]
+-}
+aggregateWeightedAverageOfTest : TestContext -> List Float
+aggregateWeightedAverageOfTest ctx =
+    let
+        testDataSet = [1.0, 2.0, 3.0]
+    in
+    test ctx <|
+        testDataSet |>
+            aggregateMap 
+                (weightedAverageOf (\a -> a) (\_ -> 1.0))
+                (\total input -> input + total)
+
+
+{-| Test: Aggregate/byKey
+expected = [3.0, 3.0, 3.0, 2.0, 2.0, 1.0]
+-}
+aggregateByKeyTest : TestContext -> List Float
+aggregateByKeyTest ctx =
+    let
+        testDataSet = [1.0, 1.0, 1.0, 2.0, 2.0, 3.0]
+    in
+    test ctx <|
+        testDataSet |>
+            aggregateMap
+                (count |> byKey (\a -> a))
+                (\total _ -> total)
+
+
+{-| Test: Aggregate/withFilter
+expected = [3.0, 2.0, 1.0]
+-}
+aggregateWithFilterTest : TestContext -> List Float
+aggregateWithFilterTest ctx =
+    let
+        testDataSet = [1.0, 1.0, 1.0, 2.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    in
+    test ctx <|
+        testDataSet |>
+            aggregateMap
+                (count |> withFilter (\a -> a < 4.0))
+                (\total _ -> total)

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Native.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Native.scala
@@ -9,6 +9,7 @@ import org.finos.morphir.runtime.Extractors.*
 import org.finos.morphir.runtime.internal.{InvokeableEvaluator, NativeFunctionSignatureAdv}
 import org.finos.morphir.runtime.*
 import org.finos.morphir.runtime.sdk.DecimalSDK.{minusOne, one, zero}
+import org.finos.morphir.runtime.sdk.AggregateSDK.count
 
 import scala.collection.mutable
 
@@ -441,6 +442,7 @@ object Native {
     FQName.fromString("Morphir.SDK:Decimal:minusOne")           -> minusOne,
     FQName.fromString("Morphir.SDK:Decimal:one")                -> one,
     FQName.fromString("Morphir.SDK:Decimal:zero")               -> zero,
+    FQName.fromString("Morphir.SDK:Aggregate:count")            -> count,
     FQName.fromString("Morphir.SDK:LocalTime:fromMilliseconds") -> fromMilliseconds
 //    FQName.fromString("Morphir.Examples.App:Example:myMap") -> map
   ) ++ DictSDK.sdk ++ SetSDK.sdk ++ StringSDK.sdk ++ SetSDK.sdk ++ TupleSDK.sdk ++ BasicsSDK.sdk

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -289,11 +289,77 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
             )
           )
         ),
-        testEvaluation("Map")("aggregateTests", "aggregateAggregateMapTest")(Data.List(
-          Data.Int(6),
-          Data.Int(8),
-          Data.Int(10)
-        )),
+//        testEvaluation("Map")("aggregateTests", "aggregateAggregateMapTest")(
+//          Data.List(
+//            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(1)), Data.Float(8.0 / 1)),
+//            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(2)), Data.Float(8.0 / 2)),
+//            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(3)), Data.Float(8.0 / 3)),
+//            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(4)), Data.Float(8.0 / 4)),
+//            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(5)), Data.Float(8.0 / 5)),
+//            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(6)), Data.Float(8.0 / 6)),
+//            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(7)), Data.Float(8.0 / 7)),
+//            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(8)), Data.Float(8.0 / 8))
+//          )
+//        ),
+        testEvaluation("Count")("aggregateTests", "aggregateCountTest")(
+          Data.List(
+            Data.Float(4.0),
+            Data.Float(5.0),
+            Data.Float(6.0),
+          )
+        ),
+        testEvaluation("SumOf")("aggregateTests", "aggregateSumOfTest")(
+          Data.List(
+            Data.Float(7.0),
+            Data.Float(8.0),
+            Data.Float(9.0),
+          )
+        ),
+        testEvaluation("MinimumOf")("aggregateTests", "aggregateMinimumOfTest")(
+          Data.List(
+            Data.Float(2.0),
+            Data.Float(3.0),
+            Data.Float(4.0),
+          )
+        ),
+        testEvaluation("MaximumOf")("aggregateTests", "aggregateMaximumOfTest")(
+          Data.List(
+            Data.Float(6.0),
+            Data.Float(7.0),
+            Data.Float(8.0),
+          )
+        ),
+        testEvaluation("AverageOf")("aggregateTests", "aggregateAverageOfTest")(
+          Data.List(
+            Data.Float(3.0),
+            Data.Float(4.0),
+            Data.Float(5.0),
+          )
+        ),
+        testEvaluation("WeightedAverageOf")("aggregateTests", "aggregateWeightedAverageOfTest")(
+          Data.List(
+            Data.Float(3.0),
+            Data.Float(4.0),
+            Data.Float(5.0),
+          )
+        ),
+        testEvaluation("ByKey")("aggregateTests", "aggregateByKeyTest")(
+          Data.List(
+            Data.Float(3.0),
+            Data.Float(3.0),
+            Data.Float(3.0),
+            Data.Float(2.0),
+            Data.Float(2.0),
+            Data.Float(1.0),
+          )
+        ),
+        testEvaluation("WithFilter")("aggregateTests", "aggregateWithFilterTest")(
+          Data.List(
+            Data.Float(3.0),
+            Data.Float(2.0),
+            Data.Float(1.0),
+          )
+        ),
       ),
       suite("Char")(
         testEval("isUpper true")("charTests", "charIsUpperTest", 'A')(Data.Boolean(true)),

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -289,18 +289,18 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
             )
           )
         ),
-//        testEvaluation("Map")("aggregateTests", "aggregateAggregateMapTest")(
-//          Data.List(
-//            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(1)), Data.Float(8.0 / 1)),
-//            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(2)), Data.Float(8.0 / 2)),
-//            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(3)), Data.Float(8.0 / 3)),
-//            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(4)), Data.Float(8.0 / 4)),
-//            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(5)), Data.Float(8.0 / 5)),
-//            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(6)), Data.Float(8.0 / 6)),
-//            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(7)), Data.Float(8.0 / 7)),
-//            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(8)), Data.Float(8.0 / 8))
-//          )
-//        ),
+        testEvaluation("Map")("aggregateTests", "aggregateAggregateMapTest")(
+          Data.List(
+            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(1.0)), Data.Float(10.0 / 1.0)),
+            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(2.0)), Data.Float(10.0 / 2.0)),
+            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(3.0)), Data.Float(10.0 / 3.0)),
+            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(4.0)), Data.Float(10.0 / 4.0)),
+            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(5.0)), Data.Float(26.0 / 5.0)),
+            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(6.0)), Data.Float(26.0 / 6.0)),
+            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(7.0)), Data.Float(26.0 / 7.0)),
+            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(8.0)), Data.Float(26.0 / 8.0))
+          )
+        ),
         testEvaluation("Count")("aggregateTests", "aggregateCountTest")(
           Data.List(
             Data.Float(4.0),
@@ -349,15 +349,17 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
             Data.Float(3.0),
             Data.Float(3.0),
             Data.Float(2.0),
-            Data.Float(2.0),
-            Data.Float(1.0),
+            Data.Float(2.0)
           )
         ),
         testEvaluation("WithFilter")("aggregateTests", "aggregateWithFilterTest")(
           Data.List(
-            Data.Float(3.0),
-            Data.Float(2.0),
-            Data.Float(1.0),
+            Data.Float(6.0),
+            Data.Float(6.0),
+            Data.Float(6.0),
+            Data.Float(6.0),
+            Data.Float(6.0),
+            Data.Float(6.0)
           )
         ),
       ),

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -337,42 +337,42 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           Data.List(
             Data.Float(4.0),
             Data.Float(5.0),
-            Data.Float(6.0),
+            Data.Float(6.0)
           )
         ),
         testEvaluation("SumOf")("aggregateTests", "aggregateSumOfTest")(
           Data.List(
             Data.Float(7.0),
             Data.Float(8.0),
-            Data.Float(9.0),
+            Data.Float(9.0)
           )
         ),
         testEvaluation("MinimumOf")("aggregateTests", "aggregateMinimumOfTest")(
           Data.List(
             Data.Float(2.0),
             Data.Float(3.0),
-            Data.Float(4.0),
+            Data.Float(4.0)
           )
         ),
         testEvaluation("MaximumOf")("aggregateTests", "aggregateMaximumOfTest")(
           Data.List(
             Data.Float(6.0),
             Data.Float(7.0),
-            Data.Float(8.0),
+            Data.Float(8.0)
           )
         ),
         testEvaluation("AverageOf")("aggregateTests", "aggregateAverageOfTest")(
           Data.List(
             Data.Float(3.0),
             Data.Float(4.0),
-            Data.Float(5.0),
+            Data.Float(5.0)
           )
         ),
         testEvaluation("WeightedAverageOf")("aggregateTests", "aggregateWeightedAverageOfTest")(
           Data.List(
             Data.Float(3.0),
             Data.Float(4.0),
-            Data.Float(5.0),
+            Data.Float(5.0)
           )
         ),
         testEvaluation("ByKey")("aggregateTests", "aggregateByKeyTest")(
@@ -393,7 +393,7 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
             Data.Float(6.0),
             Data.Float(6.0)
           )
-        ),
+        )
       ),
       suite("Char")(
         testEval("isUpper true")("charTests", "charIsUpperTest", 'A')(Data.Boolean(true)),

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -267,28 +267,27 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
   def spec =
     suite("Evaluator MDM Specs")(
       suite("Aggregate")(
-        testEvaluation("GroupBy")("aggregateTests", "aggregateGroupByTest")(
-          Data.Map(
-            (
-              Data.String("k2_1"),
-              Data.List(
-                Data.Tuple(Data.String("k2_1"), Data.Int32(1)),
-                Data.Tuple(Data.String("k2_1"), Data.Int32(2)),
-                Data.Tuple(Data.String("k2_1"), Data.Int32(5)),
-                Data.Tuple(Data.String("k2_1"), Data.Int32(6))
-              )
-            ),
-            (
-              Data.String("k2_2"),
-              Data.List(
-                Data.Tuple(Data.String("k2_2"), Data.Int32(3)),
-                Data.Tuple(Data.String("k2_2"), Data.Int32(4)),
-                Data.Tuple(Data.String("k2_2"), Data.Int32(7)),
-                Data.Tuple(Data.String("k2_2"), Data.Int32(8))
-              )
-            )
-          )
-        )
+        testEvaluation("GroupBy")("aggregateTests", "aggregateGroupByTest")(Data.Map()),
+        testEvaluation("Map2")("listTests", "listMap2Test")(Data.List(
+          Data.Int(6),
+          Data.Int(8),
+          Data.Int(10)
+        )),
+        testEvaluation("Map3")("listTests", "listMap3Test")(Data.List(
+          Data.Int(9),
+          Data.Int(12),
+          Data.Int(15)
+        )),
+        testEvaluation("Map4")("listTests", "listMap4Test")(Data.List(
+          Data.Int(12),
+          Data.Int(16),
+          Data.Int(20)
+        )),
+        testEvaluation("Map5")("listTests", "listMap5Test")(Data.List(
+          Data.Int(15),
+          Data.Int(20),
+          Data.Int(25)
+        )),
       ),
       suite("Char")(
         testEval("isUpper true")("charTests", "charIsUpperTest", 'A')(Data.Boolean(true)),

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -267,26 +267,32 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
   def spec =
     suite("Evaluator MDM Specs")(
       suite("Aggregate")(
-        testEvaluation("GroupBy")("aggregateTests", "aggregateGroupByTest")(Data.Map()),
-        testEvaluation("Map2")("listTests", "listMap2Test")(Data.List(
+        testEvaluation("GroupBy")("aggregateTests", "aggregateGroupByTest")(
+          Data.Map(
+            (
+              Data.String("k2_1"),
+              Data.List(
+                Data.Tuple(Data.String("k2_1"), Data.Int32(1)),
+                Data.Tuple(Data.String("k2_1"), Data.Int32(2)),
+                Data.Tuple(Data.String("k2_1"), Data.Int32(5)),
+                Data.Tuple(Data.String("k2_1"), Data.Int32(6))
+              )
+            ),
+            (
+              Data.String("k2_2"),
+              Data.List(
+                Data.Tuple(Data.String("k2_2"), Data.Int32(3)),
+                Data.Tuple(Data.String("k2_2"), Data.Int32(4)),
+                Data.Tuple(Data.String("k2_2"), Data.Int32(7)),
+                Data.Tuple(Data.String("k2_2"), Data.Int32(8))
+              )
+            )
+          )
+        ),
+        testEvaluation("Map")("aggregateTests", "aggregateAggregateMapTest")(Data.List(
           Data.Int(6),
           Data.Int(8),
           Data.Int(10)
-        )),
-        testEvaluation("Map3")("listTests", "listMap3Test")(Data.List(
-          Data.Int(9),
-          Data.Int(12),
-          Data.Int(15)
-        )),
-        testEvaluation("Map4")("listTests", "listMap4Test")(Data.List(
-          Data.Int(12),
-          Data.Int(16),
-          Data.Int(20)
-        )),
-        testEvaluation("Map5")("listTests", "listMap5Test")(Data.List(
-          Data.Int(15),
-          Data.Int(20),
-          Data.Int(25)
         )),
       ),
       suite("Char")(

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -301,6 +301,38 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
             Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(8.0)), Data.Float(26.0 / 8.0))
           )
         ),
+        testEvaluation("Map2")("aggregateTests", "aggregateAggregateMap2Test")(
+          Data.List(
+            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(1.0)), Data.Float(10.0 * 4.0 / 1.0)),
+            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(2.0)), Data.Float(10.0 * 4.0 / 2.0)),
+            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(3.0)), Data.Float(10.0 * 4.0 / 3.0)),
+            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(4.0)), Data.Float(10.0 * 4.0 / 4.0)),
+            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(5.0)), Data.Float(26.0 * 8.0 / 5.0)),
+            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(6.0)), Data.Float(26.0 * 8.0 / 6.0)),
+            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(7.0)), Data.Float(26.0 * 8.0 / 7.0)),
+            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(8.0)), Data.Float(26.0 * 8.0 / 8.0))
+          )
+        ),
+        testEvaluation("Map3")("aggregateTests", "aggregateAggregateMap3Test")(
+          Data.List(
+            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(1.0)), Data.Float(10.0 * 4.0 / 1.0 + 1)),
+            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(2.0)), Data.Float(10.0 * 4.0 / 2.0 + 1)),
+            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(3.0)), Data.Float(10.0 * 4.0 / 3.0 + 1)),
+            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(4.0)), Data.Float(10.0 * 4.0 / 4.0 + 1)),
+            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(5.0)), Data.Float(26.0 * 8.0 / 5.0 + 5)),
+            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(6.0)), Data.Float(26.0 * 8.0 / 6.0 + 5)),
+            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(7.0)), Data.Float(26.0 * 8.0 / 7.0 + 5)),
+            Data.Tuple(Data.Tuple(Data.String("k1_2"), Data.Float(8.0)), Data.Float(26.0 * 8.0 / 8.0 + 5))
+          )
+        ),
+        testEvaluation("Map4")("aggregateTests", "aggregateAggregateMap4Test")(
+          Data.List(
+            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(1.0)), Data.Float(10.0 * 4.0 / 1.0 + 1 + 2.5)),
+            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(2.0)), Data.Float(10.0 * 4.0 / 2.0 + 1 + 2.5)),
+            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(3.0)), Data.Float(10.0 * 4.0 / 3.0 + 1 + 2.5)),
+            Data.Tuple(Data.Tuple(Data.String("k1_1"), Data.Float(4.0)), Data.Float(10.0 * 4.0 / 4.0 + 1 + 2.5))
+          )
+        ),
         testEvaluation("Count")("aggregateTests", "aggregateCountTest")(
           Data.List(
             Data.Float(4.0),

--- a/morphir/src/org/finos/morphir/runtime/Coercer.scala
+++ b/morphir/src/org/finos/morphir/runtime/Coercer.scala
@@ -87,4 +87,12 @@ object Coercer {
   implicit val tupleCoercer: Coercer[RTValue.Tuple] = new Coercer[RTValue.Tuple] {
     def coerce(result: RTValue): RTValue.Tuple = RTValue.coerceTuple(result)
   }
+
+  implicit val aggregationCoercer: Coercer[RTValue.Aggregation] = new Coercer[RTValue.Aggregation] {
+    def coerce(result: RTValue): RTValue.Aggregation = RTValue.coerceAggregation(result)
+  }
+
+  implicit val keyCoercer: Coercer[RTValue.Key] = new Coercer[RTValue.Key] {
+    def coerce(result: RTValue): RTValue.Key = RTValue.coerceKey(result)
+  }
 }

--- a/morphir/src/org/finos/morphir/runtime/NativeSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/NativeSDK.scala
@@ -18,7 +18,6 @@ object NativeSDK {
       case object Aggregate extends SdkModuleDescriptor(moduleName = "Aggregate") {
         val functions: List[NativeFunctionAdapter] = scala.List(
           NativeFunctionAdapter.Fun2(AggregateSDK.groupBy),
-          NativeFunctionAdapter.Fun2(AggregateSDK.aggregate),
           NativeFunctionAdapter.Fun3(AggregateSDK.aggregateMap),
           NativeFunctionAdapter.Fun4(AggregateSDK.aggregateMap2),
           NativeFunctionAdapter.Fun5(AggregateSDK.aggregateMap3),
@@ -171,6 +170,12 @@ object NativeSDK {
           NativeFunctionAdapter.Fun1(DecimalSDK.truncate),
           NativeFunctionAdapter.Fun2(DecimalSDK.shiftDecimalLeft),
           NativeFunctionAdapter.Fun2(DecimalSDK.shiftDecimalRight)
+        )
+      }
+
+      case object Key extends SdkModuleDescriptor(moduleName = "Key") {
+        val functions: List[NativeFunctionAdapter] = scala.List(
+          NativeFunctionAdapter.Fun1(KeySDK.key0)
         )
       }
 
@@ -329,6 +334,7 @@ object NativeSDK {
       Char,
       Decimal,
       Dict,
+      Key,
       List,
       LocalDate,
       LocalTime,

--- a/morphir/src/org/finos/morphir/runtime/NativeSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/NativeSDK.scala
@@ -17,7 +17,19 @@ object NativeSDK {
 
       case object Aggregate extends SdkModuleDescriptor(moduleName = "Aggregate") {
         val functions: List[NativeFunctionAdapter] = scala.List(
-          NativeFunctionAdapter.Fun2(AggregateSDK.groupBy)
+          NativeFunctionAdapter.Fun2(AggregateSDK.groupBy),
+          NativeFunctionAdapter.Fun2(AggregateSDK.aggregate),
+          NativeFunctionAdapter.Fun3(AggregateSDK.aggregateMap),
+          NativeFunctionAdapter.Fun4(AggregateSDK.aggregateMap2),
+          NativeFunctionAdapter.Fun5(AggregateSDK.aggregateMap3),
+          NativeFunctionAdapter.Fun6(AggregateSDK.aggregateMap4),
+          NativeFunctionAdapter.Fun1(AggregateSDK.sumOf),
+          NativeFunctionAdapter.Fun1(AggregateSDK.minimumOf),
+          NativeFunctionAdapter.Fun1(AggregateSDK.maximumOf),
+          NativeFunctionAdapter.Fun1(AggregateSDK.averageOf),
+          NativeFunctionAdapter.Fun2(AggregateSDK.weightedAverageOf),
+          NativeFunctionAdapter.Fun2(AggregateSDK.byKey),
+          NativeFunctionAdapter.Fun2(AggregateSDK.withFilter)
         )
       }
 
@@ -312,7 +324,6 @@ object NativeSDK {
   val modules: Seq[SdkModuleDescriptor] = {
     import Morphir.SDK._
     Seq(
-      Aggregate,
       Basics,
       Char,
       Decimal,

--- a/morphir/src/org/finos/morphir/runtime/NativeSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/NativeSDK.scala
@@ -324,6 +324,7 @@ object NativeSDK {
   val modules: Seq[SdkModuleDescriptor] = {
     import Morphir.SDK._
     Seq(
+      Aggregate,
       Basics,
       Char,
       Decimal,

--- a/morphir/src/org/finos/morphir/runtime/RTValue.scala
+++ b/morphir/src/org/finos/morphir/runtime/RTValue.scala
@@ -681,12 +681,6 @@ object RTValue {
       }
 
     private[RTValue] def flatten(keys: Tuple): scala.List[RTValue] = flattenTuples(scala.List[RTValue](), keys.value)
-
-    def apply(tuple: Tuple): Option[Key] = {
-      val l = flatten(tuple)
-      // TODO
-      None
-    }
   }
 
   sealed trait Key extends ValueResult[scala.List[RTValue]] {}

--- a/morphir/src/org/finos/morphir/runtime/RTValue.scala
+++ b/morphir/src/org/finos/morphir/runtime/RTValue.scala
@@ -653,6 +653,77 @@ object RTValue {
       curried: scala.List[(Name, RTValue)],
       closingContext: CallStackFrame
   )
+  
+  sealed trait Key extends ValueResult[scala.List[Function]]
+  
+  object Key0 extends ValueResult[MInt] {
+    def value = 0
+    override def succinct(depth: Int) = s"Key0($value)"
+  }
+  
+  case class Key2(b1: Function, b2: Function) extends Key {
+    def value = scala.List(b1, b2)
+  }
+
+  case class Key3(b1: Function, b2: Function, b3: Function) extends Key {
+    def value = scala.List(b1, b2, b3)
+  }
+
+  case class Key4(b1: Function, b2: Function, b3: Function, b4: Function) extends Key {
+    def value = scala.List(b1, b2, b3, b4)
+  }
+
+  case class Key5(b1: Function, b2: Function, b3: Function, b4: Function, b5: Function) extends Key {
+    def value = scala.List(b1, b2, b3, b4, b5)
+  }
+
+  case class Key6(b1: Function, b2: Function, b3: Function, b4: Function, b5: Function, b6: Function) extends Key {
+    def value = scala.List(b1, b2, b3, b4, b5, b6)
+  }
+
+  case class Key7(b1: Function, b2: Function, b3: Function, b4: Function, b5: Function, b6: Function, b7: Function) extends Key {
+    def value = scala.List(b1, b2, b3, b4, b5, b6, b7)
+  }
+
+  case class Key8(b1: Function, b2: Function, b3: Function, b4: Function, b5: Function, b6: Function, b7: Function, b8: Function) extends Key {
+    def value = scala.List(b1, b2, b3, b4, b5, b6, b7, b8)
+  }
+
+  case class Key9(b1: Function, b2: Function, b3: Function, b4: Function, b5: Function, b6: Function, b7: Function, b8: Function, b9: Function) extends Key {
+    def value = scala.List(b1, b2, b3, b4, b5, b6, b7, b8, b9)
+  }
+
+  case class Key10(b1: Function, b2: Function, b3: Function, b4: Function, b5: Function, b6: Function, b7: Function, b8: Function, b9: Function, b10: Function) extends Key {
+    def value = scala.List(b1, b2, b3, b4, b5, b6, b7, b8, b9, b10)
+  }
+
+  case class Key11(b1: Function, b2: Function, b3: Function, b4: Function, b5: Function, b6: Function, b7: Function, b8: Function, b9: Function, b10: Function, b11: Function) extends Key {
+    def value = scala.List(b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11)
+  }
+
+  case class Key12(b1: Function, b2: Function, b3: Function, b4: Function, b5: Function, b6: Function, b7: Function, b8: Function, b9: Function, b10: Function, b11: Function, b12: Function) extends Key {
+    def value = scala.List(b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12)
+  }
+
+  case class Key13(b1: Function, b2: Function, b3: Function, b4: Function, b5: Function, b6: Function, b7: Function, b8: Function, b9: Function, b10: Function, b11: Function, b12: Function, b13: Function) extends Key {
+    def value = scala.List(b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13)
+  }
+
+  case class Key14(b1: Function, b2: Function, b3: Function, b4: Function, b5: Function, b6: Function, b7: Function, b8: Function, b9: Function, b10: Function, b11: Function, b12: Function, b13: Function, b14: Function) extends Key {
+    def value = scala.List(b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14)
+  }
+
+  case class Key15(b1: Function, b2: Function, b3: Function, b4: Function, b5: Function, b6: Function, b7: Function, b8: Function, b9: Function, b10: Function, b11: Function, b12: Function, b13: Function, b14: Function, b15: Function) extends Key {
+    def value = scala.List(b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15)
+  }
+
+  case class Key16(b1: Function, b2: Function, b3: Function, b4: Function, b5: Function, b6: Function, b7: Function, b8: Function, b9: Function, b10: Function, b11: Function, b12: Function, b13: Function, b14: Function, b15: Function, b16: Function) extends Key {
+    def value = scala.List(b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16)
+  }
+
+  case class Aggregation[T <: RTValue](value: T, key: Function) extends ValueResult[T] {
+    override def succinct(depth: Int) = s"Aggregation($value, $key)"
+  }
 
   case class FieldFunction(fieldName: Name) extends Function
 

--- a/morphir/src/org/finos/morphir/runtime/RTValue.scala
+++ b/morphir/src/org/finos/morphir/runtime/RTValue.scala
@@ -655,10 +655,11 @@ object RTValue {
   )
   
   sealed trait Key extends ValueResult[scala.List[Function]]
-  
-  object Key0 extends ValueResult[MInt] {
-    def value = 0
-    override def succinct(depth: Int) = s"Key0($value)"
+
+  // format: off
+  object Key0 extends Key {
+    def value = scala.List.empty[Function]
+    override def succinct(depth: Int) = s"Key0(0)"
   }
   
   case class Key2(b1: Function, b2: Function) extends Key {
@@ -721,8 +722,18 @@ object RTValue {
     def value = scala.List(b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16)
   }
 
-  case class Aggregation[T <: RTValue](value: T, key: Function) extends ValueResult[T] {
-    override def succinct(depth: Int) = s"Aggregation($value, $key)"
+  // format: on
+  
+  object Aggregation {
+    private val noFilter: RTValue => Primitive.Boolean = _ => Primitive.Boolean(true)
+    
+    def apply(operation: List => Primitive.Float, key: Key = Key0): Aggregation = {
+      Aggregation(operation, key, noFilter)
+    }
+  }
+
+  case class Aggregation(operation: List => Primitive.Float, key: Key, filter: RTValue => Primitive.Boolean) extends ValueResult[RTValue] {
+    override def succinct(depth: Int) = s"Aggregation($key, $filter, $operation)"
   }
 
   case class FieldFunction(fieldName: Name) extends Function

--- a/morphir/src/org/finos/morphir/runtime/RTValue.scala
+++ b/morphir/src/org/finos/morphir/runtime/RTValue.scala
@@ -723,16 +723,16 @@ object RTValue {
   }
 
   // format: on
-  
+
   object Aggregation {
     private val noFilter: RTValue => Primitive.Boolean = _ => Primitive.Boolean(true)
-    
+
     def apply(operation: List => Primitive.Float, key: Key = Key0): Aggregation = {
       Aggregation(operation, key, noFilter)
     }
   }
 
-  case class Aggregation(operation: List => Primitive.Float, key: Key, filter: RTValue => Primitive.Boolean) extends ValueResult[RTValue] {
+  case class Aggregation(operation: List => Primitive.Float, key: Key, filter: RTValue => Primitive.Boolean) extends RTValue {
     override def succinct(depth: Int) = s"Aggregation($key, $filter, $operation)"
   }
 

--- a/morphir/src/org/finos/morphir/runtime/RTValue.scala
+++ b/morphir/src/org/finos/morphir/runtime/RTValue.scala
@@ -126,7 +126,7 @@ object RTValue {
   def coerceKey(arg: RTValue): Key =
     arg match {
       case k: Key      => k
-      case rt: RTValue => Key1(rt) //keys are arbitrary, so if not a key, just make it a Key1
+      case rt: RTValue => Key1(rt) // keys are arbitrary, so if not a key, just make it a Key1
     }
 
   def coerceFloat(arg: RTValue) =

--- a/morphir/src/org/finos/morphir/runtime/RTValue.scala
+++ b/morphir/src/org/finos/morphir/runtime/RTValue.scala
@@ -31,6 +31,12 @@ object RTValue {
     def value: T
   }
   sealed trait Function extends RTValue
+  
+  def coerceAggregation(arg: RTValue): Aggregation =
+    arg match {
+      case f: Aggregation => f
+      case _ => throw new FailedCoercion(s"Cannot unwrap the value `${arg}` into a Aggregation")
+    }
 
   def coerceList(arg: RTValue) =
     arg match {
@@ -110,6 +116,12 @@ object RTValue {
       case _ =>
         throw new FailedCoercion(s"Cannot unwrap the value `${arg}` into a primitive Int. It is not a primitive!")
     }
+
+  def coerceKey(arg: RTValue): Key =
+    arg match {
+      case k: Key => k
+      case _ => throw new FailedCoercion(s"Cannot unwrap the value `${arg}` into a Key")
+    }  
 
   def coerceFloat(arg: RTValue) =
     arg match {
@@ -733,6 +745,7 @@ object RTValue {
   }
 
   case class Aggregation(operation: List => Primitive.Float, key: Key, filter: RTValue => Primitive.Boolean) extends RTValue {
+    def value = "Aggregation"  // TODO Handle for printable value for logging
     override def succinct(depth: Int) = s"Aggregation($key, $filter, $operation)"
   }
 

--- a/morphir/src/org/finos/morphir/runtime/sdk/AggregateSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/AggregateSDK.scala
@@ -22,23 +22,13 @@ object AggregateSDK {
       RT.Map(mutable.LinkedHashMap.from(r))
   }
 
-//  val aggregate = DynamicNativeFunction2("aggregate") {
-//    (context: NativeContext) => (f: RT.Function, dict: RT.Map) =>
-//      val result = dict.value flatMap { case (mapKey, values) =>
-//        coerceList(values).value map { a =>
-//          context.evaluator.handleApplyResult2(Type.UType.Unit(()), f, mapKey, a)
-//        }
-//      }
-//      RT.List(result.toList)
-//  }
-
-  object AggregateMapHelper {
+  private object AggregateMapHelper {
     def apply(list: RT.List): List[AggregateMapHelper] = {
       list.value.map(AggregateMapHelper(_, Nil))
     }
   }
 
-  case class AggregateMapHelper(originalValue: RTValue, opResults: List[RT.Primitive.Float])
+  private case class AggregateMapHelper(originalValue: RTValue, opResults: List[RT.Primitive.Float])
 
   private def mapAndFilter(agg: RT.Aggregation, list: List[AggregateMapHelper])(ctx: NativeContext): List[AggregateMapHelper] = {
     val filtered: List[AggregateMapHelper] = list filter { case AggregateMapHelper(a, _) =>

--- a/morphir/src/org/finos/morphir/runtime/sdk/AggregateSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/AggregateSDK.scala
@@ -5,34 +5,25 @@ import org.finos.morphir.ir.Type
 import org.finos.morphir.runtime.*
 import org.finos.morphir.runtime.MorphirRuntimeError.{FailedCoercion, IllegalValue}
 import org.finos.morphir.runtime.internal.*
-import org.finos.morphir.runtime.RTValue as RT
+import org.finos.morphir.runtime.RTValue
 import org.finos.morphir.runtime.RTValue.Comparable.orderToInt
 import org.finos.morphir.runtime.RTValue.{
   Primitive,
-  coerceBoolean,
   coerceComparable,
   coerceDecimal,
   coerceFloat,
   coerceInt,
-  coerceList,
   coerceNumeric,
   coerceTuple,
   unwrapNumericWithHelper
 }
 
-import scala.collection.mutable
-
 object AggregateSDK {
 
-  // Aggregations
-
-  val groupBy = DynamicNativeFunction2("groupBy") {
-    (context: NativeContext) => (f: RT.Function, list: RT.List) =>
-      val result = list.value groupBy { a =>
-        context.evaluator.handleApplyResult(Type.UType.Variable("a"), f, a)
-      }
-      val r = result.view.mapValues(l => RT.List(l))
-      RT.Map(mutable.LinkedHashMap.from(r))
+  val concat = DynamicNativeFunction1("concat") {
+    (context: NativeContext) => (list: RTValue.List) =>
+      val flattened = list.elements.flatMap(inner => RTValue.coerceList(inner).elements)
+      RTValue.List(flattened)
   }
 
 }

--- a/morphir/src/org/finos/morphir/runtime/sdk/AggregateSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/AggregateSDK.scala
@@ -5,25 +5,114 @@ import org.finos.morphir.ir.Type
 import org.finos.morphir.runtime.*
 import org.finos.morphir.runtime.MorphirRuntimeError.{FailedCoercion, IllegalValue}
 import org.finos.morphir.runtime.internal.*
-import org.finos.morphir.runtime.RTValue
+import org.finos.morphir.runtime.{RTValue => RT}
 import org.finos.morphir.runtime.RTValue.Comparable.orderToInt
-import org.finos.morphir.runtime.RTValue.{
-  Primitive,
-  coerceComparable,
-  coerceDecimal,
-  coerceFloat,
-  coerceInt,
-  coerceNumeric,
-  coerceTuple,
-  unwrapNumericWithHelper
-}
+import org.finos.morphir.runtime.RTValue.{Primitive, coerceComparable, coerceDecimal, coerceFloat, coerceInt, coerceNumeric, coerceTuple, unwrapNumericWithHelper}
+
+import scala.collection.mutable
 
 object AggregateSDK {
+  
+  val groupBy = DynamicNativeFunction2("groupBy") {
+    (context: NativeContext) => (f: RT.Function, list: RT.List) =>
+      val result = list.value groupBy { a =>
+        context.evaluator.handleApplyResult(Type.UType.Variable("a"), f, a)
+      }
+      val r = result.view.mapValues(l => RT.List(l))
+      RT.Map(mutable.LinkedHashMap.from(r))
+  }
 
-  val concat = DynamicNativeFunction1("concat") {
-    (context: NativeContext) => (list: RTValue.List) =>
-      val flattened = list.elements.flatMap(inner => RTValue.coerceList(inner).elements)
-      RTValue.List(flattened)
+  val aggregateMap = DynamicNativeFunction3("aggregateMap") {
+    (context: NativeContext) => (agg: RT.Aggregation, f: RT.Function, list: RT.List) =>
+      val result = list.value map { a =>
+        val aggResult = context.evaluator.handleApplyResult(Type.UType.Variable("a"), agg.key, a)
+        val input = coerceFloat(aggResult)
+        val output = context.evaluator.handleApplyResult2(Type.UType.Variable("a"), f, input, a)
+        RT.Tuple(a, output)
+      }
+      RT.List(result)
+  }
+  
+  //Operations
+
+  val count: SDKValue = SDKValue.SDKNativeValue(RT.Aggregation(l => RT.Primitive.Float(l.value.size.toDouble)))
+
+  val sumOf = DynamicNativeFunction1("sumOf") {
+    (context: NativeContext) => (aToFloat: RT.Function) =>
+      RT.Aggregation(
+        list => {
+          val results: List[Double] = list.value map { a =>
+            val aggResult = context.evaluator.handleApplyResult(Type.UType.Unit(()), aToFloat, a)
+            coerceFloat(aggResult).value
+          }
+          RT.Primitive.Float(results.sum)
+        }
+      )
+  }
+
+  val minimumOf = DynamicNativeFunction1("minimumOf") {
+    (context: NativeContext) => (aToFloat: RT.Function) =>
+      RT.Aggregation(
+        list => {
+          val results: List[Double] = list.value map { a =>
+            val aggResult = context.evaluator.handleApplyResult(Type.UType.Unit(()), aToFloat, a)
+            coerceFloat(aggResult).value
+          }
+          RT.Primitive.Float(results.min)
+        }
+      )
+  }
+
+  val maximumOf = DynamicNativeFunction1("maximumOf") {
+    (context: NativeContext) => (aToFloat: RT.Function) =>
+      RT.Aggregation(
+        list => {
+          val results: List[Double] = list.value map { a =>
+            val aggResult = context.evaluator.handleApplyResult(Type.UType.Unit(()), aToFloat, a)
+            coerceFloat(aggResult).value
+          }
+          RT.Primitive.Float(results.max)
+        }
+      )
+  }
+
+  val averageOf = DynamicNativeFunction1("averageOf") {
+    (context: NativeContext) => (aToFloat: RT.Function) =>
+      RT.Aggregation(
+        list => {
+          val results: List[Double] = list.value map { a =>
+            val aggResult = context.evaluator.handleApplyResult(Type.UType.Unit(()), aToFloat, a)
+            coerceFloat(aggResult).value
+          }
+          RT.Primitive.Float(results.sum / results.size)
+        }
+      )
+  }
+
+  val weightedAverageOf = DynamicNativeFunction2("weightedAverageOf") {
+    (context: NativeContext) => (aToFloat: RT.Function, aToWeight: RT.Function) =>
+      RT.Aggregation(
+        list => {
+          val results: List[Double] = list.value map { a =>
+            val aggResult = context.evaluator.handleApplyResult(Type.UType.Unit(()), aToFloat, a)
+            val weightedResult = context.evaluator.handleApplyResult(Type.UType.Unit(()), aToWeight, a)
+            coerceFloat(aggResult).value * coerceFloat(weightedResult).value
+          }
+          RT.Primitive.Float(results.sum / results.size)
+        }
+      )
+  }
+
+  val byKey = DynamicNativeFunction2("byKey") {
+    (context: NativeContext) => (key: RT.Key, aggregation: RT.Aggregation) =>
+      aggregation.copy(key = key)
+  }
+
+  val withFilter = DynamicNativeFunction2("withFilter") {
+    (context: NativeContext) => (filterFunc: RT.Function, aggregation: RT.Aggregation) =>
+      aggregation.copy(filter = a: RTValue => {
+        context.evaluator.handleApplyResult(Type.UType.Unit(()), filterFunc, a)
+      })
   }
 
 }

--- a/morphir/src/org/finos/morphir/runtime/sdk/AggregateSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/AggregateSDK.scala
@@ -43,7 +43,7 @@ object AggregateSDK {
       RT.List(result)
   }
 
-  val aggregate2Map = DynamicNativeFunction4("aggregate2Map") {
+  val aggregateMap2 = DynamicNativeFunction4("aggregateMap2") {
     (context: NativeContext) => (agg1: RT.Aggregation, agg2: RT.Aggregation, f: RT.Function, list: RT.List) =>
       val result = list.value map { a =>
         val agg1Result = context.evaluator.handleApplyResult(Type.UType.Variable("a"), agg1.key, a)
@@ -56,7 +56,7 @@ object AggregateSDK {
       RT.List(result)
   }
 
-  val aggregate3Map = DynamicNativeFunction5("aggregate3Map") {
+  val aggregateMap3 = DynamicNativeFunction5("aggregateMap3") {
     (context: NativeContext) => (agg1: RT.Aggregation, agg2: RT.Aggregation, agg3: RT.Aggregation, f: RT.Function, list: RT.List) =>
       val result = list.value map { a =>
         val agg1Result = context.evaluator.handleApplyResult(Type.UType.Variable("a"), agg1.key, a)
@@ -71,7 +71,7 @@ object AggregateSDK {
       RT.List(result)
   }
 
-  val aggregate4Map = DynamicNativeFunction6("aggregate4Map") {
+  val aggregateMap4 = DynamicNativeFunction6("aggregateMap4") {
     (context: NativeContext) => (agg1: RT.Aggregation, agg2: RT.Aggregation, agg3: RT.Aggregation, agg4: RT.Aggregation, f: RT.Function, list: RT.List) =>
       val result = list.value map { a =>
         val agg1Result = context.evaluator.handleApplyResult(Type.UType.Variable("a"), agg1.key, a)

--- a/morphir/src/org/finos/morphir/runtime/sdk/AggregateSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/AggregateSDK.scala
@@ -7,7 +7,7 @@ import org.finos.morphir.runtime.MorphirRuntimeError.{FailedCoercion, IllegalVal
 import org.finos.morphir.runtime.internal.*
 import org.finos.morphir.runtime.RTValue as RT
 import org.finos.morphir.runtime.RTValue.Comparable.orderToInt
-import org.finos.morphir.runtime.RTValue.{Primitive, coerceBoolean, coerceComparable, coerceDecimal, coerceFloat, coerceInt, coerceNumeric, coerceTuple, unwrapNumericWithHelper}
+import org.finos.morphir.runtime.RTValue.{Primitive, coerceBoolean, coerceComparable, coerceDecimal, coerceFloat, coerceInt, coerceList, coerceNumeric, coerceTuple, unwrapNumericWithHelper}
 
 import scala.collection.mutable
 
@@ -22,12 +22,67 @@ object AggregateSDK {
       RT.Map(mutable.LinkedHashMap.from(r))
   }
 
+  val aggregate = DynamicNativeFunction2("aggregate") {
+    (context: NativeContext) => (f: RT.Function, dict: RT.Map) =>
+      val result = dict.value flatMap { case (mapKey, values) =>
+        coerceList(values).value map { a =>
+          context.evaluator.handleApplyResult2(Type.UType.Unit(()), f, mapKey, a)
+        }
+      }
+      RT.List(result.toList)
+  }
+
   val aggregateMap = DynamicNativeFunction3("aggregateMap") {
     (context: NativeContext) => (agg: RT.Aggregation, f: RT.Function, list: RT.List) =>
       val result = list.value map { a =>
         val aggResult = context.evaluator.handleApplyResult(Type.UType.Variable("a"), agg.key, a)
         val input = coerceFloat(aggResult)
         val output = context.evaluator.handleApplyResult2(Type.UType.Variable("a"), f, input, a)
+        RT.Tuple(a, output)
+      }
+      RT.List(result)
+  }
+
+  val aggregate2Map = DynamicNativeFunction4("aggregate2Map") {
+    (context: NativeContext) => (agg1: RT.Aggregation, agg2: RT.Aggregation, f: RT.Function, list: RT.List) =>
+      val result = list.value map { a =>
+        val agg1Result = context.evaluator.handleApplyResult(Type.UType.Variable("a"), agg1.key, a)
+        val agg1Value = coerceFloat(agg1Result)
+        val agg2Result = context.evaluator.handleApplyResult(Type.UType.Variable("a"), agg2.key, a)
+        val agg2Value = coerceFloat(agg2Result)
+        val output = context.evaluator.handleApplyResult3(Type.UType.Variable("a"), f, agg1Value, agg2Value, a)
+        RT.Tuple(a, output)
+      }
+      RT.List(result)
+  }
+
+  val aggregate3Map = DynamicNativeFunction5("aggregate3Map") {
+    (context: NativeContext) => (agg1: RT.Aggregation, agg2: RT.Aggregation, agg3: RT.Aggregation, f: RT.Function, list: RT.List) =>
+      val result = list.value map { a =>
+        val agg1Result = context.evaluator.handleApplyResult(Type.UType.Variable("a"), agg1.key, a)
+        val agg1Value = coerceFloat(agg1Result)
+        val agg2Result = context.evaluator.handleApplyResult(Type.UType.Variable("a"), agg2.key, a)
+        val agg2Value = coerceFloat(agg2Result)
+        val agg3Result = context.evaluator.handleApplyResult(Type.UType.Variable("a"), agg3.key, a)
+        val agg3Value = coerceFloat(agg3Result)
+        val output = context.evaluator.handleApplyResult4(Type.UType.Variable("a"), f, agg1Value, agg2Value, agg3Value, a)
+        RT.Tuple(a, output)
+      }
+      RT.List(result)
+  }
+
+  val aggregate4Map = DynamicNativeFunction6("aggregate4Map") {
+    (context: NativeContext) => (agg1: RT.Aggregation, agg2: RT.Aggregation, agg3: RT.Aggregation, agg4: RT.Aggregation, f: RT.Function, list: RT.List) =>
+      val result = list.value map { a =>
+        val agg1Result = context.evaluator.handleApplyResult(Type.UType.Variable("a"), agg1.key, a)
+        val agg1Value = coerceFloat(agg1Result)
+        val agg2Result = context.evaluator.handleApplyResult(Type.UType.Variable("a"), agg2.key, a)
+        val agg2Value = coerceFloat(agg2Result)
+        val agg3Result = context.evaluator.handleApplyResult(Type.UType.Variable("a"), agg3.key, a)
+        val agg3Value = coerceFloat(agg3Result)
+        val agg4Result = context.evaluator.handleApplyResult(Type.UType.Variable("a"), agg4.key, a)
+        val agg4Value = coerceFloat(agg4Result)
+        val output = context.evaluator.handleApplyResult5(Type.UType.Variable("a"), f, agg1Value, agg2Value, agg3Value, agg4Value, a)
         RT.Tuple(a, output)
       }
       RT.List(result)

--- a/morphir/src/org/finos/morphir/runtime/sdk/AggregateSDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/AggregateSDK.scala
@@ -5,9 +5,9 @@ import org.finos.morphir.ir.Type
 import org.finos.morphir.runtime.*
 import org.finos.morphir.runtime.MorphirRuntimeError.{FailedCoercion, IllegalValue}
 import org.finos.morphir.runtime.internal.*
-import org.finos.morphir.runtime.{RTValue => RT}
+import org.finos.morphir.runtime.RTValue as RT
 import org.finos.morphir.runtime.RTValue.Comparable.orderToInt
-import org.finos.morphir.runtime.RTValue.{Primitive, coerceComparable, coerceDecimal, coerceFloat, coerceInt, coerceNumeric, coerceTuple, unwrapNumericWithHelper}
+import org.finos.morphir.runtime.RTValue.{Primitive, coerceBoolean, coerceComparable, coerceDecimal, coerceFloat, coerceInt, coerceNumeric, coerceTuple, unwrapNumericWithHelper}
 
 import scala.collection.mutable
 
@@ -110,8 +110,9 @@ object AggregateSDK {
 
   val withFilter = DynamicNativeFunction2("withFilter") {
     (context: NativeContext) => (filterFunc: RT.Function, aggregation: RT.Aggregation) =>
-      aggregation.copy(filter = a: RTValue => {
-        context.evaluator.handleApplyResult(Type.UType.Unit(()), filterFunc, a)
+      aggregation.copy(filter = a => {
+        val result = context.evaluator.handleApplyResult(Type.UType.Unit(()), filterFunc, a)
+        coerceBoolean(result)
       })
   }
 

--- a/morphir/src/org/finos/morphir/runtime/sdk/KeySDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/KeySDK.scala
@@ -4,7 +4,18 @@ import org.finos.morphir.ir.Type
 import org.finos.morphir.runtime.MorphirRuntimeError.{FailedCoercion, IllegalValue}
 import org.finos.morphir.runtime.{RTValue as RT, *}
 import org.finos.morphir.runtime.RTValue.Comparable.orderToInt
-import org.finos.morphir.runtime.RTValue.{Primitive, coerceBoolean, coerceComparable, coerceDecimal, coerceFloat, coerceInt, coerceList, coerceNumeric, coerceTuple, unwrapNumericWithHelper}
+import org.finos.morphir.runtime.RTValue.{
+  Primitive,
+  coerceBoolean,
+  coerceComparable,
+  coerceDecimal,
+  coerceFloat,
+  coerceInt,
+  coerceList,
+  coerceNumeric,
+  coerceTuple,
+  unwrapNumericWithHelper
+}
 import org.finos.morphir.runtime.internal.*
 import org.finos.morphir.{MInt, MValue}
 

--- a/morphir/src/org/finos/morphir/runtime/sdk/KeySDK.scala
+++ b/morphir/src/org/finos/morphir/runtime/sdk/KeySDK.scala
@@ -1,0 +1,20 @@
+package org.finos.morphir.runtime.sdk
+
+import org.finos.morphir.ir.Type
+import org.finos.morphir.runtime.MorphirRuntimeError.{FailedCoercion, IllegalValue}
+import org.finos.morphir.runtime.{RTValue as RT, *}
+import org.finos.morphir.runtime.RTValue.Comparable.orderToInt
+import org.finos.morphir.runtime.RTValue.{Primitive, coerceBoolean, coerceComparable, coerceDecimal, coerceFloat, coerceInt, coerceList, coerceNumeric, coerceTuple, unwrapNumericWithHelper}
+import org.finos.morphir.runtime.internal.*
+import org.finos.morphir.{MInt, MValue}
+
+import scala.collection.mutable
+
+object KeySDK {
+
+  val key0 = DynamicNativeFunction1("key0") {
+    (context: NativeContext) => (a: RT) =>
+      RT.Key0
+  }
+
+}

--- a/morphir/src/org/finos/morphir/util/PrintRTValue.scala
+++ b/morphir/src/org/finos/morphir/util/PrintRTValue.scala
@@ -108,7 +108,15 @@ class PrintRTValue(
 
         case v: RT.Set =>
           Tree.ofRT(v)(v.elements.toList.map(r => treeify(r)))
-
+          
+        case v: RT.Aggregation =>
+          Tree.Literal(v.value.toString)
+          
+        case key: RT.Key => key match {
+          case RT.Key0 => Tree.Literal("0")
+          case v: RT.Key => Tree.ofRT(v)(v.value.map(treeify(_)))
+        }
+          
         case v: RT.Function =>
           val body = v match {
             case RT.FieldFunction(name) =>

--- a/morphir/src/org/finos/morphir/util/PrintRTValue.scala
+++ b/morphir/src/org/finos/morphir/util/PrintRTValue.scala
@@ -108,15 +108,15 @@ class PrintRTValue(
 
         case v: RT.Set =>
           Tree.ofRT(v)(v.elements.toList.map(r => treeify(r)))
-          
+
         case v: RT.Aggregation =>
           Tree.Literal(v.value.toString)
-          
+
         case key: RT.Key => key match {
-          case RT.Key0 => Tree.Literal("0")
-          case v: RT.Key => Tree.ofRT(v)(v.value.map(treeify(_)))
-        }
-          
+            case RT.Key0   => Tree.Literal("0")
+            case v: RT.Key => Tree.ofRT(v)(v.value.map(treeify(_)))
+          }
+
         case v: RT.Function =>
           val body = v match {
             case RT.FieldFunction(name) =>


### PR DESCRIPTION
Adds the aggregateMap(2/3/4) functions and all relevant Aggregations. Key objects 0-16 added, but respective SDK has not been added.

Commit history is a bit messy for this PR, can squash if it would improve clarity.