### PR TITLE
Add tests for some MorphirRuntimeErrors

### DIFF
--- a/examples/morphir-elm-projects/evaluator-tests/morphir.json
+++ b/examples/morphir-elm-projects/evaluator-tests/morphir.json
@@ -30,6 +30,7 @@
         "TestUtils",
         "TypeCheckerTests",
         "UserDefinedReferenceTests",
-        "SdkBasicsTests"
+        "SdkBasicsTests",
+        "ExceptionTests"
     ]
 }

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExceptionTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExceptionTests.elm
@@ -2,6 +2,7 @@ module Morphir.Examples.App.ExceptionTests exposing (..)
 
 import Morphir.SDK.Decimal as Decimal exposing (..)
 
+
 {-| Test: ExceptionTests/add
 -}
 sdkAddTest : number -> number -> number

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExceptionTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExceptionTests.elm
@@ -19,3 +19,10 @@ decimalHundred : Int -> Decimal
 decimalHundred value =
     Decimal.hundred
         value
+
+
+{-| Test: ExceptionTests/ignoreArgReturnString
+-}
+ignoreArgReturnString : a -> String
+ignoreArgReturnString _ =
+    "test"

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExceptionTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExceptionTests.elm
@@ -1,0 +1,21 @@
+module Morphir.Examples.App.ExceptionTests exposing (..)
+
+import Morphir.SDK.Decimal as Decimal exposing (..)
+
+{-| Test: ExceptionTests/add
+-}
+sdkAddTest : number -> number -> number
+sdkAddTest a b =
+    let
+        f x y =
+            x + y
+    in
+    f a b
+
+
+{-| Test: ExceptionTests/hundred
+-}
+decimalHundred : Int -> Decimal
+decimalHundred value =
+    Decimal.hundred
+        value

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -4,6 +4,7 @@ import org.finos.morphir.datamodel.Util.*
 import org.finos.morphir.datamodel.*
 import org.finos.morphir.ir.Type
 import org.finos.morphir.naming.*
+import org.finos.morphir.runtime.EvaluatorMDMTests.testExceptionMultiple
 import org.finos.morphir.runtime.environment.MorphirEnv
 import org.finos.morphir.runtime.MorphirRuntimeError.*
 import org.finos.morphir.testing.MorphirBaseSpec
@@ -3470,13 +3471,37 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           case TopLevelError(_, _, _) => assertTrue(true)
           case e => assertNever(s"Expected FailedCoercion but $e was thrown")
         },
-        testExceptionMultiple("Test")("exceptionTests", "decimalHundred", List(Data.String("a"))) {
+        testExceptionMultiple("UnknownTypeMismatch Test")("exceptionTests", "decimalHundred", List(Data.String("a"))) {
           case TopLevelError(_, _, _: TypeError.UnknownTypeMismatch) => assertTrue(true)
+          case e => assertNever(s"Expected UnknownTypeMismatch but $e was thrown")
+        },
+        /* There are 2 different UnsupportedType errors possible.
+           MorphirRuntimeError.UnsupportedType and MorphirErrorRuntime.TypeError.UnsupportedType 
+         */
+        testExceptionMultiple("MorphirRuntimeError UnsupportedType Test")("exceptionTests", "sdkAddTest", List(Data.String("a"))) {
+          case TopLevelError(_, _, _: UnsupportedType) => assertTrue(true)
+          case TopLevelError(_, _, inner) => assertNever(s"Expected UnsupportedType but $inner was thrown")
+          case e => assertNever(s"Expected UnsupportedType but $e was thrown")
+        },
+        testExceptionMultiple("Type Test")("exceptionTests", "sdkAddTest", List(Data.Float(1), Data.Decimal(2))) {
+          case TopLevelError(_, _, _: TypeError.InferenceConflict) => assertTrue(true)
           case e => assertNever(s"Expected FailedCoercion but $e was thrown")
         },
-        testExceptionMultiple("Test")("exceptionTests", "decimalHundred", List(Data.String("a"))) {
-          case TopLevelError(_, _, _: TypeError.UnknownTypeMismatch) => assertTrue(true)
-          case e => assertNever(s"Expected FailedCoercion but $e was thrown")
+        testExceptionMultiple("MissingDefinition Test")("exceptionTests", "notARealFunction", List(Data.Unit)) {
+          case LookupError.MissingDefinition(_,_,_,_) => assertTrue(true)
+          case e => assertNever(s"Expected MissingDefinition but $e was thrown")
+        },
+        testExceptionMultiple("MissingModule Test")("notARealModule", "notARealFunction", List(Data.Unit)) {
+          case LookupError.MissingModule(_,_,_) => assertTrue(true)
+          case e => assertNever(s"Expected MissingModule but $e was thrown")
+        },
+        testExceptionMultiple("MissingPackage Test")("", "", List(Data.Unit)) {
+          case LookupError.MissingPackage(_,_) => assertTrue(true)
+          case e => assertNever(s"Expected MissingPackage but $e was thrown")
+        },
+        testExceptionMultiple("ImproperType Test")("exceptionTests", "ignoreArgReturnString", List(Data.Int(1),Data.Int(1),Data.Int(1))) {
+          case TopLevelError(_, _, _: TypeError.ImproperType) => assertTrue(true)
+          case e => assertNever(s"Expected ImproperType but $e was thrown")
         }
       )
     ).provideLayerShared(morphirRuntimeLayer)

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -3481,7 +3481,8 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
         },
         testExceptionMultiple("UnknownTypeMismatch Test")("exceptionTests", "decimalHundred", List(Data.String("a"))) {
           case TopLevelError(_, _, _: TypeError.UnknownTypeMismatch) => assertTrue(true)
-          case e => assertNever(s"Expected UnknownTypeMismatch but $e was thrown")
+          case TopLevelError(_, _, inner) => assertNever(s"Expected UnsupportedType but $inner was thrown")
+          case e                          => assertNever(s"Expected UnknownTypeMismatch but $e was thrown")
         },
         /* There are 2 different UnsupportedType errors possible.
            MorphirRuntimeError.UnsupportedType and MorphirErrorRuntime.TypeError.UnsupportedType

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -79,14 +79,14 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
     }
 
   def evaluateException(
-                       moduleName: String,
-                       functionName: String,
-                       values: List[Any]
-                     )(expected: Throwable => TestResult): ZIO[TypedMorphirRuntime, Throwable, TestResult] =
+      moduleName: String,
+      functionName: String,
+      values: List[Any]
+  )(expected: Throwable => TestResult): ZIO[TypedMorphirRuntime, Throwable, TestResult] =
     runTest(moduleName, functionName, values).fold(
       throwable => expected(throwable),
       data => assertNever(s"Expected exception but test returned $data")
-  )
+    )
 
   def testEvaluation(label: String)(moduleName: String, functionName: String)(expected: => Data) =
     test(label) {
@@ -103,7 +103,11 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
       checkEvaluation(moduleName, functionName, values)(expected)
     }
 
-  def testExceptionMultiple(label: String)(moduleName: String, functionName: String, values: List[Any])(expected: Throwable => TestResult) =
+  def testExceptionMultiple(label: String)(
+      moduleName: String,
+      functionName: String,
+      values: List[Any]
+  )(expected: Throwable => TestResult) =
     test(label) {
       evaluateException(moduleName, functionName, values)(expected)
     }
@@ -3467,41 +3471,53 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
         )
       ),
       suite("Morphir Runtime Exception Tests")(
-        testExceptionMultiple("FailedCoercion Test")("exceptionTests", "sdkAddTest", List(Data.String("a"), Data.String("b"))) {
+        testExceptionMultiple("FailedCoercion Test")(
+          "exceptionTests",
+          "sdkAddTest",
+          List(Data.String("a"), Data.String("b"))
+        ) {
           case TopLevelError(_, _, _) => assertTrue(true)
-          case e => assertNever(s"Expected FailedCoercion but $e was thrown")
+          case e                      => assertNever(s"Expected FailedCoercion but $e was thrown")
         },
         testExceptionMultiple("UnknownTypeMismatch Test")("exceptionTests", "decimalHundred", List(Data.String("a"))) {
           case TopLevelError(_, _, _: TypeError.UnknownTypeMismatch) => assertTrue(true)
           case e => assertNever(s"Expected UnknownTypeMismatch but $e was thrown")
         },
         /* There are 2 different UnsupportedType errors possible.
-           MorphirRuntimeError.UnsupportedType and MorphirErrorRuntime.TypeError.UnsupportedType 
+           MorphirRuntimeError.UnsupportedType and MorphirErrorRuntime.TypeError.UnsupportedType
          */
-        testExceptionMultiple("MorphirRuntimeError UnsupportedType Test")("exceptionTests", "sdkAddTest", List(Data.String("a"))) {
+        testExceptionMultiple("MorphirRuntimeError UnsupportedType Test")(
+          "exceptionTests",
+          "sdkAddTest",
+          List(Data.String("a"))
+        ) {
           case TopLevelError(_, _, _: UnsupportedType) => assertTrue(true)
-          case TopLevelError(_, _, inner) => assertNever(s"Expected UnsupportedType but $inner was thrown")
-          case e => assertNever(s"Expected UnsupportedType but $e was thrown")
+          case TopLevelError(_, _, inner)              => assertNever(s"Expected UnsupportedType but $inner was thrown")
+          case e                                       => assertNever(s"Expected UnsupportedType but $e was thrown")
         },
         testExceptionMultiple("Type Test")("exceptionTests", "sdkAddTest", List(Data.Float(1), Data.Decimal(2))) {
           case TopLevelError(_, _, _: TypeError.InferenceConflict) => assertTrue(true)
           case e => assertNever(s"Expected FailedCoercion but $e was thrown")
         },
         testExceptionMultiple("MissingDefinition Test")("exceptionTests", "notARealFunction", List(Data.Unit)) {
-          case LookupError.MissingDefinition(_,_,_,_) => assertTrue(true)
-          case e => assertNever(s"Expected MissingDefinition but $e was thrown")
+          case LookupError.MissingDefinition(_, _, _, _) => assertTrue(true)
+          case e                                         => assertNever(s"Expected MissingDefinition but $e was thrown")
         },
         testExceptionMultiple("MissingModule Test")("notARealModule", "notARealFunction", List(Data.Unit)) {
-          case LookupError.MissingModule(_,_,_) => assertTrue(true)
-          case e => assertNever(s"Expected MissingModule but $e was thrown")
+          case LookupError.MissingModule(_, _, _) => assertTrue(true)
+          case e                                  => assertNever(s"Expected MissingModule but $e was thrown")
         },
         testExceptionMultiple("MissingPackage Test")("", "", List(Data.Unit)) {
-          case LookupError.MissingPackage(_,_) => assertTrue(true)
-          case e => assertNever(s"Expected MissingPackage but $e was thrown")
+          case LookupError.MissingPackage(_, _) => assertTrue(true)
+          case e                                => assertNever(s"Expected MissingPackage but $e was thrown")
         },
-        testExceptionMultiple("ImproperType Test")("exceptionTests", "ignoreArgReturnString", List(Data.Int(1),Data.Int(1),Data.Int(1))) {
+        testExceptionMultiple("ImproperType Test")(
+          "exceptionTests",
+          "ignoreArgReturnString",
+          List(Data.Int(1), Data.Int(1), Data.Int(1))
+        ) {
           case TopLevelError(_, _, _: TypeError.ImproperType) => assertTrue(true)
-          case e => assertNever(s"Expected ImproperType but $e was thrown")
+          case e                                              => assertNever(s"Expected ImproperType but $e was thrown")
         }
       )
     ).provideLayerShared(morphirRuntimeLayer)

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -3477,12 +3477,11 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           List(Data.String("a"), Data.String("b"))
         ) {
           case TopLevelError(_, _, _) => assertTrue(true)
-          case e                      => assertNever(s"Expected FailedCoercion but $e was thrown")
+          case _                      => assertNever(s"Unexpected exception type was thrown")
         },
         testExceptionMultiple("UnknownTypeMismatch Test")("exceptionTests", "decimalHundred", List(Data.String("a"))) {
           case TopLevelError(_, _, _: TypeError.UnknownTypeMismatch) => assertTrue(true)
-          case TopLevelError(_, _, inner) => assertNever(s"Expected UnsupportedType but $inner was thrown")
-          case e                          => assertNever(s"Expected UnknownTypeMismatch but $e was thrown")
+          case _ => assertNever(s"Unexpected exception type was thrown")
         },
         /* There are 2 different UnsupportedType errors possible.
            MorphirRuntimeError.UnsupportedType and MorphirErrorRuntime.TypeError.UnsupportedType
@@ -3493,24 +3492,23 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           List(Data.String("a"))
         ) {
           case TopLevelError(_, _, _: UnsupportedType) => assertTrue(true)
-          case TopLevelError(_, _, inner)              => assertNever(s"Expected UnsupportedType but $inner was thrown")
-          case e                                       => assertNever(s"Expected UnsupportedType but $e was thrown")
+          case _                                       => assertNever(s"Unexpected exception type was thrown")
         },
         testExceptionMultiple("Type Test")("exceptionTests", "sdkAddTest", List(Data.Float(1), Data.Decimal(2))) {
           case TopLevelError(_, _, _: TypeError.InferenceConflict) => assertTrue(true)
-          case e => assertNever(s"Expected FailedCoercion but $e was thrown")
+          case _ => assertNever(s"Unexpected exception type was thrown")
         },
         testExceptionMultiple("MissingDefinition Test")("exceptionTests", "notARealFunction", List(Data.Unit)) {
           case LookupError.MissingDefinition(_, _, _, _) => assertTrue(true)
-          case e                                         => assertNever(s"Expected MissingDefinition but $e was thrown")
+          case _                                         => assertNever(s"Unexpected exception type was thrown")
         },
         testExceptionMultiple("MissingModule Test")("notARealModule", "notARealFunction", List(Data.Unit)) {
           case LookupError.MissingModule(_, _, _) => assertTrue(true)
-          case e                                  => assertNever(s"Expected MissingModule but $e was thrown")
+          case _                                  => assertNever(s"Unexpected exception type was thrown")
         },
         testExceptionMultiple("MissingPackage Test")("", "", List(Data.Unit)) {
           case LookupError.MissingPackage(_, _) => assertTrue(true)
-          case e                                => assertNever(s"Expected MissingPackage but $e was thrown")
+          case _                                => assertNever(s"Unexpected exception type was thrown")
         },
         testExceptionMultiple("ImproperType Test")(
           "exceptionTests",
@@ -3518,7 +3516,7 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           List(Data.Int(1), Data.Int(1), Data.Int(1))
         ) {
           case TopLevelError(_, _, _: TypeError.ImproperType) => assertTrue(true)
-          case e                                              => assertNever(s"Expected ImproperType but $e was thrown")
+          case _                                              => assertNever(s"Unexpected exception type was thrown")
         }
       )
     ).provideLayerShared(morphirRuntimeLayer)


### PR DESCRIPTION
Adds logic to the EvaluatorMDMTests that allows for testing situation where we expect exceptions to get thrown. Also adds some simplified testing to test specific exceptions getting thrown.

An added benefit of this setup is that tests for unhappy path testing should be easier to write going forward (when they expect exceptions to get thrown)