### PR TITLE
Add test coverage to mill

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,33 @@ For your convience, you can run the morphir-runtime tests using the following co
 ./build.sh test-runtime-jvm
 ```
 
+#### Test Coverage
+
+Before checking test coverage, ensure that all tests have been run using the following command:
+
+```bash
+./mill __.test
+```
+
+##### HTML Coverage Report
+
+To generate a human-readable coverage report, run the following command:
+
+```bash
+./mill scoverage.htmlReportAll
+```
+
+To view the resulting coverage report, open `out/scoverage/htmlReportAll.dest/index.html`
+
+##### XML Coverage Report
+
+To generate an XML coverage report, run the following command:
+
+```bash
+./mill scoverage.xmlReportAll
+```
+
+The report will be generated at this location `out/scoverage/xmlReportAll.dest/scoverage.xml`
 
 #### Formatting Scala Code
 

--- a/build.sc
+++ b/build.sc
@@ -21,7 +21,7 @@ import millbuild.settings._
 import mill._, mill.scalalib._, mill.scalajslib._, mill.scalanativelib._, scalafmt._
 import mill.scalajslib.api.ModuleKind
 import mill.contrib.buildinfo.BuildInfo
-import mill.contrib.scoverage.ScoverageModule
+import mill.contrib.scoverage.{ScoverageModule, ScoverageReport}
 import com.github.lolgab.mill.mima._
 import de.tobiasroeser.mill.vcs.version.VcsVersion
 import scala.concurrent.duration.DurationInt
@@ -57,6 +57,11 @@ def reformatAll(evaluator: Evaluator, sources: mill.main.Tasks[Seq[PathRef]]) = 
 
 def showBuildSettings() = T.command {
   MyBuild.showBuildSettings()
+}
+
+object scoverage extends ScoverageReport {
+  def scalaVersion = "3.3.3"
+  def scoverageVersion = Vers.scoverage
 }
 
 trait MorphirPublishModule extends PublishModule with JavaModule with Mima {
@@ -234,8 +239,10 @@ trait MorphirCrossModule extends Cross.Module[String] with CrossPlatform { morph
         def platformSpecificModuleDeps = Seq(morphir)
       }
 
-      object jvm extends Shared with MorphirJVMModule {
-        object test extends ScalaTests with TestModule.ZioTest {
+      object jvm extends Shared with MorphirJVMModule with ScoverageModule {
+        def scoverageVersion = Vers.scoverage
+
+        object test extends ScoverageTests with TestModule.ZioTest {
           def ivyDeps = Agg(
             Deps.dev.zio.zio,
             Deps.dev.zio.`zio-streams`,
@@ -285,8 +292,10 @@ trait MorphirCrossModule extends Cross.Module[String] with CrossPlatform { morph
           def platformSpecificModuleDeps = Seq(morphir)
         }
 
-        object jvm extends Shared with MorphirJVMModule {
-          object test extends ScalaTests with TestModule.ZioTest {
+        object jvm extends Shared with MorphirJVMModule with ScoverageModule {
+          def scoverageVersion = Vers.scoverage
+
+          object test extends ScoverageTests with TestModule.ZioTest {
             def ivyDeps: T[Agg[Dep]] = Agg(
               Deps.dev.zio.`zio-json-golden`,
               ivy"io.github.deblockt:json-diff:1.1.0",
@@ -311,8 +320,10 @@ trait MorphirCrossModule extends Cross.Module[String] with CrossPlatform { morph
         def platformSpecificModuleDeps = Seq(morphir)
       }
 
-      object jvm extends Shared with MorphirJVMModule {
-        object test extends ScalaTests with TestModule.ZioTest {
+      object jvm extends Shared with MorphirJVMModule with ScoverageModule {
+        def scoverageVersion = Vers.scoverage
+
+        object test extends ScoverageTests with TestModule.ZioTest {
           def ivyDeps: T[Agg[Dep]] = Agg(
             Deps.io.bullet.`borer-core`(crossScalaVersion),
             Deps.io.bullet.`borer-derivation`(crossScalaVersion)
@@ -362,8 +373,10 @@ trait MorphirCrossModule extends Cross.Module[String] with CrossPlatform { morph
       }
     }
 
-    object jvm extends Shared with MorphirJVMModule {
-      object test extends ScalaTests with RuntimeTests {
+    object jvm extends Shared with MorphirJVMModule with ScoverageModule {
+      def scoverageVersion = Vers.scoverage
+
+      object test extends ScoverageTests with RuntimeTests {
         def ivyDeps = Agg(
           Deps.com.lihaoyi.`os-lib`,
           Deps.com.lihaoyi.sourcecode,
@@ -381,11 +394,6 @@ trait MorphirCrossModule extends Cross.Module[String] with CrossPlatform { morph
         def moduleKind = ModuleKind.CommonJSModule
       }
     }
-  }
-
-  object scoverage extends ScoverageReport {
-    def scalaVersion = "3.3.3"
-    def scoverageVersion = Vers.scoverage
   }
 
   object testing extends Module {
@@ -425,8 +433,10 @@ trait MorphirCrossModule extends Cross.Module[String] with CrossPlatform { morph
       def platformSpecificModuleDeps = Seq(extensibility, morphir, runtime, tools)
     }
 
-    object jvm extends Shared with MorphirJVMModule {
-      object test extends ScoverageTests with ScalaTests with TestModule.ZioTest {
+    object jvm extends Shared with MorphirJVMModule with ScoverageModule {
+      def scoverageVersion = Vers.scoverage
+
+      object test extends ScoverageTests with TestModule.ZioTest {
 
         def ivyDeps = Agg(
           Deps.com.lihaoyi.`os-lib`,

--- a/build.sc
+++ b/build.sc
@@ -2,6 +2,7 @@ import $meta._
 import $ivy.`de.tototec::de.tobiasroeser.mill.integrationtest::0.7.1`
 import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.4.0`
 import $ivy.`com.lihaoyi::mill-contrib-buildinfo:$MILL_VERSION`
+import $ivy.`com.lihaoyi::mill-contrib-scoverage:$MILL_VERSION`
 import $ivy.`com.carlosedp::mill-aliases::0.4.1`
 import $ivy.`com.github.lolgab::mill-mima::0.1.1`
 import $file.project.deps, deps.{Deps, MillVersions, Versions => Vers}
@@ -20,6 +21,7 @@ import millbuild.settings._
 import mill._, mill.scalalib._, mill.scalajslib._, mill.scalanativelib._, scalafmt._
 import mill.scalajslib.api.ModuleKind
 import mill.contrib.buildinfo.BuildInfo
+import mill.contrib.scoverage.ScoverageModule
 import com.github.lolgab.mill.mima._
 import de.tobiasroeser.mill.vcs.version.VcsVersion
 import scala.concurrent.duration.DurationInt
@@ -381,6 +383,11 @@ trait MorphirCrossModule extends Cross.Module[String] with CrossPlatform { morph
     }
   }
 
+  object scoverage extends ScoverageReport {
+    def scalaVersion = "3.3.3"
+    def scoverageVersion = Vers.scoverage
+  }
+
   object testing extends Module {
     object generators extends CrossPlatform with CrossValue {
       trait Shared extends MorphirCommonCrossModule {
@@ -419,7 +426,7 @@ trait MorphirCrossModule extends Cross.Module[String] with CrossPlatform { morph
     }
 
     object jvm extends Shared with MorphirJVMModule {
-      object test extends ScalaTests with TestModule.ZioTest {
+      object test extends ScoverageTests with ScalaTests with TestModule.ZioTest {
 
         def ivyDeps = Agg(
           Deps.com.lihaoyi.`os-lib`,

--- a/build.sc
+++ b/build.sc
@@ -5,7 +5,7 @@ import $ivy.`com.lihaoyi::mill-contrib-buildinfo:$MILL_VERSION`
 import $ivy.`com.lihaoyi::mill-contrib-scoverage:$MILL_VERSION`
 import $ivy.`com.carlosedp::mill-aliases::0.4.1`
 import $ivy.`com.github.lolgab::mill-mima::0.1.1`
-import $file.project.deps, deps.{Deps, MillVersions, Versions => Vers}
+import $file.project.deps, deps.{Deps, MillVersions, Versions => Vers, ScalaVersions => ScalaVers}
 import $file.project.modules.docs, docs.{Docusaurus2Module, MDocModule}
 import mill.testrunner.TestResult
 import mill.scalalib.publish.PublishInfo
@@ -60,7 +60,9 @@ def showBuildSettings() = T.command {
 }
 
 object scoverage extends ScoverageReport {
-  def scalaVersion = "3.3.3"
+  // While the plugin doesn't seem to support multiple scala versions, that doesn't seem to impact the coverage
+  // For overall coverage report, just specifying Scala 3
+  def scalaVersion = ScalaVers.scala3x
   def scoverageVersion = Vers.scoverage
 }
 

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -220,6 +220,7 @@ object Versions {
   val `scala-java-time`          = "2.6.0"
   val `scala-native-crypto`      = "0.0.4"
   val `scalac-compat-annotation` = "0.1.4"
+  val scoverage                  = "2.1.1"
   val scribe                     = "3.11.9"
   val silencer                   = "1.4.2"
   val spire                      = "0.18.0"


### PR DESCRIPTION
Add test coverage to available mill ops. 
Test coverage is handled with the scoverage plugin.

This does not in any way interact with existing github actions and the coverage tests are only run manually for the time being. Coverage requirements can be added later (likely with a ratcheting coverage goal that caps out at a certain level)