### PR TITLE
Increase error testing for MorphirRuntimeErrors

### DIFF
--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExceptionTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExceptionTests.elm
@@ -40,9 +40,30 @@ acceptTuple3 _ =
 type alias XYRecord =
     { x : Int, y : Int }
 
-
 {-| Test: ExceptionTests/accept XYRecord
 -}
 acceptRecord : XYRecord -> String
 acceptRecord _ =
     "accept record test"
+
+
+type alias AliasAlias =
+    { xyRecord : XYRecord }
+
+{-| Test: ExceptionTests/acceptAliasTuple
+-}
+acceptAliasAlias : AliasAlias -> String
+acceptAliasAlias _ =
+    "accept AliasAlias test"
+
+
+{-| Test: ExceptionTests/nonExhustiveCase
+-}
+nonExhaustiveCase : Int -> String
+nonExhaustiveCase a =
+    case a of
+        1 ->
+            "1"
+        2 ->
+            "2"
+    

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExceptionTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExceptionTests.elm
@@ -1,6 +1,7 @@
 module Morphir.Examples.App.ExceptionTests exposing (..)
 
 import Morphir.SDK.Decimal as Decimal exposing (..)
+import Tuple exposing (..)
 
 
 {-| Test: ExceptionTests/add
@@ -27,3 +28,21 @@ decimalHundred value =
 ignoreArgReturnString : a -> String
 ignoreArgReturnString _ =
     "test"
+
+
+{-| Test: ExceptionTests/acceptTuple3
+-}
+acceptTuple3 : ( Int, Int, Int ) -> String
+acceptTuple3 _ =
+    "accept tuple test"
+
+
+type alias XYRecord =
+    { x : Int, y : Int }
+
+
+{-| Test: ExceptionTests/accept XYRecord
+-}
+acceptRecord : XYRecord -> String
+acceptRecord _ =
+    "accept record test"

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExceptionTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExceptionTests.elm
@@ -40,6 +40,7 @@ acceptTuple3 _ =
 type alias XYRecord =
     { x : Int, y : Int }
 
+
 {-| Test: ExceptionTests/accept XYRecord
 -}
 acceptRecord : XYRecord -> String
@@ -49,6 +50,7 @@ acceptRecord _ =
 
 type alias AliasAlias =
     { xyRecord : XYRecord }
+
 
 {-| Test: ExceptionTests/acceptAliasTuple
 -}
@@ -64,6 +66,6 @@ nonExhaustiveCase a =
     case a of
         1 ->
             "1"
+
         2 ->
             "2"
-    

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExceptionTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExceptionTests.elm
@@ -75,7 +75,7 @@ type alias StringAlias =
     String
 
 
-{-| Test: ExceptionTests/nonExhustiveCase
+{-| Test: ExceptionTests/stringAliasToString
 -}
 stringAliasToString : StringAlias -> String
 stringAliasToString a =

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExceptionTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExceptionTests.elm
@@ -37,26 +37,26 @@ acceptTuple3 _ =
     "accept tuple test"
 
 
-type alias XYRecord =
+type alias XY =
     { x : Int, y : Int }
 
 
-{-| Test: ExceptionTests/accept XYRecord
+{-| Test: ExceptionTests/acceptXY
 -}
-acceptRecord : XYRecord -> String
-acceptRecord _ =
-    "accept record test"
+acceptXY : XY -> String
+acceptXY _ =
+    "accept xy test"
 
 
-type alias AliasAlias =
-    { xyRecord : XYRecord }
+type alias XYRecord =
+    { xy : XY }
 
 
-{-| Test: ExceptionTests/acceptAliasTuple
+{-| Test: ExceptionTests/acceptXYRecord
 -}
-acceptAliasAlias : AliasAlias -> String
-acceptAliasAlias _ =
-    "accept AliasAlias test"
+acceptXYRecord : XYRecord -> String
+acceptXYRecord _ =
+    "accept XYRecord test"
 
 
 {-| Test: ExceptionTests/nonExhustiveCase

--- a/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExceptionTests.elm
+++ b/examples/morphir-elm-projects/evaluator-tests/src/Morphir/Examples/App/ExceptionTests.elm
@@ -69,3 +69,14 @@ nonExhaustiveCase a =
 
         2 ->
             "2"
+
+
+type alias StringAlias =
+    String
+
+
+{-| Test: ExceptionTests/nonExhustiveCase
+-}
+stringAliasToString : StringAlias -> String
+stringAliasToString a =
+    a

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -3477,11 +3477,47 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           List(Data.String("a"), Data.String("b"))
         ) {
           case TopLevelError(_, _, _) => assertTrue(true)
-          case _                      => assertNever(s"Unexpected exception type was thrown")
+          case _                      => assertNever("Unexpected exception type was thrown")
         },
         testExceptionMultiple("UnknownTypeMismatch Test")("exceptionTests", "decimalHundred", List(Data.String("a"))) {
           case TopLevelError(_, _, _: TypeError.UnknownTypeMismatch) => assertTrue(true)
-          case _ => assertNever(s"Unexpected exception type was thrown")
+          case _ => assertNever("Unexpected exception type was thrown")
+        },
+        testExceptionMultiple("SizeMismatch Test")(
+          "exceptionTests",
+          "acceptTuple3",
+          List(Data.Tuple(Data.Int(1), Data.Int(1)))
+        ) {
+          case TopLevelError(_, _, _: TypeError.SizeMismatch) => assertTrue(true)
+          case _                                              => assertNever("Unexpected exception type was thrown")
+        },
+        testExceptionMultiple("ValueLacksField Test")(
+          "exceptionTests",
+          "acceptRecord",
+          List(
+            Data.Record(
+              FQName.fromString("Morphir.Examples.App:ExceptionTests:XYRecord"),
+              (Label("x"), Data.Int(1))
+            )
+          )
+        ) {
+          case TopLevelError(_, _, _: TypeError.ValueLacksField) => assertTrue(true)
+          case _                                                 => assertNever("Unexpected exception type was thrown")
+        },
+        testExceptionMultiple("ValueHasExtraField Test")(
+          "exceptionTests",
+          "acceptRecord",
+          List(
+            Data.Record(
+              FQName.fromString("Morphir.Examples.App:ExceptionTests:XYRecord"),
+              (Label("x"), Data.Int(1)),
+              (Label("y"), Data.Int(1)),
+              (Label("z"), Data.Int(1))
+            )
+          )
+        ) {
+          case TopLevelError(_, _, _: TypeError.ValueHasExtraField) => assertTrue(true)
+          case _ => assertNever("Unexpected exception type was thrown")
         },
         /* There are 2 different UnsupportedType errors possible.
            MorphirRuntimeError.UnsupportedType and MorphirErrorRuntime.TypeError.UnsupportedType
@@ -3500,15 +3536,15 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
         },
         testExceptionMultiple("MissingDefinition Test")("exceptionTests", "notARealFunction", List(Data.Unit)) {
           case LookupError.MissingDefinition(_, _, _, _) => assertTrue(true)
-          case _                                         => assertNever(s"Unexpected exception type was thrown")
+          case _                                         => assertNever("Unexpected exception type was thrown")
         },
         testExceptionMultiple("MissingModule Test")("notARealModule", "notARealFunction", List(Data.Unit)) {
           case LookupError.MissingModule(_, _, _) => assertTrue(true)
-          case _                                  => assertNever(s"Unexpected exception type was thrown")
+          case _                                  => assertNever("Unexpected exception type was thrown")
         },
         testExceptionMultiple("MissingPackage Test")("", "", List(Data.Unit)) {
           case LookupError.MissingPackage(_, _) => assertTrue(true)
-          case _                                => assertNever(s"Unexpected exception type was thrown")
+          case _                                => assertNever("Unexpected exception type was thrown")
         },
         testExceptionMultiple("ImproperType Test")(
           "exceptionTests",
@@ -3516,7 +3552,7 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           List(Data.Int(1), Data.Int(1), Data.Int(1))
         ) {
           case TopLevelError(_, _, _: TypeError.ImproperType) => assertTrue(true)
-          case _                                              => assertNever(s"Unexpected exception type was thrown")
+          case _                                              => assertNever("Unexpected exception type was thrown")
         }
       )
     ).provideLayerShared(morphirRuntimeLayer)

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -7,6 +7,7 @@ import org.finos.morphir.naming.*
 import org.finos.morphir.runtime.EvaluatorMDMTests.testExceptionMultiple
 import org.finos.morphir.runtime.environment.MorphirEnv
 import org.finos.morphir.runtime.MorphirRuntimeError.*
+import org.finos.morphir.runtime.MorphirRuntimeError.RTValueToMDMError.ResultTypeMismatch
 import org.finos.morphir.testing.MorphirBaseSpec
 import zio.test.*
 import zio.test.TestAspect.{ignore, tag}
@@ -3582,7 +3583,20 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           )
         ) {
           case TopLevelError(_, _, _: TypeError.TypesMismatch) => assertTrue(true)
-          case e                                               => assertNever(s"$e")
+          case _                                               => assertNever(s"Unexpected exception type was thrown")
+        },
+        testExceptionMultiple("ResultTypeMismatch Test")(
+          "exceptionTests",
+          "stringAliasToString",
+          List(
+            Data.Aliased(
+              Data.Unit,
+              Concept.Alias(FQName.fromString("Morphir.Examples.App:ExceptionTests:StringAlias"), Concept.Unit)
+            )
+          )
+        ) {
+          case TopLevelError(_, _, _: ResultTypeMismatch) => assertTrue(true)
+          case _                                          => assertNever(s"Unexpected exception type was thrown")
         },
         testExceptionMultiple("UnmatchedPattern Test")(
           "exceptionTests",
@@ -3590,7 +3604,7 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           List(Data.Int(3))
         ) {
           case TopLevelError(_, _, _) => assertTrue(true)
-          case e                      => assertNever(s"Unexpected exception type was thrown $e")
+          case _                      => assertNever(s"Unexpected exception type was thrown")
         },
         /* There are 2 different UnsupportedType errors possible.
            MorphirRuntimeError.UnsupportedType and MorphirErrorRuntime.TypeError.UnsupportedType

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -3494,10 +3494,10 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
         },
         testExceptionMultiple("ValueLacksField Test")(
           "exceptionTests",
-          "acceptRecord",
+          "acceptXY",
           List(
             Data.Record(
-              FQName.fromString("Morphir.Examples.App:ExceptionTests:XYRecord"),
+              FQName.fromString("Morphir.Examples.App:ExceptionTests:XY"),
               (Label("x"), Data.Int(1))
             )
           )
@@ -3507,10 +3507,10 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
         },
         testExceptionMultiple("ValueHasExtraField Test")(
           "exceptionTests",
-          "acceptRecord",
+          "acceptXY",
           List(
             Data.Record(
-              FQName.fromString("Morphir.Examples.App:ExceptionTests:XYRecord"),
+              FQName.fromString("Morphir.Examples.App:ExceptionTests:XY"),
               (Label("x"), Data.Int(1)),
               (Label("y"), Data.Int(1)),
               (Label("z"), Data.Int(1))
@@ -3522,10 +3522,10 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
         },
         testExceptionMultiple("ManyTypeErrors Test")(
           "exceptionTests",
-          "acceptRecord",
+          "acceptXY",
           List(
             Data.Record(
-              FQName.fromString("Morphir.Examples.App:ExceptionTests:XYRecord"),
+              FQName.fromString("Morphir.Examples.App:ExceptionTests:XY"),
               (Label("a"), Data.Int(1)),
               (Label("b"), Data.Int(1))
             )
@@ -3536,15 +3536,15 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
         },
         testExceptionMultiple("LiteralTypeMismatch Test")(
           "exceptionTests",
-          "acceptAliasAlias",
+          "acceptXYRecord",
           List(
             Data.Record(
-              FQName.fromString("Morphir.Examples.App:ExceptionTests:AliasAlias"),
+              FQName.fromString("Morphir.Examples.App:ExceptionTests:XYRecord"),
               (
-                Label("xyRecord"),
+                Label("xy"),
                 Data.Aliased.apply(
                   Data.String("test"),
-                  Concept.Alias(FQName.fromString("Morphir.Examples.App:ExceptionTests:XYRecord"), Concept.String)
+                  Concept.Alias(FQName.fromString("Morphir.Examples.App:ExceptionTests:XY"), Concept.String)
                 )
               )
             )
@@ -3558,19 +3558,19 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           "ignoreArgReturnString",
           List(
             Data.Record(
-              FQName.fromString("Morphir.Examples.App:ExceptionTests:AliasAlias"),
+              FQName.fromString("Morphir.Examples.App:ExceptionTests:XYRecord"),
               (
-                Label("xyRecord"),
+                Label("xy"),
                 Data.Aliased.apply(
                   Data.Record(
-                    FQName.fromString("Morphir.Examples.App:ExceptionTests:XYRecord"),
+                    FQName.fromString("Morphir.Examples.App:ExceptionTests:XY"),
                     (Label("x"), Data.Decimal(1.0)),
                     (Label("y"), Data.Decimal(1.0))
                   ),
                   Concept.Alias(
-                    FQName.fromString("Morphir.Examples.App:ExceptionTests:XYRecord"),
+                    FQName.fromString("Morphir.Examples.App:ExceptionTests:XY"),
                     Concept.Record(
-                      FQName.fromString("Morphir.Examples.App:ExceptionTests:XYRecord"),
+                      FQName.fromString("Morphir.Examples.App:ExceptionTests:XY"),
                       List(
                         (Label("x"), Concept.Int32),
                         (Label("y"), Concept.Int32)

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -3553,7 +3553,7 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           case TopLevelError(_, _, _: TypeError.LiteralTypeMismatch) => assertTrue(true)
           case _ => assertNever("Unexpected exception type was thrown")
         },
-        testExceptionMultiple("test Test")(
+        testExceptionMultiple("TypesMismatch Test")(
           "exceptionTests",
           "ignoreArgReturnString",
           List(
@@ -3583,7 +3583,7 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           )
         ) {
           case TopLevelError(_, _, _: TypeError.TypesMismatch) => assertTrue(true)
-          case _                                               => assertNever(s"Unexpected exception type was thrown")
+          case _                                               => assertNever("Unexpected exception type was thrown")
         },
         testExceptionMultiple("ResultTypeMismatch Test")(
           "exceptionTests",
@@ -3596,7 +3596,7 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           )
         ) {
           case TopLevelError(_, _, _: ResultTypeMismatch) => assertTrue(true)
-          case _                                          => assertNever(s"Unexpected exception type was thrown")
+          case _                                          => assertNever("Unexpected exception type was thrown")
         },
         testExceptionMultiple("UnmatchedPattern Test")(
           "exceptionTests",

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -3531,7 +3531,7 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           )
         ) {
           case TopLevelError(_, _, _: TypeError.ManyTypeErrors) => assertTrue(true)
-          case _ => assertNever("Unexpected exception type was thrown")
+          case _                                                => assertNever("Unexpected exception type was thrown")
         },
         testExceptionMultiple("LiteralTypeMismatch Test")(
           "exceptionTests",
@@ -3541,7 +3541,10 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
               FQName.fromString("Morphir.Examples.App:ExceptionTests:AliasAlias"),
               (
                 Label("xyRecord"),
-                Data.Aliased.apply(Data.String("test"), Concept.Alias(FQName.fromString("Morphir.Examples.App:ExceptionTests:XYRecord"), Concept.String))
+                Data.Aliased.apply(
+                  Data.String("test"),
+                  Concept.Alias(FQName.fromString("Morphir.Examples.App:ExceptionTests:XYRecord"), Concept.String)
+                )
               )
             )
           )
@@ -3579,7 +3582,7 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           )
         ) {
           case TopLevelError(_, _, _: TypeError.TypesMismatch) => assertTrue(true)
-          case e                                                    => assertNever(s"$e")
+          case e                                               => assertNever(s"$e")
         },
         testExceptionMultiple("UnmatchedPattern Test")(
           "exceptionTests",
@@ -3587,7 +3590,7 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           List(Data.Int(3))
         ) {
           case TopLevelError(_, _, _) => assertTrue(true)
-          case e => assertNever(s"Unexpected exception type was thrown $e")
+          case e                      => assertNever(s"Unexpected exception type was thrown $e")
         },
         /* There are 2 different UnsupportedType errors possible.
            MorphirRuntimeError.UnsupportedType and MorphirErrorRuntime.TypeError.UnsupportedType
@@ -3600,7 +3603,11 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           case TopLevelError(_, _, _: UnsupportedType) => assertTrue(true)
           case _                                       => assertNever(s"Unexpected exception type was thrown")
         },
-        testExceptionMultiple("InferenceConflict Test")("exceptionTests", "sdkAddTest", List(Data.Float(1), Data.Decimal(2))) {
+        testExceptionMultiple("InferenceConflict Test")(
+          "exceptionTests",
+          "sdkAddTest",
+          List(Data.Float(1), Data.Decimal(2))
+        ) {
           case TopLevelError(_, _, _: TypeError.InferenceConflict) => assertTrue(true)
           case _ => assertNever(s"Unexpected exception type was thrown")
         },

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -3519,10 +3519,80 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           case TopLevelError(_, _, _: TypeError.ValueHasExtraField) => assertTrue(true)
           case _ => assertNever("Unexpected exception type was thrown")
         },
+        testExceptionMultiple("ManyTypeErrors Test")(
+          "exceptionTests",
+          "acceptRecord",
+          List(
+            Data.Record(
+              FQName.fromString("Morphir.Examples.App:ExceptionTests:XYRecord"),
+              (Label("a"), Data.Int(1)),
+              (Label("b"), Data.Int(1))
+            )
+          )
+        ) {
+          case TopLevelError(_, _, _: TypeError.ManyTypeErrors) => assertTrue(true)
+          case _ => assertNever("Unexpected exception type was thrown")
+        },
+        testExceptionMultiple("LiteralTypeMismatch Test")(
+          "exceptionTests",
+          "acceptAliasAlias",
+          List(
+            Data.Record(
+              FQName.fromString("Morphir.Examples.App:ExceptionTests:AliasAlias"),
+              (
+                Label("xyRecord"),
+                Data.Aliased.apply(Data.String("test"), Concept.Alias(FQName.fromString("Morphir.Examples.App:ExceptionTests:XYRecord"), Concept.String))
+              )
+            )
+          )
+        ) {
+          case TopLevelError(_, _, _: TypeError.LiteralTypeMismatch) => assertTrue(true)
+          case _ => assertNever("Unexpected exception type was thrown")
+        },
+        testExceptionMultiple("test Test")(
+          "exceptionTests",
+          "ignoreArgReturnString",
+          List(
+            Data.Record(
+              FQName.fromString("Morphir.Examples.App:ExceptionTests:AliasAlias"),
+              (
+                Label("xyRecord"),
+                Data.Aliased.apply(
+                  Data.Record(
+                    FQName.fromString("Morphir.Examples.App:ExceptionTests:XYRecord"),
+                    (Label("x"), Data.Decimal(1.0)),
+                    (Label("y"), Data.Decimal(1.0))
+                  ),
+                  Concept.Alias(
+                    FQName.fromString("Morphir.Examples.App:ExceptionTests:XYRecord"),
+                    Concept.Record(
+                      FQName.fromString("Morphir.Examples.App:ExceptionTests:XYRecord"),
+                      List(
+                        (Label("x"), Concept.Int32),
+                        (Label("y"), Concept.Int32)
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        ) {
+          case TopLevelError(_, _, _: TypeError.TypesMismatch) => assertTrue(true)
+          case e                                                    => assertNever(s"$e")
+        },
+        testExceptionMultiple("UnmatchedPattern Test")(
+          "exceptionTests",
+          "nonExhaustiveCase",
+          List(Data.Int(3))
+        ) {
+          case TopLevelError(_, _, _) => assertTrue(true)
+          case e => assertNever(s"Unexpected exception type was thrown $e")
+        },
         /* There are 2 different UnsupportedType errors possible.
            MorphirRuntimeError.UnsupportedType and MorphirErrorRuntime.TypeError.UnsupportedType
          */
-        testExceptionMultiple("MorphirRuntimeError UnsupportedType Test")(
+        testExceptionMultiple("UnsupportedType Test")(
           "exceptionTests",
           "sdkAddTest",
           List(Data.String("a"))
@@ -3530,7 +3600,7 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           case TopLevelError(_, _, _: UnsupportedType) => assertTrue(true)
           case _                                       => assertNever(s"Unexpected exception type was thrown")
         },
-        testExceptionMultiple("Type Test")("exceptionTests", "sdkAddTest", List(Data.Float(1), Data.Decimal(2))) {
+        testExceptionMultiple("InferenceConflict Test")("exceptionTests", "sdkAddTest", List(Data.Float(1), Data.Decimal(2))) {
           case TopLevelError(_, _, _: TypeError.InferenceConflict) => assertTrue(true)
           case _ => assertNever(s"Unexpected exception type was thrown")
         },


### PR DESCRIPTION
Adds coverage for the following errors:
- SizeMismatch
- ValueLacksField
- ValueHasExtraField
- ManyTypeErrors
- LiteralTypeMismatch
- TypesMismatch
- ResultTypeMismatch
- UnmatchedPattern
- InferenceConflict