### PR TITLE
updating function containsTestCode 

### DIFF
--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/testing/UnitTesting.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/testing/UnitTesting.scala
@@ -34,14 +34,12 @@ object UnitTesting {
   def testPackagePath = fqn"Morphir.UnitTest:Test:foo".packagePath
 
   def containsTestCode(
-      globals: GlobalDefs,
       fqn: FQName,
       definition: TypedDefinition,
-      testNames: List[FQName]
   ): Boolean = {
-    def knownTestsPackages: List[PackageName] = testNames.map(_.packagePath).distinct
+    val fnName:String = fqn.localName.toUpperCase
     fqn.packagePath == testPackagePath ||
-    definition.outputType == testType || knownTestsPackages.contains(fqn.packagePath)
+    definition.outputType == testType || fnName.contains("TEST")
   }
 
   /**
@@ -57,7 +55,7 @@ object UnitTesting {
     val globals = GlobalDefs.fromDistributions(dists)
     RTAction.environmentWithPure[MorphirSdk] { env =>
       val testNames            = collectTests(globals)
-      val userDefinedFunctions = collectNonTests(globals, testNames)
+      val userDefinedFunctions = collectNonTests(globals)
       val testIRs              = testNames.map(fqn => Value.Reference.Typed(testType, fqn))
       if (testIRs.isEmpty) {
         val emptySummary = TestSummary(
@@ -200,7 +198,7 @@ object UnitTesting {
     val withResults = TestSet.processExpects(newGlobals, withExpects)
 
     // begin collecting coverage related information
-    val userDefinedFunctions = collectNonTests(globals, testNames)
+    val userDefinedFunctions = collectNonTests(globals)
     val referencedFunctions  = testNames.flatMap(name => GlobalDefs.getStaticallyReachable(name, globals)).toSet
     val coverageInfo = CoverageInfo(
       referencedFunctions,
@@ -237,15 +235,12 @@ object UnitTesting {
    *
    * @param globals
    *   The global definitions to collect non tests from
-   * @param testNames
-   *   The list of tests names so we can identify test helper functions to exclude
    */
   private[runtime] def collectNonTests(
       globals: GlobalDefs,
-      testNames: List[FQName]
   ): Set[FQName] =
     globals.definitions.collect {
       case (fqn -> SDKValue.SDKValueDefinition(definition: TypedDefinition))
-          if !containsTestCode(globals, fqn, definition, testNames) => fqn
+          if !containsTestCode( fqn, definition) => fqn
     }.toSet
 }

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/UnitTestingSpec.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/UnitTestingSpec.scala
@@ -105,7 +105,7 @@ object UnitTestingSpec extends MorphirBaseSpec {
         test("Coverage is calculated") {
           getTestSummary.map { result =>
             assertTrue(result.coverageCounts == CoverageCounts(
-              covered = 2,
+              covered = 11,
               uncovered = 0
             ))
           }
@@ -179,7 +179,7 @@ object UnitTestingSpec extends MorphirBaseSpec {
         test("Coverage is calculated") {
           getTestSummary.map { result =>
             assertTrue(result.coverageCounts == CoverageCounts(
-              covered = 2,
+              covered = 11,
               uncovered = 0
             ))
           }
@@ -200,7 +200,7 @@ object UnitTestingSpec extends MorphirBaseSpec {
       test("Project coverage is calculated") {
         getTestSummary.map { result =>
           assertTrue(result.coverageCounts == CoverageCounts(
-            covered = 1,
+            covered = 3,
             uncovered = 1
           ))
         }
@@ -220,7 +220,7 @@ object UnitTestingSpec extends MorphirBaseSpec {
       test("Project coverage is calculated") {
         getTestSummary.map { result =>
           assertTrue(result.coverageCounts == CoverageCounts(
-            covered = 1,
+            covered = 3,
             uncovered = 1
           ))
         }


### PR DESCRIPTION
This function is used in calculating code coverage. The old implementation only worked if you separated your tests from your code. However, some repos co-locate files so the coverage was off.