### PR TITLE
Add CodeLocation to most Morphir errors

### DIFF
--- a/morphir/runtime/src/org/finos/morphir/runtime/MorphirRuntime.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/MorphirRuntime.scala
@@ -38,7 +38,10 @@ trait MorphirRuntime {
       params: Value[TypeAttribs, ValueAttribs]*
   ): RTAction[MorphirEnv, TypeError, Value[TypeAttribs, ValueAttribs]]
   def evaluate(entryPoint: FQName): RTAction[MorphirEnv, MorphirRuntimeError, Data]
-  def evaluate(value: Value[TypeAttribs, ValueAttribs], location: Option[CodeLocation] = None): RTAction[MorphirEnv, MorphirRuntimeError, Data]
+  def evaluate(
+      value: Value[TypeAttribs, ValueAttribs],
+      location: Option[CodeLocation] = None
+  ): RTAction[MorphirEnv, MorphirRuntimeError, Data]
 
 }
 

--- a/morphir/runtime/src/org/finos/morphir/runtime/MorphirRuntime.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/MorphirRuntime.scala
@@ -38,7 +38,7 @@ trait MorphirRuntime {
       params: Value[TypeAttribs, ValueAttribs]*
   ): RTAction[MorphirEnv, TypeError, Value[TypeAttribs, ValueAttribs]]
   def evaluate(entryPoint: FQName): RTAction[MorphirEnv, MorphirRuntimeError, Data]
-  def evaluate(value: Value[TypeAttribs, ValueAttribs]): RTAction[MorphirEnv, MorphirRuntimeError, Data]
+  def evaluate(value: Value[TypeAttribs, ValueAttribs], location: Option[CodeLocation] = None): RTAction[MorphirEnv, MorphirRuntimeError, Data]
 
 }
 

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -198,7 +198,7 @@ final class TypeChecker(dists: Distributions, location: Option[CodeLocation] = N
         List(
           UnknownTypeMismatch(valueOther, declaredOther, location = location)
         )
-      case (valueOther, declaredOther) => List(new TypesMismatch(valueOther, declaredOther, "Different types of type"))
+      case (valueOther, declaredOther) => List(TypesMismatch(valueOther, declaredOther, "Different types of type", location = location))
     }
   }
 
@@ -529,7 +529,7 @@ final class TypeChecker(dists: Distributions, location: Option[CodeLocation] = N
             case Some(found) => conformsTo(field._2.attributes, found, context)
           }
         }
-      case other => List(new ImproperType(other, "Record type expected"))
+      case other => List(ImproperType(other, "Record type expected", location = location))
     }
     fromChildren ++ fromTpe
   }

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -42,7 +42,7 @@ object TypeChecker {
 }
 
 //TODO: This is final because references to ValueDefinition are private, and thus letDefinition and letRecursion handlers cannot be overridden. There may be a better way to handle this.
-final class TypeChecker(dists: Distributions) {
+final class TypeChecker(dists: Distributions, location: Option[CodeLocation] = None) {
   import TypeChecker.*
   private val dealiased = new Extractors.Types.Dealiased(dists)
   // TODO: Use or remove
@@ -69,7 +69,7 @@ final class TypeChecker(dists: Distributions) {
       context: Context
   ) = // Maybe that should be in context?
     if (argList.size != paramList.size)
-      List(new ArgNumberMismatch(argList.size, paramList.size, s"${context.prefix} : Different arities: "))
+      List(ArgNumberMismatch(argList.size, paramList.size, s"${context.prefix} : Different arities: ", location = location))
     else
       argList.zip(paramList).flatMap { case (arg, param) => conformsTo(arg, param, context) }
 
@@ -109,9 +109,9 @@ final class TypeChecker(dists: Distributions) {
             case Left(lookupErr) =>
               original_fqn match {
                 case Some(original) =>
-                  Left(new CannotDealias(lookupErr, s"Unable to dealias (nested beneath $original"))
+                  Left(CannotDealias(lookupErr, s"Unable to dealias (nested beneath $original", location = location))
                 case None =>
-                  Left(new CannotDealias(lookupErr))
+                  Left(CannotDealias(lookupErr, location = location))
               }
           }
         case other => Right(other)
@@ -196,7 +196,7 @@ final class TypeChecker(dists: Distributions) {
         if (left == right) List() else List(TypesMismatch(left, right, "Value type does not match declared type"))
       case (valueOther, declaredOther) if valueOther.getClass == declaredOther.getClass =>
         List(
-          new UnknownTypeMismatch(valueOther, declaredOther)
+          UnknownTypeMismatch(valueOther, declaredOther, location = location)
         )
       case (valueOther, declaredOther) => List(new TypesMismatch(valueOther, declaredOther, "Different types of type"))
     }
@@ -246,7 +246,7 @@ final class TypeChecker(dists: Distributions) {
       case (WholeNumberLiteral(_), IntRef()) => List() // TODO: "WholeNumberRef" extractor
       case (DecimalLiteral(_), DecimalRef()) => List()
       case (_, Type.Variable(_, _))          => List() // TODO: Type variable handling
-      case (otherLit, otherTpe)              => List(new LiteralTypeMismatch(otherLit, otherTpe))
+      case (otherLit, otherTpe)              => List(LiteralTypeMismatch(otherLit, otherTpe, location = location))
     }
     fromChildren ++ matchErrors
   }
@@ -267,7 +267,7 @@ final class TypeChecker(dists: Distributions) {
             tpe,
             context
           ) // TODO: Useful context lost here
-        case Right(_)  => List(new ApplyToNonFunction(node, function, argument))
+        case Right(_)  => List(ApplyToNonFunction(node, function, argument, location = location))
         case Left(err) => List(err)
       }
     fromChildren ++ fromTpe
@@ -300,7 +300,7 @@ final class TypeChecker(dists: Distributions) {
                 val newBindings = typeParams.toList.zip(typeArgs.toList).toMap
                 val missedName = helper(
                   fqn.packagePath != name.packagePath || fqn.modulePath != name.modulePath,
-                  new OtherTypeError(s"Constructor $fqn does not match type name $name")
+                  OtherTypeError(s"Constructor $fqn does not match type name $name", location = location)
                 )
                 val fromCtor = ctors.toMap.get(fqn.localName) match {
                   case Some(ctorArgs) =>
@@ -311,14 +311,15 @@ final class TypeChecker(dists: Distributions) {
                     )
                   case None =>
                     List(
-                      new OtherTypeError(
-                        s"Constructor type $name exists, but does not have arm for ${fqn.localName.toCamelCase}"
+                      OtherTypeError(
+                        s"Constructor type $name exists, but does not have arm for ${fqn.localName.toCamelCase}",
+                        location = location
                       )
                     )
                 }
                 missedName ++ fromCtor
               case Right(other) =>
-                List(new ImproperTypeDef(name, other, s"Type union expected"))
+                List(ImproperTypeDef(name, other, s"Type union expected", location = location))
               case Left(err) =>
                 List(err.withContext(s"Needed looking for implicit constructor ${fqn.toStringTitleCase}"))
             }
@@ -334,7 +335,8 @@ final class TypeChecker(dists: Distributions) {
               case Right(other) => List(ImproperTypeDef(
                   fqn,
                   other,
-                  s"I think this is an implicit record constructor because the return type is a record, but the function points to something else"
+                  s"I think this is an implicit record constructor because the return type is a record, but the function points to something else",
+                  location = location
                 ))
               case Left(err) =>
                 List(err.withContext(s"Needed looking for implicit constructor ${fqn.toStringTitleCase}"))
@@ -343,7 +345,7 @@ final class TypeChecker(dists: Distributions) {
 
           case NativeRef(_, _) => List() // TODO: check native constructor calls
           case other =>
-            List(new ImproperType(other, s"Reference to type union or implicit record constructor expected"))
+            List(ImproperType(other, s"Reference to type union or implicit record constructor expected", location = location))
         }
     }
   }
@@ -352,10 +354,10 @@ final class TypeChecker(dists: Distributions) {
     val fromTpe = dealias(recordValue.attributes, context) match {
       case Right(rTpe @ Type.Record(_, fields)) =>
         fields.map(field => field.name -> field.data).toMap.get(name) match {
-          case None           => List(new TypeLacksField(rTpe, name, "Referenced by field node"))
+          case None           => List(TypeLacksField(rTpe, name, "Referenced by field node", location = location))
           case Some(fieldTpe) => conformsTo(fieldTpe, tpe, context)
         }
-      case Right(other) => List(new ImproperType(other, s"Record type expected"))
+      case Right(other) => List(ImproperType(other, s"Record type expected", location = location))
       case Left(err)    => List(err)
     }
     fromChildren ++ fromTpe
@@ -364,7 +366,7 @@ final class TypeChecker(dists: Distributions) {
     val fromChildren = List()
     val fromTpe = tpe match {
       case Type.Function(_, _, _) => List()
-      case other                  => List(new ImproperType(other, "Field function should be function:"))
+      case other                  => List(ImproperType(other, "Field function should be function:", location = location))
     }
     // TODO: tpe should be... function from extensible record type to ???
     fromChildren ++ fromTpe
@@ -389,7 +391,7 @@ final class TypeChecker(dists: Distributions) {
     val fromTpe = tpe match {
       case Type.Function(_, arg, ret) =>
         conformsTo(ret, body.attributes, context) ++ conformsTo(pattern.attributes, arg, context)
-      case other => List(new ImproperType(other, "Field function should be function:"))
+      case other => List(ImproperType(other, "Field function should be function:", location = location))
     }
     // TODO: Check tpe's argument matches (strictly) with pattern
     // TODO: Figure out variable bindings
@@ -435,7 +437,7 @@ final class TypeChecker(dists: Distributions) {
             ) // Check each element vs. the declared element type (only keep first errors)
           }
         }
-      case other => List(ImproperType(other, s"Expected list"))
+      case other => List(ImproperType(other, s"Expected list", location = location))
     }
     fromChildren ++ fromTpe
   }
@@ -480,7 +482,7 @@ final class TypeChecker(dists: Distributions) {
           conformsTo(valFieldMap(name).attributes, tpeFieldMap(name), context)
         )
         missingFromTpe ++ missingFromValue ++ conflicts
-      case other => List(ImproperType(other, "Value is of type Record"))
+      case other => List(ImproperType(other, "Value is of type Record", location = location))
     }
     fromChildren ++ fromTpe
   }
@@ -504,7 +506,7 @@ final class TypeChecker(dists: Distributions) {
     val fromTpe = tpe match {
       case Type.Tuple(_, elementTypes) =>
         checkList(elements.map(_.attributes), elementTypes.toList, context)
-      case other => List(new ImproperType(other, "Tuple expected"))
+      case other => List(ImproperType(other, "Tuple expected", location = location))
     }
     val fromChildren = elements.flatMap(check(_, context))
     fromChildren ++ fromTpe
@@ -523,7 +525,7 @@ final class TypeChecker(dists: Distributions) {
         val fieldMap = tpeFields.map(field => field.name -> field.data).toMap
         conformsTo(valueToUpdate.attributes, tpe) ++ fields.flatMap { field =>
           fieldMap.get(field._1) match {
-            case None        => List(TypeLacksField(tpe, field._1, "Tried to update record field which is not present"))
+            case None        => List(TypeLacksField(tpe, field._1, "Tried to update record field which is not present", location = location))
             case Some(found) => conformsTo(field._2.attributes, found, context)
           }
         }

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypeChecker.scala
@@ -69,7 +69,12 @@ final class TypeChecker(dists: Distributions, location: Option[CodeLocation] = N
       context: Context
   ) = // Maybe that should be in context?
     if (argList.size != paramList.size)
-      List(ArgNumberMismatch(argList.size, paramList.size, s"${context.prefix} : Different arities: ", location = location))
+      List(ArgNumberMismatch(
+        argList.size,
+        paramList.size,
+        s"${context.prefix} : Different arities: ",
+        location = location
+      ))
     else
       argList.zip(paramList).flatMap { case (arg, param) => conformsTo(arg, param, context) }
 
@@ -198,7 +203,8 @@ final class TypeChecker(dists: Distributions, location: Option[CodeLocation] = N
         List(
           UnknownTypeMismatch(valueOther, declaredOther, location = location)
         )
-      case (valueOther, declaredOther) => List(TypesMismatch(valueOther, declaredOther, "Different types of type", location = location))
+      case (valueOther, declaredOther) =>
+        List(TypesMismatch(valueOther, declaredOther, "Different types of type", location = location))
     }
   }
 
@@ -345,7 +351,11 @@ final class TypeChecker(dists: Distributions, location: Option[CodeLocation] = N
 
           case NativeRef(_, _) => List() // TODO: check native constructor calls
           case other =>
-            List(ImproperType(other, s"Reference to type union or implicit record constructor expected", location = location))
+            List(ImproperType(
+              other,
+              s"Reference to type union or implicit record constructor expected",
+              location = location
+            ))
         }
     }
   }
@@ -366,7 +376,7 @@ final class TypeChecker(dists: Distributions, location: Option[CodeLocation] = N
     val fromChildren = List()
     val fromTpe = tpe match {
       case Type.Function(_, _, _) => List()
-      case other                  => List(ImproperType(other, "Field function should be function:", location = location))
+      case other => List(ImproperType(other, "Field function should be function:", location = location))
     }
     // TODO: tpe should be... function from extensible record type to ???
     fromChildren ++ fromTpe
@@ -525,7 +535,12 @@ final class TypeChecker(dists: Distributions, location: Option[CodeLocation] = N
         val fieldMap = tpeFields.map(field => field.name -> field.data).toMap
         conformsTo(valueToUpdate.attributes, tpe) ++ fields.flatMap { field =>
           fieldMap.get(field._1) match {
-            case None        => List(TypeLacksField(tpe, field._1, "Tried to update record field which is not present", location = location))
+            case None => List(TypeLacksField(
+                tpe,
+                field._1,
+                "Tried to update record field which is not present",
+                location = location
+              ))
             case Some(found) => conformsTo(field._2.attributes, found, context)
           }
         }

--- a/morphir/runtime/src/org/finos/morphir/runtime/TypedMorphirRuntime.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/TypedMorphirRuntime.scala
@@ -1,15 +1,16 @@
 package org.finos.morphir.runtime
 
-import org.finos.morphir.naming._
+import org.finos.morphir.naming.*
 import org.finos.morphir.ir.Type.UType
 import org.finos.morphir.ir.Value.Value
-import org.finos.morphir.ir.{Value => V}
+import org.finos.morphir.ir.Value as V
 import org.finos.morphir.datamodel.Data
 import Utils.*
 import org.finos.morphir.ir.distribution.Distribution
 import org.finos.morphir.ir.conversion.*
 import org.finos.morphir.datamodel.Util.*
 import org.finos.morphir.datamodel.*
+import org.finos.morphir.runtime.CodeLocation.TopLevelFunction
 import org.finos.morphir.runtime.environment.MorphirEnv
 import org.finos.morphir.runtime.exports.*
 

--- a/morphir/runtime/src/org/finos/morphir/runtime/Utils.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/Utils.scala
@@ -150,14 +150,13 @@ object Utils {
     val example = FQName.fromString("Morphir.SDK:Basics:equal")
     fqn.getPackagePath == example.getPackagePath
   }
-  
-  def fqnToCodeLocation(fqn: FQName): CodeLocation = {
+
+  def fqnToCodeLocation(fqn: FQName): CodeLocation =
     if (isNative(fqn)) {
       CodeLocation.NativeFunction(fqn)
     } else {
       CodeLocation.TopLevelFunction(fqn)
     }
-  }
 
   def curryTypeFunction(inner: UType, params: Chunk[(Name, UType)]): UType =
     params match {

--- a/morphir/runtime/src/org/finos/morphir/runtime/Utils.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/Utils.scala
@@ -1,22 +1,22 @@
 package org.finos.morphir.runtime
 
-import org.finos.morphir.naming._
-import org.finos.morphir.ir.{Type => T, Value => V}
-import org.finos.morphir.ir.Value.{Value, Pattern, TypedValue, USpecification => UValueSpec}
-import org.finos.morphir.ir.Type.{Field, Type, UType, USpecification => UTypeSpec}
+import org.finos.morphir.naming.*
+import org.finos.morphir.ir.{Type as T, Value as V}
+import org.finos.morphir.ir.Value.{Pattern, TypedValue, Value, USpecification as UValueSpec}
+import org.finos.morphir.ir.Type.{Field, Type, UType, USpecification as UTypeSpec}
 import org.finos.morphir.ir.sdk
 import org.finos.morphir.ir.sdk.Basics
 import org.finos.morphir.runtime.exports.*
-import org.finos.morphir.ir.Module.{Specification => ModSpec}
+import org.finos.morphir.ir.Module.Specification as ModSpec
 import zio.Chunk
 import org.finos.morphir.ir.sdk.Basics
 import org.finos.morphir.ir.sdk
-import org.finos.morphir.ir.Value.{USpecification => UValueSpec, Definition => ValueDefinition}
-import org.finos.morphir.ir.Type.{USpecification => UTypeSpec}
-
+import org.finos.morphir.ir.Value.{Definition as ValueDefinition, USpecification as UValueSpec}
+import org.finos.morphir.ir.Type.USpecification as UTypeSpec
 import org.finos.morphir.ir.printing.{DetailLevel, PrintIR}
 import org.finos.morphir.runtime.MorphirRuntimeError.*
 import TypeError.*
+import org.finos.morphir.runtime.CodeLocation.TopLevelFunction
 
 object Utils {
   import Extractors.Types.*
@@ -149,6 +149,14 @@ object Utils {
   def isNative(fqn: FQName): Boolean = {
     val example = FQName.fromString("Morphir.SDK:Basics:equal")
     fqn.getPackagePath == example.getPackagePath
+  }
+  
+  def fqnToCodeLocation(fqn: FQName): CodeLocation = {
+    if (isNative(fqn)) {
+      CodeLocation.NativeFunction(fqn)
+    } else {
+      CodeLocation.TopLevelFunction(fqn)
+    }
   }
 
   def curryTypeFunction(inner: UType, params: Chunk[(Name, UType)]): UType =

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Loop.scala
@@ -130,7 +130,7 @@ private[morphir] case class Loop(globals: GlobalDefs) extends InvokeableEvaluato
             RTValue.DefinitionFunction(body, tail, curried :+ (name -> argValue), closingContext, loc)
           case Nil =>
             throw InvalidState(
-              "Tried to apply definition function with no un-applied arguments (should not exist)", 
+              "Tried to apply definition function with no un-applied arguments (should not exist)",
               location = Some(loc),
               function
             )
@@ -154,7 +154,7 @@ private[morphir] case class Loop(globals: GlobalDefs) extends InvokeableEvaluato
           case head :: tail => RTValue.ImplicitConstructorFunction(name, tail, curried ++ Map(head.name -> argValue))
           case Nil =>
             throw InvalidState(
-              "Tried to apply to implicit constructor function with no arguments (should not exist)", 
+              "Tried to apply to implicit constructor function with no arguments (should not exist)",
               location = None,
               function
             )
@@ -305,13 +305,13 @@ private[morphir] case class LoopFrame(globals: GlobalDefs, codeLocation: CodeLoc
       case record @ RTValue.Record(fields) =>
         fields.getOrElse(
           fieldName,
-          throw MissingField(record, fieldName,  location = Some(codeLocation))
+          throw MissingField(record, fieldName, location = Some(codeLocation))
         )
       case other => throw UnexpectedType(
           "Record",
           other,
           hint = s"Expected because I tried to access .${fieldName.toCamelCase}",
-        location = Some(codeLocation)
+          location = Some(codeLocation)
         )
     }
 
@@ -331,8 +331,8 @@ private[morphir] case class LoopFrame(globals: GlobalDefs, codeLocation: CodeLoc
           "Boolean",
           other,
           hint = "Expected because I found this in the condition of an if statement",
-        location = Some(codeLocation)
-    )
+          location = Some(codeLocation)
+        )
     }
 
   def handleLambda(
@@ -452,7 +452,12 @@ private[morphir] case class LoopFrame(globals: GlobalDefs, codeLocation: CodeLoc
         val newFields = fields.map { case (name, value) => name -> loop(value, store) }
         RTValue.Record(oldFields ++ newFields)
       case other =>
-        throw UnexpectedType("Record", other, hint = "Expected because I found this in an update record node", location = Some(codeLocation))
+        throw UnexpectedType(
+          "Record",
+          other,
+          hint = "Expected because I found this in an update record node",
+          location = Some(codeLocation)
+        )
     }
 
   def handleVariable(va: UType, name: Name, store: Store) =

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/Native.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/Native.scala
@@ -212,7 +212,7 @@ object BasicsSDK {
         RTValue.List(aElements.appendedAll(bElements))
       case (RTValue.Primitive.String(a), RTValue.Primitive.String(b)) => RTValue.Primitive.String(a + b)
       case (other1, other2) =>
-        throw new WrongArgumentTypes(s"Append must be called on two Lists or two Strings", other1, other2)
+        throw WrongArgumentTypes(s"Append must be called on two Lists or two Strings", other1, other2)
     }
   )
   val sdk: Map[FQName, SDKValue] = Map(

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/QuickMorphirRuntime.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/QuickMorphirRuntime.scala
@@ -40,7 +40,10 @@ private[runtime] case class QuickMorphirRuntime(dists: Distributions, globals: G
         .mapError(err => TopLevelError(entryPoint, dists.getDists, err))
     } yield res
 
-  def evaluate(value: TypedValue, location: Option[CodeLocation] = None): RTAction[MorphirEnv, MorphirRuntimeError, Data] =
+  def evaluate(
+      value: TypedValue,
+      location: Option[CodeLocation] = None
+  ): RTAction[MorphirEnv, MorphirRuntimeError, Data] =
     for {
       _   <- typeCheck(value, location)
       res <- EvaluatorQuick.evalAction(value, globals, dists)

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/QuickMorphirRuntime.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/QuickMorphirRuntime.scala
@@ -40,15 +40,15 @@ private[runtime] case class QuickMorphirRuntime(dists: Distributions, globals: G
         .mapError(err => TopLevelError(entryPoint, dists.getDists, err))
     } yield res
 
-  def evaluate(value: TypedValue): RTAction[MorphirEnv, MorphirRuntimeError, Data] =
+  def evaluate(value: TypedValue, location: Option[CodeLocation] = None): RTAction[MorphirEnv, MorphirRuntimeError, Data] =
     for {
-      _   <- typeCheck(value)
+      _   <- typeCheck(value, location)
       res <- EvaluatorQuick.evalAction(value, globals, dists)
     } yield res
 
   def evaluate(entryPoint: FQName): RTAction[MorphirEnv, MorphirRuntimeError, Data] = for {
     tpe <- fetchType(entryPoint)
-    res <- evaluate(Value.Reference.Typed(tpe, entryPoint))
+    res <- evaluate(Value.Reference.Typed(tpe, entryPoint), location = Some(fqnToCodeLocation(entryPoint)))
   } yield res
 
   def fetchType(fqn: FQName): RTAction[MorphirEnv, MorphirRuntimeError, UType] = {
@@ -59,16 +59,16 @@ private[runtime] case class QuickMorphirRuntime(dists: Distributions, globals: G
     }
   }
 
-  def typeCheck(value: TypedValue): RTAction[MorphirEnv, TypeError, Unit] = for {
+  def typeCheck(value: TypedValue, location: Option[CodeLocation]): RTAction[MorphirEnv, TypeError, Unit] = for {
     ctx <- ZPure.get[RTExecutionContext]
     result <- ctx.options.enableTyper match {
       case EnableTyper.Disabled => RTAction.succeed[RTExecutionContext, Unit](())
       case EnableTyper.Warn =>
-        val errors = new TypeChecker(dists).check(value)
+        val errors = new TypeChecker(dists, location).check(value)
         errors.foreach(error => println(s"TYPE WARNING: $error"))
         RTAction.succeed[RTExecutionContext, Unit](())
       case EnableTyper.Enabled =>
-        val errors = new TypeChecker(dists).check(value)
+        val errors = new TypeChecker(dists, location).check(value)
         if (errors.length == 0) RTAction.succeed[RTExecutionContext, Unit](())
         else if (errors.length == 1) RTAction.fail(errors(0))
         else RTAction.fail(TypeError.ManyTypeErrors(errors))

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/testing/UnitTesting.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/testing/UnitTesting.scala
@@ -107,11 +107,11 @@ object UnitTesting {
           RTAction.succeed(detailedReport)
         // If the results were different, something went wrong in our test framework - it either hid an error, or created one that didn't exist in the simple pass
         else if (detailedReport.passed && (!simplePassed))
-          throw new InvalidState(s"""Detailed Test Report passed, but simple morphir-based testing failed.
-          Detailed:  $detailedReport""")
+          throw InvalidState(s"""Detailed Test Report passed, but simple morphir-based testing failed.
+          Detailed:  $detailedReport""", location = None)
         else
-          throw new InvalidState(s"""Detailed Test Report found failures, but simple morphir-based testing passed.
-          Detailed:  $detailedReport""")
+          throw InvalidState(s"""Detailed Test Report found failures, but simple morphir-based testing passed.
+          Detailed:  $detailedReport""", location = None)
       }
     }
   }

--- a/morphir/runtime/src/org/finos/morphir/runtime/quick/testing/UnitTesting.scala
+++ b/morphir/runtime/src/org/finos/morphir/runtime/quick/testing/UnitTesting.scala
@@ -107,11 +107,17 @@ object UnitTesting {
           RTAction.succeed(detailedReport)
         // If the results were different, something went wrong in our test framework - it either hid an error, or created one that didn't exist in the simple pass
         else if (detailedReport.passed && (!simplePassed))
-          throw InvalidState(s"""Detailed Test Report passed, but simple morphir-based testing failed.
-          Detailed:  $detailedReport""", location = None)
+          throw InvalidState(
+            s"""Detailed Test Report passed, but simple morphir-based testing failed.
+          Detailed:  $detailedReport""",
+            location = None
+          )
         else
-          throw InvalidState(s"""Detailed Test Report found failures, but simple morphir-based testing passed.
-          Detailed:  $detailedReport""", location = None)
+          throw InvalidState(
+            s"""Detailed Test Report found failures, but simple morphir-based testing passed.
+          Detailed:  $detailedReport""",
+            location = None
+          )
       }
     }
   }

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -3627,15 +3627,15 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
         },
         testExceptionMultiple("MissingDefinition Test")("exceptionTests", "notARealFunction", List(Data.Unit)) {
           case LookupError.MissingDefinition(_, _, _, _, _) => assertTrue(true)
-          case _                                         => assertNever("Unexpected exception type was thrown")
+          case _                                            => assertNever("Unexpected exception type was thrown")
         },
         testExceptionMultiple("MissingModule Test")("notARealModule", "notARealFunction", List(Data.Unit)) {
           case LookupError.MissingModule(_, _, _, _) => assertTrue(true)
-          case _                                  => assertNever("Unexpected exception type was thrown")
+          case _                                     => assertNever("Unexpected exception type was thrown")
         },
         testExceptionMultiple("MissingPackage Test")("", "", List(Data.Unit)) {
           case LookupError.MissingPackage(_, _, _) => assertTrue(true)
-          case _                                => assertNever("Unexpected exception type was thrown")
+          case _                                   => assertNever("Unexpected exception type was thrown")
         },
         testExceptionMultiple("ImproperType Test")(
           "exceptionTests",

--- a/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
+++ b/morphir/runtime/test/jvm/src/org/finos/morphir/runtime/EvaluatorMDMTests.scala
@@ -3626,15 +3626,15 @@ object EvaluatorMDMTests extends MorphirBaseSpec {
           case _ => assertNever(s"Unexpected exception type was thrown")
         },
         testExceptionMultiple("MissingDefinition Test")("exceptionTests", "notARealFunction", List(Data.Unit)) {
-          case LookupError.MissingDefinition(_, _, _, _) => assertTrue(true)
+          case LookupError.MissingDefinition(_, _, _, _, _) => assertTrue(true)
           case _                                         => assertNever("Unexpected exception type was thrown")
         },
         testExceptionMultiple("MissingModule Test")("notARealModule", "notARealFunction", List(Data.Unit)) {
-          case LookupError.MissingModule(_, _, _) => assertTrue(true)
+          case LookupError.MissingModule(_, _, _, _) => assertTrue(true)
           case _                                  => assertNever("Unexpected exception type was thrown")
         },
         testExceptionMultiple("MissingPackage Test")("", "", List(Data.Unit)) {
-          case LookupError.MissingPackage(_, _) => assertTrue(true)
+          case LookupError.MissingPackage(_, _, _) => assertTrue(true)
           case _                                => assertNever("Unexpected exception type was thrown")
         },
         testExceptionMultiple("ImproperType Test")(

--- a/morphir/src/org/finos/morphir/runtime/MorphirRuntimeError.scala
+++ b/morphir/src/org/finos/morphir/runtime/MorphirRuntimeError.scala
@@ -39,8 +39,6 @@ object MorphirRuntimeError {
       else err"$cause: $l"
     }
   }
-  
-  
 
   final case class TopLevelError(
       entryPoint: FQName,
@@ -103,60 +101,85 @@ object MorphirRuntimeError {
       if (!stack.isEmpty) this // Only include the detailed error at the top of the stack
       else sourceTaggedUntagged match {
         case Some((tagged, untagged)) if countMatches(untagged, code) == 1 =>
-            val newTagged   = code.replace(untagged, tagged)
-            val newUntagged = code
-            this.copy(sourceTaggedUntagged = Some((newTagged, newUntagged)))
+          val newTagged   = code.replace(untagged, tagged)
+          val newUntagged = code
+          this.copy(sourceTaggedUntagged = Some((newTagged, newUntagged)))
         case _ =>
           this.copy(sourceTaggedUntagged =
             Some((s">>>$code<<<", code))
           ) // We don't know exactly where the error is, so we'll just tag the whole thing
       }
     }
-    
+
     val location: Option[CodeLocation] = stack.headOption
   }
 
-  final case class ExternalError(error: Throwable, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation {
+  final case class ExternalError(error: Throwable, location: Option[CodeLocation] = None) extends EvaluationError
+      with AttachedLocation {
     def message = s"External error: ${error.getMessage}"
   }
 
-  final case class MissingField(value: RTValue.Record, field: Name, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation {
+  final case class MissingField(value: RTValue.Record, field: Name, location: Option[CodeLocation] = None)
+      extends EvaluationError with AttachedLocation {
     def message = err"Record $value does not contain field ${field.toCamelCase}"
   }
 
-  final case class UnexpectedType(expected: String, found: RTValue, hint: String = "", location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation {
+  final case class UnexpectedType(
+      expected: String,
+      found: RTValue,
+      hint: String = "",
+      location: Option[CodeLocation] = None
+  ) extends EvaluationError with AttachedLocation {
     def message = err"Expected $expected but found $found. ${if (hint != "") "Hint: " + hint else ""}"
   }
-  final case class UnexpectedTypeWithIR(expected: String, found: RTValue, ir: TypedValue, hint: String = "", location: Option[CodeLocation] = None)
-      extends EvaluationError with AttachedLocation {
+  final case class UnexpectedTypeWithIR(
+      expected: String,
+      found: RTValue,
+      ir: TypedValue,
+      hint: String = "",
+      location: Option[CodeLocation] = None
+  ) extends EvaluationError with AttachedLocation {
     def message = err"Expected $expected but found $found from IR $ir. ${if (hint != "") "Hint: " + hint else ""}"
   }
-  final case class FailedCoercion(message: String, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation
+  final case class FailedCoercion(message: String, location: Option[CodeLocation] = None) extends EvaluationError
+      with AttachedLocation
 
-  final case class IllegalValue(cause: String, context: String = "", location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation {
+  final case class IllegalValue(cause: String, context: String = "", location: Option[CodeLocation] = None)
+      extends EvaluationError with AttachedLocation {
     def message                         = s"$cause . $context"
     def withContext(newContext: String) = this.copy(context = context + "\n" + newContext)
   }
 
-  final case class WrongNumberOfArguments(function: RTValue.NativeFunctionResult, applied: Int, location: Option[CodeLocation] = None)
-      extends EvaluationError with AttachedLocation {
+  final case class WrongNumberOfArguments(
+      function: RTValue.NativeFunctionResult,
+      applied: Int,
+      location: Option[CodeLocation] = None
+  ) extends EvaluationError with AttachedLocation {
     def message =
       err"Applied wrong number of args. Needed ${function.arguments} args but got $applied when applying the function $function}"
   }
 
-  final case class UnmatchedPattern(value: RTValue, node: Any, location: Option[CodeLocation], patterns: Pattern[UType]*) extends EvaluationError with AttachedLocation {
+  final case class UnmatchedPattern(
+      value: RTValue,
+      node: Any,
+      location: Option[CodeLocation],
+      patterns: Pattern[UType]*
+  ) extends EvaluationError with AttachedLocation {
     def message = err"Failed to match $value to any pattern from $patterns in node $node"
   }
 
-  final case class VariableNotFound(name: Name, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation {
+  final case class VariableNotFound(name: Name, location: Option[CodeLocation] = None) extends EvaluationError
+      with AttachedLocation {
     def message = err"Variable ${name.toCamelCase} not found in store."
   }
 
   // TODO: Message definition should live in this class, but requires visibility of Utils functions not present here.
   // TODO: Ideally these would fall under "Lookup Errors", but they do not come from the Distributions packet or equivalent structure
-  final case class DefinitionNotFound(message: String, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation
+  final case class DefinitionNotFound(message: String, location: Option[CodeLocation] = None) extends EvaluationError
+      with AttachedLocation
 
-  final case class ConstructorNotFound(message: String, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation
+  final case class ConstructorNotFound(message: String, location: Option[CodeLocation] = None) extends EvaluationError
+      with AttachedLocation
 
   final case class WrongArgumentTypes(msg: String, args: RTValue*) extends EvaluationError {
     def message = args.toList match {
@@ -167,21 +190,26 @@ object MorphirRuntimeError {
     }
   }
 
-  final case class VariableAccessError(message: String, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation
+  final case class VariableAccessError(message: String, location: Option[CodeLocation] = None) extends EvaluationError
+      with AttachedLocation
 
-  final case class UnsupportedType(tpe: UType, reason: String, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation {
+  final case class UnsupportedType(tpe: UType, reason: String, location: Option[CodeLocation] = None)
+      extends EvaluationError with AttachedLocation {
     def message = err"Type $tpe not supported. $reason"
   }
 
-  final case class UnsupportedTypeSpecification(spec: UTypeSpec, reason: String, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation {
+  final case class UnsupportedTypeSpecification(spec: UTypeSpec, reason: String, location: Option[CodeLocation] = None)
+      extends EvaluationError with AttachedLocation {
     def message = err"Type Specification $spec not supported. $reason"
   }
 
-  final case class UnsupportedTypeDefinition(spec: UTypeDef, reason: String, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation {
+  final case class UnsupportedTypeDefinition(spec: UTypeDef, reason: String, location: Option[CodeLocation] = None)
+      extends EvaluationError with AttachedLocation {
     def message = err"Type Definition $spec not supported. $reason"
   }
 
-  final case class InvalidState(context: String, location: Option[CodeLocation], vals: RTValue*) extends EvaluationError with AttachedLocation {
+  final case class InvalidState(context: String, location: Option[CodeLocation], vals: RTValue*) extends EvaluationError
+      with AttachedLocation {
     def message =
       if (vals.length == 0) err"$context (This should not be reachable, and indicates an evaluator bug.)"
       else if (vals.length == 1)
@@ -190,7 +218,8 @@ object MorphirRuntimeError {
         err"$context ${vals(0)}, ${vals(1)} (This should not be reachable, and indicates an evaluator bug.)"
       else err"$context $vals (This should not be reachable, and indicates an evaluator bug.)"
   }
-  final case class NotImplemented(message: String, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation
+  final case class NotImplemented(message: String, location: Option[CodeLocation] = None) extends EvaluationError
+      with AttachedLocation
 
   // LookupErrors are a generic form of error that can occur at different points
   sealed trait LookupError extends EvaluationError with TypeError {
@@ -198,26 +227,41 @@ object MorphirRuntimeError {
     def withContext(newContext: String): LookupError
   }
   object LookupError {
-    case class MissingPackage(pkgName: PackageName, context: String = "", location: Option[CodeLocation] = None) extends LookupError {
+    case class MissingPackage(pkgName: PackageName, context: String = "", location: Option[CodeLocation] = None)
+        extends LookupError {
       def message                         = s"Package ${pkgName.toString} not found. $context"
       def withContext(newContext: String) = this.copy(context = context + "\n" + newContext)
     }
-    case class MissingModule(pkgName: PackageName, modName: ModuleName, context: String = "", location: Option[CodeLocation] = None)
-        extends LookupError {
+    case class MissingModule(
+        pkgName: PackageName,
+        modName: ModuleName,
+        context: String = "",
+        location: Option[CodeLocation] = None
+    ) extends LookupError {
       def message = s"Package ${pkgName.toString} does not contain module ${modName.toString}. $context"
 
       def withContext(newContext: String) = this.copy(context = context + "\n" + newContext)
     }
 
-    case class MissingType(pkgName: PackageName, modName: ModuleName, typeName: Name, context: String = "", location: Option[CodeLocation] = None)
-        extends LookupError {
+    case class MissingType(
+        pkgName: PackageName,
+        modName: ModuleName,
+        typeName: Name,
+        context: String = "",
+        location: Option[CodeLocation] = None
+    ) extends LookupError {
       def message =
         (s"Module ${pkgName.toString}:${modName.toString} has no type named ${typeName.toTitleCase}. $context")
 
       def withContext(newContext: String) = this.copy(context = context + "\n" + newContext)
     }
-    case class MissingDefinition(pkgName: PackageName, modName: ModuleName, defName: Name, context: String = "", location: Option[CodeLocation] = None)
-        extends LookupError {
+    case class MissingDefinition(
+        pkgName: PackageName,
+        modName: ModuleName,
+        defName: Name,
+        context: String = "",
+        location: Option[CodeLocation] = None
+    ) extends LookupError {
       def message =
         s"Module ${pkgName.toString}:${modName.toString} has no definition named ${defName.toCamelCase}. $context"
 
@@ -227,12 +271,17 @@ object MorphirRuntimeError {
 
   sealed trait RTValueToMDMError extends MorphirRuntimeError with AttachedLocation
   object RTValueToMDMError {
-    final case class MissingField(value: RTValue.Record, field: Label, location: Option[CodeLocation] = None) extends RTValueToMDMError {
+    final case class MissingField(value: RTValue.Record, field: Label, location: Option[CodeLocation] = None)
+        extends RTValueToMDMError {
       def message = err"Record $value appeared in result without expected field $field"
     }
 
-    final case class ResultTypeMismatch(result: RTValue, concept: Concept, explanation: String, location: Option[CodeLocation] = None)
-        extends EvaluationError {
+    final case class ResultTypeMismatch(
+        result: RTValue,
+        concept: Concept,
+        explanation: String,
+        location: Option[CodeLocation] = None
+    ) extends EvaluationError {
       def message =
         err"""Result $result cannot be matched to type $concept. $explanation.
              (This type was derived from the entry point. These may be nested within broader result/type trees.""".stripMargin
@@ -246,8 +295,12 @@ object MorphirRuntimeError {
         extends TypeError {
       def message = (err"$msg: $tpe1 vs $tpe2")
     }
-    final case class ApplyToNonFunction(applyNode: TypedValue, nonFunction: TypedValue, arg: TypedValue, location: Option[CodeLocation] = None)
-        extends TypeError {
+    final case class ApplyToNonFunction(
+        applyNode: TypedValue,
+        nonFunction: TypedValue,
+        arg: TypedValue,
+        location: Option[CodeLocation] = None
+    ) extends TypeError {
       def message =
         err"$applyNode tried to apply $arg to $nonFunction of type ${nonFunction.attributes}, which is not a function"
     }
@@ -256,34 +309,57 @@ object MorphirRuntimeError {
         extends TypeError {
       def message = err"Literal $lit is not of type $tpe"
     }
-    final case class ImproperType(tpe: UType, explanation: String, location: Option[CodeLocation] = None) extends TypeError {
+    final case class ImproperType(tpe: UType, explanation: String, location: Option[CodeLocation] = None)
+        extends TypeError {
       def message = (err"Improper Type: $explanation. Found: $tpe")
     }
-    final case class ImproperTypeSpec(fqn: FQName, spec: UTypeSpec, explanation: String, location: Option[CodeLocation] = None)
-        extends TypeError {
+    final case class ImproperTypeSpec(
+        fqn: FQName,
+        spec: UTypeSpec,
+        explanation: String,
+        location: Option[CodeLocation] = None
+    ) extends TypeError {
       def message = err"Improper Type Specification found: $explanation. $fqn points to: $spec"
     }
-    final case class ImproperTypeDef(fqn: FQName, defn: UTypeDef, explanation: String, location: Option[CodeLocation] = None)
-        extends TypeError {
+    final case class ImproperTypeDef(
+        fqn: FQName,
+        defn: UTypeDef,
+        explanation: String,
+        location: Option[CodeLocation] = None
+    ) extends TypeError {
       def message = err"Improper Type Definition found: $explanation. $fqn points to: $defn"
     }
-    final case class CannotDealias(err: LookupError, xplanation: String = "Cannot dealias type", location: Option[CodeLocation] = None)
-        extends TypeError {
+    final case class CannotDealias(
+        err: LookupError,
+        xplanation: String = "Cannot dealias type",
+        location: Option[CodeLocation] = None
+    ) extends TypeError {
       def message = err"$xplanation: ${err.message}"
     }
     final case class TypeLacksField(tpe: UType, field: Name, msg: String, location: Option[CodeLocation] = None)
         extends TypeError {
       def message = err"$tpe lacks field <${field.toCamelCase}>. $msg"
     }
-    final case class TypeHasExtraField(tpe: UType, contract: UType, field: Name, location: Option[CodeLocation] = None) extends TypeError {
+    final case class TypeHasExtraField(tpe: UType, contract: UType, field: Name, location: Option[CodeLocation] = None)
+        extends TypeError {
       def message = err"$tpe has field <${field.toCamelCase}>, which is not included in $contract"
     }
 
-    final case class ValueLacksField(value: TypedValue, contract: UType, field: Name, location: Option[CodeLocation] = None) extends TypeError {
+    final case class ValueLacksField(
+        value: TypedValue,
+        contract: UType,
+        field: Name,
+        location: Option[CodeLocation] = None
+    ) extends TypeError {
       def message = err"$value lacks field <${field.toCamelCase}>, which is required by $contract"
     }
 
-    final case class ValueHasExtraField(value: TypedValue, contract: UType, field: Name, location: Option[CodeLocation] = None) extends TypeError {
+    final case class ValueHasExtraField(
+        value: TypedValue,
+        contract: UType,
+        field: Name,
+        location: Option[CodeLocation] = None
+    ) extends TypeError {
       def message = err"$value has field <${field.toCamelCase}>, which is not included in $contract"
     }
 
@@ -296,27 +372,38 @@ object MorphirRuntimeError {
     //  ) extends TypeError(
     //        s"tpe for field ${field.toCamelCase} is ${succinct(firstTpe)} in ${succinct(first)} but ${succinct(secondTpe)} in ${succinct(second)}"
     //      )
-    
+
     class SizeMismatch(first: Int, second: Int, msg: String, val location: Option[CodeLocation] = None)
         extends TypeError {
       def message = err"$msg: ($first vs $second)"
     }
-    
-    final case class ArgNumberMismatch(first: Int, second: Int, msg: String, override val location: Option[CodeLocation] = None)
-        extends SizeMismatch(first: Int, second: Int, msg: String, location)
 
-    final case class InferenceConflict(older: UType, newer: UType, name: Name, location: Option[CodeLocation] = None) extends TypeError {
+    final case class ArgNumberMismatch(
+        first: Int,
+        second: Int,
+        msg: String,
+        override val location: Option[CodeLocation] = None
+    ) extends SizeMismatch(first: Int, second: Int, msg: String, location)
+
+    final case class InferenceConflict(older: UType, newer: UType, name: Name, location: Option[CodeLocation] = None)
+        extends TypeError {
       def message =
         err"While trying to bind the type variables of the entry point function, the input matched type variable ${name
             .toCamelCase} with $older and then also $newer, which are not the same."
     }
 
-    final case class UnknownTypeMismatch(tpe1: UType, tpe2: UType, hint: String = "", location: Option[CodeLocation] = None) extends TypeError {
+    final case class UnknownTypeMismatch(
+        tpe1: UType,
+        tpe2: UType,
+        hint: String = "",
+        location: Option[CodeLocation] = None
+    ) extends TypeError {
       def message =
         err"Could not match $tpe1 to $tpe2, but it is unclear why. ${if (hint != "") "Hint: " + hint else ""}"
     }
 
-    final case class UnsupportedType(tpe: UType, hint: String = "", location: Option[CodeLocation] = None) extends TypeError {
+    final case class UnsupportedType(tpe: UType, hint: String = "", location: Option[CodeLocation] = None)
+        extends TypeError {
       def message = err"$tpe is not currently supported.  ${if (hint != "") "Hint: " + hint else ""}"
     }
     final case class OtherTypeError(message: String, location: Option[CodeLocation] = None) extends TypeError

--- a/morphir/src/org/finos/morphir/runtime/MorphirRuntimeError.scala
+++ b/morphir/src/org/finos/morphir/runtime/MorphirRuntimeError.scala
@@ -19,8 +19,12 @@ import scala.collection.immutable.{AbstractSeq, LinearSeq}
 
 sealed trait MorphirRuntimeError extends Throwable {
   def message: String
-  override def getMessage = message
 
+  override def getMessage = message
+}
+
+sealed trait AttachedLocation {
+  def location: Option[CodeLocation]
 }
 
 object MorphirRuntimeError {
@@ -36,6 +40,8 @@ object MorphirRuntimeError {
       else err"$cause: $l"
     }
   }
+  
+  
 
   final case class TopLevelError(
       entryPoint: FQName,
@@ -97,65 +103,59 @@ object MorphirRuntimeError {
       def countMatches(inner: String, outer: String) = outer.sliding(inner.length).count(_ == inner)
       if (!stack.isEmpty) this // Only include the detailed error at the top of the stack
       else sourceTaggedUntagged match {
-        case Some((tagged, untagged)) =>
-          if (countMatches(untagged, code) == 1) { // If we can tell where in the broader source the error came from, we can keep that specificity
+        case Some((tagged, untagged)) if countMatches(untagged, code) == 1 =>
             val newTagged   = code.replace(untagged, tagged)
             val newUntagged = code
             this.copy(sourceTaggedUntagged = Some((newTagged, newUntagged)))
-          } else {
-            this.copy(sourceTaggedUntagged =
-              Some((s">>>$code<<<", code))
-            ) // We don't know exactly where the error is, so we'll just tag the whole thing
-          }
-        case None =>
+        case _ =>
           this.copy(sourceTaggedUntagged =
             Some((s">>>$code<<<", code))
-          ) // This shouldn't be reachable, but here for completeness
+          ) // We don't know exactly where the error is, so we'll just tag the whole thing
       }
     }
   }
 
-  final case class ExternalError(error: Throwable) extends EvaluationError {
+  final case class ExternalError(error: Throwable, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation {
     def message = s"External error: ${error.getMessage}"
   }
 
-  final case class MissingField(value: RTValue.Record, field: Name) extends EvaluationError {
+  final case class MissingField(value: RTValue.Record, field: Name, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation {
     def message = err"Record $value does not contain field ${field.toCamelCase}"
   }
 
-  final case class UnexpectedType(expected: String, found: RTValue, hint: String = "") extends EvaluationError {
+  final case class UnexpectedType(expected: String, found: RTValue, hint: String = "", location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation {
     def message = err"Expected $expected but found $found. ${if (hint != "") "Hint: " + hint else ""}"
   }
-  final case class UnexpectedTypeWithIR(expected: String, found: RTValue, ir: TypedValue, hint: String = "")
-      extends EvaluationError {
+  final case class UnexpectedTypeWithIR(expected: String, found: RTValue, ir: TypedValue, hint: String = "", location: Option[CodeLocation] = None)
+      extends EvaluationError with AttachedLocation {
     def message = err"Expected $expected but found $found from IR $ir. ${if (hint != "") "Hint: " + hint else ""}"
   }
-  final case class FailedCoercion(message: String) extends EvaluationError
+  final case class FailedCoercion(message: String, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation
 
-  final case class IllegalValue(cause: String, context: String = "") extends EvaluationError {
+  final case class IllegalValue(cause: String, context: String = "", location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation {
     def message                         = s"$cause . $context"
     def withContext(newContext: String) = this.copy(context = context + "\n" + newContext)
   }
 
-  final case class WrongNumberOfArguments(function: RTValue.NativeFunctionResult, applied: Int)
-      extends EvaluationError {
+  final case class WrongNumberOfArguments(function: RTValue.NativeFunctionResult, applied: Int, location: Option[CodeLocation] = None)
+      extends EvaluationError with AttachedLocation {
     def message =
       err"Applied wrong number of args. Needed ${function.arguments} args but got $applied when applying the function $function}"
   }
 
-  final case class UnmatchedPattern(value: RTValue, node: Any, patterns: Pattern[UType]*) extends EvaluationError {
+  final case class UnmatchedPattern(value: RTValue, node: Any, location: Option[CodeLocation], patterns: Pattern[UType]*) extends EvaluationError with AttachedLocation {
     def message = err"Failed to match $value to any pattern from $patterns in node $node"
   }
 
-  final case class VariableNotFound(name: Name) extends EvaluationError {
+  final case class VariableNotFound(name: Name, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation {
     def message = err"Variable ${name.toCamelCase} not found in store."
   }
 
   // TODO: Message definition should live in this class, but requires visibility of Utils functions not present here.
   // TODO: Ideally these would fall under "Lookup Errors", but they do not come from the Distributions packet or equivalent structure
-  final case class DefinitionNotFound(message: String) extends EvaluationError
+  final case class DefinitionNotFound(message: String, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation
 
-  final case class ConstructorNotFound(message: String) extends EvaluationError
+  final case class ConstructorNotFound(message: String, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation
 
   final case class WrongArgumentTypes(msg: String, args: RTValue*) extends EvaluationError {
     def message = args.toList match {
@@ -166,21 +166,21 @@ object MorphirRuntimeError {
     }
   }
 
-  final case class VariableAccessError(message: String) extends EvaluationError
+  final case class VariableAccessError(message: String, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation
 
-  final case class UnsupportedType(tpe: UType, reason: String) extends EvaluationError {
+  final case class UnsupportedType(tpe: UType, reason: String, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation {
     def message = err"Type $tpe not supported. $reason"
   }
 
-  final case class UnsupportedTypeSpecification(spec: UTypeSpec, reason: String) extends EvaluationError {
+  final case class UnsupportedTypeSpecification(spec: UTypeSpec, reason: String, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation {
     def message = err"Type Specification $spec not supported. $reason"
   }
 
-  final case class UnsupportedTypeDefinition(spec: UTypeDef, reason: String) extends EvaluationError {
+  final case class UnsupportedTypeDefinition(spec: UTypeDef, reason: String, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation {
     def message = err"Type Definition $spec not supported. $reason"
   }
 
-  final case class InvalidState(context: String, vals: RTValue*) extends EvaluationError {
+  final case class InvalidState(context: String, location: Option[CodeLocation], vals: RTValue*) extends EvaluationError with AttachedLocation {
     def message =
       if (vals.length == 0) err"$context (This should not be reachable, and indicates an evaluator bug.)"
       else if (vals.length == 1)
@@ -189,7 +189,7 @@ object MorphirRuntimeError {
         err"$context ${vals(0)}, ${vals(1)} (This should not be reachable, and indicates an evaluator bug.)"
       else err"$context $vals (This should not be reachable, and indicates an evaluator bug.)"
   }
-  final case class NotImplemented(message: String) extends EvaluationError
+  final case class NotImplemented(message: String, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation
 
   // LookupErrors are a generic form of error that can occur at different points
   sealed trait LookupError extends EvaluationError with TypeError {
@@ -197,25 +197,25 @@ object MorphirRuntimeError {
     def withContext(newContext: String): LookupError
   }
   object LookupError {
-    case class MissingPackage(pkgName: PackageName, context: String = "") extends LookupError {
+    case class MissingPackage(pkgName: PackageName, context: String = "", location: Option[CodeLocation] = None) extends LookupError {
       def message                         = s"Package ${pkgName.toString} not found. $context"
       def withContext(newContext: String) = this.copy(context = context + "\n" + newContext)
     }
-    case class MissingModule(pkgName: PackageName, modName: ModuleName, context: String = "")
+    case class MissingModule(pkgName: PackageName, modName: ModuleName, context: String = "", location: Option[CodeLocation] = None)
         extends LookupError {
       def message = s"Package ${pkgName.toString} does not contain module ${modName.toString}. $context"
 
       def withContext(newContext: String) = this.copy(context = context + "\n" + newContext)
     }
 
-    case class MissingType(pkgName: PackageName, modName: ModuleName, typeName: Name, context: String = "")
+    case class MissingType(pkgName: PackageName, modName: ModuleName, typeName: Name, context: String = "", location: Option[CodeLocation] = None)
         extends LookupError {
       def message =
         (s"Module ${pkgName.toString}:${modName.toString} has no type named ${typeName.toTitleCase}. $context")
 
       def withContext(newContext: String) = this.copy(context = context + "\n" + newContext)
     }
-    case class MissingDefinition(pkgName: PackageName, modName: ModuleName, defName: Name, context: String = "")
+    case class MissingDefinition(pkgName: PackageName, modName: ModuleName, defName: Name, context: String = "", location: Option[CodeLocation] = None)
         extends LookupError {
       def message =
         s"Module ${pkgName.toString}:${modName.toString} has no definition named ${defName.toCamelCase}. $context"
@@ -224,13 +224,13 @@ object MorphirRuntimeError {
     }
   }
 
-  sealed trait RTValueToMDMError extends MorphirRuntimeError
+  sealed trait RTValueToMDMError extends MorphirRuntimeError with AttachedLocation
   object RTValueToMDMError {
-    final case class MissingField(value: RTValue.Record, field: Label) extends RTValueToMDMError {
+    final case class MissingField(value: RTValue.Record, field: Label, location: Option[CodeLocation] = None) extends RTValueToMDMError {
       def message = err"Record $value appeared in result without expected field $field"
     }
 
-    final case class ResultTypeMismatch(result: RTValue, concept: Concept, explanation: String)
+    final case class ResultTypeMismatch(result: RTValue, concept: Concept, explanation: String, location: Option[CodeLocation] = None)
         extends EvaluationError {
       def message =
         err"""Result $result cannot be matched to type $concept. $explanation.
@@ -238,51 +238,51 @@ object MorphirRuntimeError {
     }
   }
 
-  sealed trait TypeError extends MorphirRuntimeError
+  sealed trait TypeError extends MorphirRuntimeError with AttachedLocation
   object TypeError {
 
-    final case class TypesMismatch(tpe1: UType, tpe2: UType, msg: String)
+    final case class TypesMismatch(tpe1: UType, tpe2: UType, msg: String, location: Option[CodeLocation] = None)
         extends TypeError {
       def message = (err"$msg: $tpe1 vs $tpe2")
     }
-    final case class ApplyToNonFunction(applyNode: TypedValue, nonFunction: TypedValue, arg: TypedValue)
+    final case class ApplyToNonFunction(applyNode: TypedValue, nonFunction: TypedValue, arg: TypedValue, location: Option[CodeLocation] = None)
         extends TypeError {
       def message =
         err"$applyNode tried to apply $arg to $nonFunction of type ${nonFunction.attributes}, which is not a function"
     }
 
-    final case class LiteralTypeMismatch(lit: Lit, tpe: UType)
+    final case class LiteralTypeMismatch(lit: Lit, tpe: UType, location: Option[CodeLocation] = None)
         extends TypeError {
       def message = err"Literal $lit is not of type $tpe"
     }
-    final case class ImproperType(tpe: UType, explanation: String) extends TypeError {
+    final case class ImproperType(tpe: UType, explanation: String, location: Option[CodeLocation] = None) extends TypeError {
       def message = (err"Improper Type: $explanation. Found: $tpe")
     }
-    final case class ImproperTypeSpec(fqn: FQName, spec: UTypeSpec, explanation: String)
+    final case class ImproperTypeSpec(fqn: FQName, spec: UTypeSpec, explanation: String, location: Option[CodeLocation] = None)
         extends TypeError {
       def message = err"Improper Type Specification found: $explanation. $fqn points to: $spec"
     }
-    final case class ImproperTypeDef(fqn: FQName, defn: UTypeDef, explanation: String)
+    final case class ImproperTypeDef(fqn: FQName, defn: UTypeDef, explanation: String, location: Option[CodeLocation] = None)
         extends TypeError {
       def message = err"Improper Type Definition found: $explanation. $fqn points to: $defn"
     }
-    final case class CannotDealias(err: LookupError, xplanation: String = "Cannot dealias type")
+    final case class CannotDealias(err: LookupError, xplanation: String = "Cannot dealias type", location: Option[CodeLocation] = None)
         extends TypeError {
       def message = err"$xplanation: ${err.message}"
     }
-    final case class TypeLacksField(tpe: UType, field: Name, msg: String)
+    final case class TypeLacksField(tpe: UType, field: Name, msg: String, location: Option[CodeLocation] = None)
         extends TypeError {
       def message = err"$tpe lacks field <${field.toCamelCase}>. $msg"
     }
-    final case class TypeHasExtraField(tpe: UType, contract: UType, field: Name) extends TypeError {
+    final case class TypeHasExtraField(tpe: UType, contract: UType, field: Name, location: Option[CodeLocation] = None) extends TypeError {
       def message = err"$tpe has field <${field.toCamelCase}>, which is not included in $contract"
     }
 
-    final case class ValueLacksField(value: TypedValue, contract: UType, field: Name) extends TypeError {
+    final case class ValueLacksField(value: TypedValue, contract: UType, field: Name, location: Option[CodeLocation] = None) extends TypeError {
       def message = err"$value lacks field <${field.toCamelCase}>, which is required by $contract"
     }
 
-    final case class ValueHasExtraField(value: TypedValue, contract: UType, field: Name) extends TypeError {
+    final case class ValueHasExtraField(value: TypedValue, contract: UType, field: Name, location: Option[CodeLocation] = None) extends TypeError {
       def message = err"$value has field <${field.toCamelCase}>, which is not included in $contract"
     }
 
@@ -295,31 +295,34 @@ object MorphirRuntimeError {
     //  ) extends TypeError(
     //        s"tpe for field ${field.toCamelCase} is ${succinct(firstTpe)} in ${succinct(first)} but ${succinct(secondTpe)} in ${succinct(second)}"
     //      )
-    class SizeMismatch(first: Int, second: Int, msg: String)
+    
+    class SizeMismatch(first: Int, second: Int, msg: String, val location: Option[CodeLocation] = None)
         extends TypeError {
       def message = err"$msg: ($first vs $second)"
     }
-    final case class ArgNumberMismatch(first: Int, second: Int, msg: String)
-        extends SizeMismatch(first: Int, second: Int, msg: String)
+    
+    final case class ArgNumberMismatch(first: Int, second: Int, msg: String, override val location: Option[CodeLocation] = None)
+        extends SizeMismatch(first: Int, second: Int, msg: String, location)
 
-    final case class InferenceConflict(older: UType, newer: UType, name: Name) extends TypeError {
+    final case class InferenceConflict(older: UType, newer: UType, name: Name, location: Option[CodeLocation] = None) extends TypeError {
       def message =
         err"While trying to bind the type variables of the entry point function, the input matched type variable ${name
             .toCamelCase} with $older and then also $newer, which are not the same."
     }
 
-    final case class UnknownTypeMismatch(tpe1: UType, tpe2: UType, hint: String = "") extends TypeError {
+    final case class UnknownTypeMismatch(tpe1: UType, tpe2: UType, hint: String = "", location: Option[CodeLocation] = None) extends TypeError {
       def message =
         err"Could not match $tpe1 to $tpe2, but it is unclear why. ${if (hint != "") "Hint: " + hint else ""}"
     }
 
-    final case class UnsupportedType(tpe: UType, hint: String = "") extends TypeError {
+    final case class UnsupportedType(tpe: UType, hint: String = "", location: Option[CodeLocation] = None) extends TypeError {
       def message = err"$tpe is not currently supported.  ${if (hint != "") "Hint: " + hint else ""}"
     }
-    final case class OtherTypeError(message: String) extends TypeError
+    final case class OtherTypeError(message: String, location: Option[CodeLocation] = None) extends TypeError
 
     final case class ManyTypeErrors(errors: List[TypeError])
         extends TypeError {
+      val location = None
       def message = ("\n" + errors.map(err =>
         s"""
              |${err.getClass.getName.split(".").lastOption.getOrElse(err.getClass.getName)}:

--- a/morphir/src/org/finos/morphir/runtime/MorphirRuntimeError.scala
+++ b/morphir/src/org/finos/morphir/runtime/MorphirRuntimeError.scala
@@ -1,7 +1,6 @@
 package org.finos.morphir.runtime
 
 import org.finos.morphir.naming.*
-import org.finos.morphir.naming.*
 import org.finos.morphir.ir.{Type as T, Value as V}
 import org.finos.morphir.ir.Value.{Pattern, TypedValue, Value, USpecification as UValueSpec}
 import org.finos.morphir.ir.Type.{Field, Type, UType, USpecification as UTypeSpec, UDefinition as UTypeDef}
@@ -78,7 +77,7 @@ object MorphirRuntimeError {
       inner: EvaluationError,
       stack: List[CodeLocation],
       sourceTaggedUntagged: Option[(String, String)]
-  ) extends EvaluationError {
+  ) extends EvaluationError with AttachedLocation {
     def message = {
       val sourceString = sourceTaggedUntagged match {
         case Some((tagged, _)) => s"Thrown from: $tagged\n\t"
@@ -113,6 +112,8 @@ object MorphirRuntimeError {
           ) // We don't know exactly where the error is, so we'll just tag the whole thing
       }
     }
+    
+    val location: Option[CodeLocation] = stack.headOption
   }
 
   final case class ExternalError(error: Throwable, location: Option[CodeLocation] = None) extends EvaluationError with AttachedLocation {


### PR DESCRIPTION
This code breaks out the CodeLocation into the individual errors themselves. This unfortunately does not yet allow for the elimination of the TopLevelError, but it gets everything closer to eliminating it. In most scenarios, CodeLocation should be available, but there are spots where no obvious location maps to the error. As such, making the CodeLocation option seems sensable. Also, given a stack of CodeLocations, only the top of the stack will be considered the "location" for the purpose of AttachedLocation.