### PR TITLE
ci: switch dependency-graph workflow to Eleven19 fork

### DIFF
--- a/.github/workflows/github-dependency-graph.yml
+++ b/.github/workflows/github-dependency-graph.yml
@@ -22,8 +22,10 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      # We want to see the transmitted graph in the logs
-      - run:  ./mill --import ivy:io.chris-kipp::mill-github-dependency-graph::0.2.5 showNamed io.kipp.mill.github.dependency.graph.Graph/generate
-
-      # Actually upload the graph
-      - uses: ckipp01/mill-dependency-submission@v1
+      # Generate and submit the dependency graph to GitHub's Dependency Submission API.
+      # Uses the Eleven19 fork of mill-github-dependency-graph (the original
+      # ckipp01/mill-github-dependency-graph is archived and does not support Mill 1.x).
+      - name: Submit dependency graph
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./mill io.eleven19.mill.github.dependency.graph.Graph/submit

--- a/build.mill
+++ b/build.mill
@@ -3,6 +3,7 @@
 //| - com.lihaoyi::mill-contrib-scoverage:$MILL_VERSION
 //| - com.carlosedp::mill-aliases::1.1.0
 //| - com.github.lolgab::mill-mima::0.2.0
+//| - io.eleven19.mill-github-dependency-graph::mill-github-dependency-graph:0.0.2
 
 package build
 


### PR DESCRIPTION
## Summary

The original [`ckipp01/mill-github-dependency-graph`](https://github.com/ckipp01/mill-github-dependency-graph) plugin is archived and does not support Mill 1.x. Since the [Mill 1.1.5 upgrade (#883)](https://github.com/finos/morphir-scala/pull/883), the `dependency-graph` workflow has been failing on every push to `main`.

This PR switches to [`Eleven19/mill-github-dependency-graph`](https://github.com/Eleven19/mill-github-dependency-graph) `0.0.2`, a maintained derivative work that supports Mill 1.x. The 0.0.2 release also contains the fix for Mill 1.x exclusive-command semantics required for `Graph/{generate,submit}` to run under Mill 1.1.5 — see [Eleven19/mill-github-dependency-graph#1](https://github.com/Eleven19/mill-github-dependency-graph/pull/1).

## Changes

- [`build.mill`](build.mill): declare the plugin in the `//| mvnDeps:` header
- [`.github/workflows/github-dependency-graph.yml`](.github/workflows/github-dependency-graph.yml): replace the archived `./mill --import ivy:…` + `ckipp01/mill-dependency-submission@v1` pair with a single `./mill … Graph/submit` step (the fork's `submit` task generates and uploads the snapshot in one go)

## Local verification

`./mill showNamed io.eleven19.mill.github.dependency.graph.Graph/generate` produces a valid Dependency Submission manifest covering **40 modules / 532 package URLs** across the repo (JVM/JS/scoverage variants, test modules, etc.).

## Test plan

- [ ] CI passes
- [ ] Once merged, verify the `dependency-graph` workflow run on `main` completes green and the GitHub Insights → Dependency graph updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)