### PR TITLE
fix(ci): stop hashing `out` into the build-cache keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,12 @@ jobs:
         with:
           path: |
             out/morphir/**/js/
-          key: ${{ runner.os }}-mill-js-${{matrix.java}}-${{ github.sha}}-${{ hashFiles('out') }}
+          # The commit already identifies the output; the key does not hash `out`.
+          # `hashFiles('out')` follows the symlinks Mill leaves there — `out/mill-home`
+          # points at $HOME and `out/mill-daemon/mill-workspace` back at the repo root —
+          # so it walks the whole runner home and a cyclical path, taking minutes when it
+          # works and failing the job outright when it hits an unreadable file or the cycle.
+          key: ${{ runner.os }}-mill-js-${{matrix.java}}-${{ github.sha }}
 
   # Scala Native is currently scoped to the langkit and kit modules ported from
   # krueger. It gets its own job rather than riding along with test-jvm because
@@ -194,7 +199,8 @@ jobs:
           path: |
             out/morphir/**/jvm/
             out/morphir/build/
-          key: ${{ runner.os }}-mill-jvm-${{matrix.java}}-${{ github.sha }}-${{ hashFiles('out') }}
+          # See the JS job: the key deliberately does not hash `out`.
+          key: ${{ runner.os }}-mill-jvm-${{matrix.java}}-${{ github.sha }}
 
   publish:
     # when in master repo: all commits to main branch and all additional tags
@@ -247,16 +253,14 @@ jobs:
         with:
           path: |
             out/morphir/**/jvm/
-          key: ${{ runner.os }}-mill-jvm-25-${{ github.sha }}-${{ hashFiles('out') }}
-          restore-keys: ${{ runner.os }}-mill-jvm-25-${{ github.sha }}-
+          key: ${{ runner.os }}-mill-jvm-25-${{ github.sha }}
 
       - name: Restore JS Build Output From Cache
         uses: actions/cache/restore@v6
         with:
           path: |
             out/morphir/**/js/
-          key: ${{ runner.os }}-mill-js-25-${{ github.sha }}-${{ hashFiles('out') }}
-          restore-keys: ${{ runner.os }}-mill-js-25-${{ github.sha }}-
+          key: ${{ runner.os }}-mill-js-25-${{ github.sha }}
 
       - name: Release
         env:


### PR DESCRIPTION
The `Cache JVM build output` step failed on the last push to main, after the tests themselves had passed ([run 30322229733](https://github.com/finos/morphir-scala/actions/runs/30322229733/job/90160299266)):

```
The template is not valid. .github/workflows/ci.yml (Line: 197, Col: 16): hashFiles('out') failed.
Fail to hash files under directory '/home/runner/work/morphir-scala/morphir-scala'
```

## Cause

`hashFiles` follows symlinks, and Mill plants two in `out` that lead straight out of it:

- `out/mill-home` → `$HOME`
- `out/mill-daemon/mill-workspace` → the repository root

So `hashFiles('out')` walked the whole runner home directory and a cyclical path, rather than the build output it was meant to fingerprint. It has been doing that for a while: on the last green main run the step sat between "JVM tests completed successfully" at 14:06:10 and "Cache saved" at 14:12:35 — six and a half minutes of hashing, and the reason that job took 12m4s against this one's 7m1s.

Whether the traversal survives depends on what happens to be under `$HOME` at that moment, which is why the identical step passed on the preceding commit and failed on this one.

## Fix

The hash bought nothing to begin with — `github.sha` already identifies the output being saved — so the keys keep the sha and drop the hash. The restore side in `publish` then matches the save key exactly, and the `restore-keys` prefixes it needed to fall back on go away with it. Main runs get those six minutes back.