### PR TITLE
feat(elm): carry port/effect module metadata through lowering

### DIFF
--- a/morphir/langkit/elm/conformance.html
+++ b/morphir/langkit/elm/conformance.html
@@ -120,7 +120,7 @@
   <tbody>
     <tr><td class="mono">G1</td><td>GLSL blocks — <code>CstGlsl</code> modelled but never produced</td><td>W7</td><td><code>StructuralSpec</code></td></tr>
     <tr><td class="mono">G2</td><td>Astral code points in character literals</td><td>W7, by widening the CST node to a code point</td><td><code>LexicalSpec</code></td></tr>
-    <tr><td class="mono">G3</td><td><code>effect module … where { … }</code></td><td>W7</td><td><code>StructuralSpec</code></td></tr>
+    <tr><td class="mono">G3</td><td><code>effect module … where { … }</code></td><td>W7 at the CST, and lowering in <a href="https://github.com/finos/morphir-scala/issues/931">#931</a></td><td><code>StructuralSpec</code> for the CST; <code>CstLoweringSpec</code>, <code>AstVisitorSpec</code> and <code>lowering.feature</code> for <code>ast.Module.moduleType</code> and <code>ast.EffectManager</code></td></tr>
     <tr><td class="mono">G4</td><td>Tuple arity beyond three</td><td>W7</td><td><code>StructuralSpec</code></td></tr>
     <tr><td class="mono">G5</td><td>Expression continuation measured from the expression rather than its enclosing declaration</td><td>W5, by giving the parser Elm's indentation context</td><td><code>LayoutSpec</code>, and 26 real modules that now parse</td></tr>
     <tr><td class="mono">G7</td><td>No real-world package corpus</td><td>W8, by fetching four packages at build time</td><td><code>RealWorldCorpusTest</code> — 453 modules</td></tr>

--- a/morphir/langkit/elm/core/src/morphir/langkit/elm/ast/AstNodes.scala
+++ b/morphir/langkit/elm/core/src/morphir/langkit/elm/ast/AstNodes.scala
@@ -17,9 +17,27 @@ case class Module(
     exposing: ExposingList,
     imports: IndexedSeq[Import],
     declarations: IndexedSeq[Declaration],
-    docComment: Option[String] = None
+    docComment: Option[String] = None,
+    moduleType: ModuleType = ModuleType.Plain,
+    manager: Option[EffectManager] = None
 )(val span: Span)
     extends AstNode derives CanEqual
+
+/**
+ * The `where { command = …, subscription = … }` clause of an `effect module`, lowered.
+ *
+ * Mirror of [[morphir.langkit.elm.cst.CstEffectManager]], with the type names flattened to Strings as the AST does
+ * elsewhere. Elm requires at least one of the two, which is why both are optional.
+ */
+case class EffectManager(
+    command: Option[String],
+    subscription: Option[String]
+)(val span: Span)
+    extends AstNode derives CanEqual
+
+/** Whether the module is plain, a `port module`, or an `effect module`. */
+enum ModuleType derives CanEqual:
+  case Plain, Port, Effect
 
 case class QualifiedName(parts: List[String])(val span: Span) extends AstNode derives CanEqual:
   def fullName: String = parts.mkString(".")

--- a/morphir/langkit/elm/core/src/morphir/langkit/elm/ast/AstQueryableTree.scala
+++ b/morphir/langkit/elm/core/src/morphir/langkit/elm/ast/AstQueryableTree.scala
@@ -30,9 +30,11 @@ object AstQueryableTree:
       case n: Module =>
         Map(
           "exposing"     -> Seq(n.exposing),
+          "manager"      -> n.manager.toSeq,
           "imports"      -> n.imports.toSeq,
           "declarations" -> n.declarations.toSeq
         )
+      case _: EffectManager => Map.empty
       case _: QualifiedName => Map.empty
       case n: Import        =>
         Map("exposing" -> n.exposing.toSeq)

--- a/morphir/langkit/elm/core/src/morphir/langkit/elm/ast/AstVisitor.scala
+++ b/morphir/langkit/elm/core/src/morphir/langkit/elm/ast/AstVisitor.scala
@@ -18,6 +18,7 @@ trait AstVisitor[A]:
 
   // --- Module structure ---
   def visitModule(node: Module): A               = visitNode(node)
+  def visitEffectManager(node: EffectManager): A = visitNode(node)
   def visitQualifiedName(node: QualifiedName): A = visitNode(node)
   def visitImport(node: Import): A               = visitNode(node)
 
@@ -109,6 +110,7 @@ object AstVisitor:
   /** Dispatch a node to the appropriate visitor method. */
   def visit[A](node: AstNode, visitor: AstVisitor[A]): A = node match
     case n: Module                => visitor.visitModule(n)
+    case n: EffectManager         => visitor.visitEffectManager(n)
     case n: QualifiedName         => visitor.visitQualifiedName(n)
     case n: Import                => visitor.visitImport(n)
     case n: ExposingAll           => visitor.visitExposingAll(n)
@@ -172,7 +174,8 @@ object AstVisitor:
 
   /** Return the direct children of a node. */
   def children(node: AstNode): List[AstNode] = node match
-    case n: Module                => n.exposing :: n.imports.toList ::: n.declarations.toList
+    case n: Module                => n.exposing :: n.manager.toList ::: n.imports.toList ::: n.declarations.toList
+    case n: EffectManager         => Nil
     case n: QualifiedName         => Nil
     case n: Import                => n.exposing.toList
     case n: ExposingAll           => Nil

--- a/morphir/langkit/elm/core/src/morphir/langkit/elm/parser/CstLowering.scala
+++ b/morphir/langkit/elm/core/src/morphir/langkit/elm/parser/CstLowering.scala
@@ -16,8 +16,18 @@ object CstLowering:
       exposing = lowerExposingList(cst.moduleDecl.exposing),
       imports = cst.imports.map(lowerImport),
       declarations = cst.declarations.map(lowerDeclaration),
-      docComment = cst.trivia.docComment.map(_.text)
+      docComment = cst.trivia.docComment.map(_.text),
+      moduleType = lowerModuleType(cst.moduleDecl.moduleType),
+      manager = cst.moduleDecl.manager.map(lowerEffectManager)
     )(cst.span)
+
+  private def lowerModuleType(t: ModuleType): ast.ModuleType = t match
+    case ModuleType.Plain  => ast.ModuleType.Plain
+    case ModuleType.Port   => ast.ModuleType.Port
+    case ModuleType.Effect => ast.ModuleType.Effect
+
+  private def lowerEffectManager(cst: CstEffectManager): ast.EffectManager =
+    ast.EffectManager(cst.command.map(_.value), cst.subscription.map(_.value))(cst.span)
 
   private def lowerQualifiedName(cst: CstQualifiedName): ast.QualifiedName =
     ast.QualifiedName(cst.parts.map(_.value))(cst.span)

--- a/morphir/langkit/elm/core/test/src/morphir/langkit/elm/ast/AstQueryableTreeSpec.scala
+++ b/morphir/langkit/elm/core/test/src/morphir/langkit/elm/ast/AstQueryableTreeSpec.scala
@@ -26,6 +26,12 @@ class AstQueryableTreeSpec extends Test[Any]:
       |main = 42
       |""".stripMargin
 
+  private val effectSource =
+    """effect module Eff where { command = MyCmd, subscription = MySub } exposing (..)
+      |
+      |x = 1
+      |""".stripMargin
+
   private val moduleTree: Module         = parse(source)
   private val root: AstNode              = moduleTree
   private val qt: QueryableTree[AstNode] = summon[QueryableTree[AstNode]]
@@ -61,12 +67,22 @@ class AstQueryableTreeSpec extends Test[Any]:
         assert(fs(field("parameters")) == valueDecl.parameters.toSeq)
         assert(fs(field("typeAnnotation")) == valueDecl.typeAnnotation.toSeq)
       }
-      "Module exposes exposing, imports, declarations as fields" in {
+      "Module exposes exposing, manager, imports, declarations as fields" in {
         val fs = qt.fields(moduleTree)
-        assert(fs.keySet == Set(field("exposing"), field("imports"), field("declarations")))
+        assert(fs.keySet == Set(field("exposing"), field("manager"), field("imports"), field("declarations")))
         assert(fs(field("exposing")) == Seq(moduleTree.exposing))
+        assert(fs(field("manager")) == Seq.empty)
         assert(fs(field("imports")) == moduleTree.imports.toSeq)
         assert(fs(field("declarations")) == moduleTree.declarations.toSeq)
+      }
+      "an effect module's manager is both a field and a child" in {
+        val effect  = parse(effectSource)
+        val manager = effect.manager.getOrElse(throw new AssertionError("no effect manager"))
+        assert(typeNameOf(manager) == "EffectManager")
+        assert(qt.fields(effect)(field("manager")) == Seq(manager))
+        assert(qt.children(effect).contains(manager))
+        assert(qt.fields(manager).isEmpty)
+        assert(qt.children(manager).isEmpty)
       }
     }
     "text" - {

--- a/morphir/langkit/elm/core/test/src/morphir/langkit/elm/ast/AstUnistProjectionSpec.scala
+++ b/morphir/langkit/elm/core/test/src/morphir/langkit/elm/ast/AstUnistProjectionSpec.scala
@@ -26,8 +26,18 @@ class AstUnistProjectionSpec extends Test[Any]:
     "projects parsed AST root with type, fields, and child count" in {
       val node = UnistProjection.project(moduleTree, Some(source))
       assert(node.`type` == "Module")
-      assert(node.data.fields.keySet == Set("exposing", "imports", "declarations"))
+      assert(node.data.fields.keySet == Set("exposing", "manager", "imports", "declarations"))
       assert(node.data.childCount == node.children.size)
+    }
+    "projects an effect module's manager as a child node" in {
+      val effectSource =
+        """effect module Eff where { command = MyCmd, subscription = MySub } exposing (..)
+          |
+          |x = 1
+          |""".stripMargin
+      val effectTree: AstNode = parse(effectSource)
+      val node                = UnistProjection.project(effectTree, Some(effectSource))
+      assert(node.children.map(_.`type`).contains("EffectManager"))
     }
     "projects AST declaration and literal text values" in {
       val node   = UnistProjection.project(moduleTree, Some(source))

--- a/morphir/langkit/elm/core/test/src/morphir/langkit/elm/ast/AstVisitorSpec.scala
+++ b/morphir/langkit/elm/core/test/src/morphir/langkit/elm/ast/AstVisitorSpec.scala
@@ -22,12 +22,29 @@ class AstVisitorSpec extends Test[Any]:
 
   private val sampleAst: Module = CstLowering.lowerModule(sampleCst)
 
+  private val effectAst: Module =
+    CstLowering.lowerModule(
+      CstModule(
+        CstModuleDeclaration(
+          ModuleType.Effect,
+          cqn("Eff"),
+          CstExposingAll()(sp),
+          Some(CstEffectManager(Some(cn("MyCmd")), Some(cn("MySub")))(sp))
+        )(sp),
+        IndexedSeq.empty,
+        IndexedSeq.empty
+      )(sp)
+    )
+
   private class TagVisitor extends AstVisitor[String]:
     def visitNode(node: AstNode): String                         = "Node"
     override def visitQualifiedName(node: QualifiedName): String = s"QN(${node.fullName})"
     override def visitIntLiteral(node: IntLiteral): String       = s"Int(${node.value})"
     override def visitImport(node: Import): String               = s"Imp(${node.moduleName.fullName})"
     override def visitModule(node: Module): String               = s"Mod(${node.name.fullName})"
+
+    override def visitEffectManager(node: EffectManager): String =
+      s"Eff(${node.command.getOrElse("-")},${node.subscription.getOrElse("-")})"
 
   "AstVisitor" - {
     "dispatch" - {
@@ -46,6 +63,14 @@ class AstVisitorSpec extends Test[Any]:
       "children returns direct children of a module" in
         // Module's children are: exposing :: imports ::: declarations
         assert(AstVisitor.children(sampleAst).size == 2)
+      "children include an effect module's manager" in {
+        val managers = AstVisitor.children(effectAst).collect { case m: EffectManager => m }
+        assert(managers == List(EffectManager(Some("MyCmd"), Some("MySub"))(sp)))
+      }
+      "visit routes an effect manager to its visitor method" in {
+        val v = new TagVisitor
+        assert(AstVisitor.visit(effectAst.manager.get, v) == "Eff(MyCmd,MySub)")
+      }
       "count counts all lowered nodes" in
         // Module + ExposingAll + Import = 3
         assert(AstVisitor.count(sampleAst) == 3)

--- a/morphir/langkit/elm/core/test/src/morphir/langkit/elm/parser/CstLoweringSpec.scala
+++ b/morphir/langkit/elm/core/test/src/morphir/langkit/elm/parser/CstLoweringSpec.scala
@@ -62,6 +62,63 @@ class CstLoweringSpec extends Test[Any]:
       )(sp)
       assert(CstLowering.lowerModule(cst).name.fullName == "Http.Body")
     }
+    "lowerModule keeps plain, port, and effect modules distinguishable" in {
+      def lowered(moduleType: ModuleType, manager: Option[CstEffectManager]) =
+        CstLowering.lowerModule(
+          CstModule(
+            CstModuleDeclaration(moduleType, qn("M"), CstExposingAll()(sp), manager)(sp),
+            IndexedSeq.empty,
+            IndexedSeq.empty
+          )(sp)
+        )
+      val plain  = lowered(ModuleType.Plain, None)
+      val port   = lowered(ModuleType.Port, None)
+      val effect = lowered(ModuleType.Effect, Some(CstEffectManager(Some(n("MyCmd")), Some(n("MySub")))(sp)))
+      assert(plain.moduleType == ast.ModuleType.Plain)
+      assert(port.moduleType == ast.ModuleType.Port)
+      assert(effect.moduleType == ast.ModuleType.Effect)
+      assert(plain != port)
+      assert(port != effect)
+      assert(plain != effect)
+    }
+    "lowerModule carries the effect manager's command and subscription types" in {
+      val cst = CstModule(
+        CstModuleDeclaration(
+          ModuleType.Effect,
+          qn("Eff"),
+          CstExposingAll()(sp),
+          Some(CstEffectManager(Some(n("MyCmd")), Some(n("MySub")))(sp))
+        )(sp),
+        IndexedSeq.empty,
+        IndexedSeq.empty
+      )(sp)
+      val m = CstLowering.lowerModule(cst)
+      assert(m.manager == Some(ast.EffectManager(Some("MyCmd"), Some("MySub"))(sp)))
+    }
+    "lowerModule keeps a half-populated effect manager" in {
+      def lowered(manager: CstEffectManager) =
+        CstLowering
+          .lowerModule(
+            CstModule(
+              CstModuleDeclaration(ModuleType.Effect, qn("Eff"), CstExposingAll()(sp), Some(manager))(sp),
+              IndexedSeq.empty,
+              IndexedSeq.empty
+            )(sp)
+          )
+          .manager
+      assert(lowered(CstEffectManager(Some(n("MyCmd")), None)(sp)).flatMap(_.command) == Some("MyCmd"))
+      assert(lowered(CstEffectManager(Some(n("MyCmd")), None)(sp)).flatMap(_.subscription) == None)
+      assert(lowered(CstEffectManager(None, Some(n("MySub")))(sp)).flatMap(_.subscription) == Some("MySub"))
+      assert(lowered(CstEffectManager(None, Some(n("MySub")))(sp)).flatMap(_.command) == None)
+    }
+    "lowerModule leaves a plain module without a manager" in {
+      val cst = CstModule(
+        CstModuleDeclaration(ModuleType.Plain, qn("M"), CstExposingAll()(sp))(sp),
+        IndexedSeq.empty,
+        IndexedSeq.empty
+      )(sp)
+      assert(CstLowering.lowerModule(cst).manager.isEmpty)
+    }
     "lowerPattern strips CstParenthesizedPattern" in {
       val inner   = CstVariablePattern(n("x"))(sp)
       val wrapped = CstParenthesizedPattern(inner)(sp)

--- a/morphir/langkit/itest/resources/features/lowering.feature
+++ b/morphir/langkit/itest/resources/features/lowering.feature
@@ -41,3 +41,37 @@ Feature: CST to AST lowering
     When the source is parsed to an AST
     Then AST declaration 1 is a value named "foo"
     And AST value "foo" has a type annotation
+
+  Scenario: Lowering keeps a plain module plain
+    Given the Elm source:
+      """
+      module M exposing (..)
+
+      x = 1
+      """
+    When the source is parsed to an AST
+    Then the AST module is plain
+    And the AST module has no effect manager
+
+  Scenario: Lowering carries the port module header
+    Given the Elm source:
+      """
+      port module Ports exposing (..)
+
+      x = 1
+      """
+    When the source is parsed to an AST
+    Then the AST module is port
+    And the AST module has no effect manager
+
+  Scenario: Lowering carries the effect module manager
+    Given the Elm source:
+      """
+      effect module Eff where { command = MyCmd, subscription = MySub } exposing (..)
+
+      x = 1
+      """
+    When the source is parsed to an AST
+    Then the AST module is effect
+    And the AST effect manager command is "MyCmd"
+    And the AST effect manager subscription is "MySub"

--- a/morphir/langkit/itest/src/morphir/langkit/itest/steps/ModuleParserSteps.scala
+++ b/morphir/langkit/itest/src/morphir/langkit/itest/steps/ModuleParserSteps.scala
@@ -2,6 +2,7 @@ package morphir.langkit.itest.steps
 
 import io.cucumber.scala.{EN, ScalaDsl}
 
+import morphir.langkit.elm.ast
 import morphir.langkit.elm.compiler.DiagnosticCode
 import morphir.langkit.elm.cst.*
 import morphir.langkit.itest.TestDriver
@@ -61,6 +62,36 @@ class ModuleParserSteps(driver: TestDriver) extends ScalaDsl with EN:
   Then("the module is effect") { () =>
     val mt = driver.cst.moduleDecl.moduleType
     assert(mt == ModuleType.Effect, s"expected effect module, got [$mt]")
+  }
+
+  Then("the AST module is plain") { () =>
+    val mt = driver.ast.moduleType
+    assert(mt == ast.ModuleType.Plain, s"expected plain AST module, got [$mt]")
+  }
+
+  Then("the AST module is port") { () =>
+    val mt = driver.ast.moduleType
+    assert(mt == ast.ModuleType.Port, s"expected port AST module, got [$mt]")
+  }
+
+  Then("the AST module is effect") { () =>
+    val mt = driver.ast.moduleType
+    assert(mt == ast.ModuleType.Effect, s"expected effect AST module, got [$mt]")
+  }
+
+  Then("the AST module has no effect manager") { () =>
+    val manager = driver.ast.manager
+    assert(manager.isEmpty, s"expected no AST effect manager, got [$manager]")
+  }
+
+  Then("the AST effect manager command is {string}") { (name: String) =>
+    val actual = driver.ast.manager.flatMap(_.command)
+    assert(actual.contains(name), s"expected AST manager command [$name], got [$actual]")
+  }
+
+  Then("the AST effect manager subscription is {string}") { (name: String) =>
+    val actual = driver.ast.manager.flatMap(_.subscription)
+    assert(actual.contains(name), s"expected AST manager subscription [$name], got [$actual]")
   }
 
   Then("the module has {int} import(s)") { (count: Int) =>


### PR DESCRIPTION
Closes #931.

`CstLowering.lowerModule` read four of the five things a module declaration carries, so a `port module` and an `effect module` lowered to something indistinguishable from a plain `module`, and the effect manager's command and subscription type names were dropped. G3 was closed at the CST level only; this is acceptance criterion **A** from the issue — carry it through.

## Changes

- `ast.Module` gains `moduleType: ModuleType` and `manager: Option[EffectManager]`, both defaulted so existing construction is unaffected (only `CstLowering` builds one).
- New `ast.EffectManager(command, subscription)` node, with the type names flattened to `String` as the AST does elsewhere, and an `ast.ModuleType` enum. `ModuleType` is duplicated in the `ast` package rather than shared with `cst`, matching how `Associativity` is already handled, so the AST keeps no dependency on the CST.
- `CstLowering.lowerModule` populates both, via `lowerModuleType` and `lowerEffectManager`.
- Per "Keep the CST and AST in step": `AstQueryableTree` exposes `manager` as a field (and it appears in `children`), `AstVisitor` gains `visitEffectManager`, a dispatch case and children. The unist projection and cursors are generic over those and needed no change. `moduleType` is a scalar enum, so it stays out of `fields` — the same treatment `InfixDeclaration.associativity` gets.

## Tests

- `CstLoweringSpec` — plain, port and effect modules lower to unequal `ast.Module` values; the manager's type names survive; either half of the manager alone survives; a plain module has no manager.
- `AstVisitorSpec` — the manager is a child of the module and dispatches to `visitEffectManager`.
- `AstQueryableTreeSpec` — `manager` is both a field and a child; `EffectManager` has no fields or children.
- `AstUnistProjectionSpec` — the manager projects as an `EffectManager` child node.
- `lowering.feature` — three scenarios (plain stays plain, port header carried, effect manager carried) with six new steps in `ModuleParserSteps`.

The G3 row in `conformance.html` now records the CST close (W7) and the lowering close separately, each with its own evidence.

## Verification

`morphir.langkit.elm.core` JVM / JS / Native (277 tests each), `morphir.langkit.elm.compiler.api.jvm`, `morphir.langkit.itest.testCached` (212 cucumber scenarios plus the real-world corpus), and `mise run lint` all pass locally.