### PR TITLE
fix(kb): a mirrored document may not be typed into one of our registers, and its injected block now follows the manifest

### DIFF
--- a/.claude/skills/kb/KbDecision.scala
+++ b/.claude/skills/kb/KbDecision.scala
@@ -39,9 +39,13 @@ object DecisionState:
   /** Display order: what governs now, then what used to. */
   val displayOrder: Seq[DecisionState] = Seq(Accepted, Proposed, Superseded, Withdrawn)
 
-/** The `type` value that marks a concept as a decision record. */
+/** The `type` value that marks a concept as a decision record.
+  *
+  * Defined in [[KbRegisters]] rather than here: discovering by `type:` claims that string knowledge-base wide, and
+  * the vendoring engine has to know the same set to keep a manifest from injecting it into somebody else's document.
+  */
 object DecisionType:
-  val Name = "Decision Record"
+  val Name: String = KbRegisters.DecisionRecord
 
 case class Decision(doc: Doc, bundle: String):
   private def fm = doc.fm

--- a/.claude/skills/kb/KbModel.scala
+++ b/.claude/skills/kb/KbModel.scala
@@ -48,6 +48,29 @@ case class Finding(
 ):
   def location: String = line.map(l => s"$path:$l").getOrElse(path)
 
+/** The `type:` values a register claims, wherever a document carrying one sits.
+  *
+  * A register that discovers its records by `type:` owns that value across the whole knowledge base — `KbDecision`
+  * collects every concept whose `type` is `Decision Record` no matter which bundle it is in, by design. Two things
+  * follow, and both are enforced elsewhere:
+  *
+  *   - A mirrored document must never be *injected* with one of these. It would be pulled into the register and
+  *     judged against a schema that is not its own, and nobody on this side could fix the resulting findings.
+  *     `KbSync.parseManifest` rejects a `type_map` that names one.
+  *   - The register that owns a value is responsible for what it does with a vendored document that carries one
+  *     anyway, because upstream is free to use any string it likes.
+  *
+  * Exactly one value is owned today. The set is named here rather than inline so that the constraint is visible from
+  * the model, and so that a second register discovering by `type:` has one place to add itself.
+  */
+object KbRegisters:
+  /** The decision register's marker. Re-exported as `DecisionType.Name`, which is what that register reads. */
+  val DecisionRecord: String = "Decision Record"
+
+  val ownedTypes: Seq[String] = Seq(DecisionRecord)
+
+  def owns(t: String): Boolean = ownedTypes.exists(_.equalsIgnoreCase(t.trim))
+
 /** Markdown shapes the tooling recognizes.
   *
   * An index entry is `* [Title](/path.md) - description`. Groups: (1) everything through the closing paren, so a

--- a/.claude/skills/kb/KbSync.scala
+++ b/.claude/skills/kb/KbSync.scala
@@ -18,6 +18,11 @@
   * byte for byte, including line endings. That is why nothing here re-serializes YAML: upstream frontmatter is moved
   * around as lines, never parsed and rewritten, so a fractional `sidebar_position` or a nested `tracking:` block
   * cannot be reformatted by accident.
+  *
+  * The invariant has a corollary worth stating, because missing it was a bug: since projection strips the fenced
+  * region, the region is invisible to every hash comparison here, and nothing about upstream drift can tell you that
+  * *our own* injection has gone stale. [[KbSync.reinjected]] is the answer — the manifest is compared against each
+  * file directly, so editing `type_map` reaches files that were imported long ago.
   */
 
 import kyo.*
@@ -50,6 +55,16 @@ case class SyncManifest(
 
   def typeFor(path: String): String =
     typeMap.collectFirst { case (glob, t) if KbGlob.matches(glob, path) => t }.getOrElse("Source Document")
+
+  /** `type_map` entries naming a type one of the knowledge base's registers discovers by.
+    *
+    * A mirrored document describes what it *is* — `Design Source`, `Decision Source` — and stays out of the
+    * vocabulary the registers claim. Injecting a register-owned type instead conscripts upstream's document into a
+    * register whose schema it was never written against, and the resulting findings are unfixable from this side.
+    * See [[KbRegisters]] for the set and why it is a constraint rather than a convention.
+    */
+  def typeMapCollisions: Seq[(String, String)] =
+    typeMap.filter((_, t) => KbRegisters.owns(t))
 
   def selects(path: String): Boolean =
     val excluded = exclude.exists(KbGlob.matches(_, path))
@@ -94,7 +109,18 @@ enum SyncState:
     case Untracked => "untracked"
     case Unreadable => "unreadable"
 
-case class FileStatus(path: String, kind: SyncKind, state: SyncState, detail: String = "")
+/** Where a mirrored file stands, plus whether the block we inject into it still says what the manifest says.
+  *
+  * Injection staleness is orthogonal to [[SyncState]] rather than another case of it: a file can have drifted
+  * upstream *and* carry a block the manifest no longer implies, and collapsing the two would lose one of them.
+  */
+case class FileStatus(
+    path: String,
+    kind: SyncKind,
+    state: SyncState,
+    detail: String = "",
+    injectionStale: Boolean = false
+)
 
 /** What a `pull` or `push` did, or would do under `--dry-run`. Mirrors `RefreshAction` so both render the same way. */
 case class SyncAction(verb: String, path: String, detail: String)
@@ -235,6 +261,58 @@ object KbSync:
           if wholeBlock && kept.isEmpty then Right(s.body)
           else Right(s.open + kept.mkString + s.close + s.body)
 
+  /** Frontmatter keys the injection owns.
+    *
+    * Fixed rather than derived from a particular file's [[injectedKeys]], because which of them apply changes with
+    * upstream: the day upstream adds a `title` of its own, ours has to go or the frontmatter carries the key twice
+    * and stops parsing. Anything inside the fence that is *not* one of these was put there by hand and survives.
+    */
+  val GeneratedKeys: Set[String] = Set("type", "title", "description", "kb_upstream")
+
+  private def isGenerated(line: String): Boolean =
+    val key = line.takeWhile(c => c != ':' && c != '\n' && c != '\r')
+    line.startsWith(s"$key:") && GeneratedKeys.contains(key)
+
+  /** Rewrites the fenced region to `keys`, keeping every line in it the injection does not own.
+    *
+    * The counterpart to [[inject]] for a file already on disk: same result, but hand-added keys stay. A file with no
+    * fence gets one, which is what a failed or lost injection needs. Left when the fence is damaged, on the same
+    * terms as [[project]] — a file we cannot take apart is one we must not write back.
+    */
+  def reinject(text: String, keys: Seq[(String, String)]): Either[String, String] =
+    split(text) match
+      case None => Right(inject(text, keys))
+      case Some(s) =>
+        val lines = linesKeepingEol(s.fm)
+        val b = lines.indexWhere(_.trim.startsWith(FenceBegin))
+        val e = lines.indexWhere(_.trim == FenceEnd)
+        if b < 0 && e < 0 then Right(inject(text, keys))
+        else if b < 0 then Left(s"$FenceEnd without $FenceBegin")
+        else if e < 0 then Left(s"$FenceBegin without $FenceEnd")
+        else if e < b then Left("kb fence closes before it opens")
+        else
+          val eol = eolOf(text)
+          // The opening line is kept verbatim so the `block` flag survives: it records whether the whole frontmatter
+          // block is ours, which is a fact about upstream and not something re-injection may re-decide.
+          val handAdded = lines.slice(b + 1, e).filterNot(isGenerated)
+          val block = lines(b) + keys.map((k, v) => s"$k: $v" + eol).mkString + handAdded.mkString + lines(e)
+          Right(s.open + lines.take(b).mkString + block + lines.drop(e + 1).mkString + s.close + s.body)
+
+  /** A mirrored concept as the manifest now implies it: upstream's own bytes, with the injected block recomputed.
+    *
+    * This is what makes the manifest self-correcting. `stateOf` compares projected forms, so the injected block is
+    * invisible to it by construction — right for detecting upstream drift, and the reason nothing used to notice
+    * when our own injection went stale. Comparing a file against this closes that gap without a second hash.
+    */
+  def reinjected(manifest: SyncManifest, rel: String, text: String): Either[String, String] =
+    project(text).flatMap(upstream => reinject(text, injectedKeys(manifest, rel, upstream)))
+
+  /** True when the file on disk is not what the manifest would now produce. Damaged fences say no: they are already
+    * reported as `unreadable`, and rewriting one would mean guessing at what it was meant to hold.
+    */
+  def injectionStale(manifest: SyncManifest, rel: String, text: String): Boolean =
+    reinjected(manifest, rel, text).exists(_ != text)
+
   /** The keys the knowledge base injects: `type` always, plus whatever OKF needs and upstream did not supply. */
   def injectedKeys(manifest: SyncManifest, path: String, upstream: String): Seq[(String, String)] =
     val fm = split(upstream).flatMap(s => KbStore.parseFrontmatter(s.fm).toOption).getOrElse(Frontmatter.Empty)
@@ -296,7 +374,7 @@ object KbSync:
           }
           if mappings.isEmpty then Left("sync.yaml needs at least one entry under `mappings:`")
           else
-            Right(SyncManifest(
+            val manifest = SyncManifest(
               repo = repo,
               ref = str(up, "ref").getOrElse("main"),
               refsPath = str(up, "refs_path").getOrElse(repo),
@@ -305,8 +383,20 @@ object KbSync:
               exclude = strs(top, "exclude"),
               // SnakeYAML preserves mapping order, and order decides which glob wins.
               typeMap = asMap(top.getOrElse("type_map", null)).toSeq.collect { case (k, v: String) => k -> v }
-            ))
+            )
+            // Rejected at parse time so that every command reading the manifest refuses it, rather than each having
+            // to remember to ask. `kb check` reports the same failure without a checkout — see `allSyncFindings`.
+            manifest.typeMapCollisions match
+              case Nil => Right(manifest)
+              case bad => Left(collisionMessage(bad))
     catch case e: Exception => Left(Option(e.getMessage).getOrElse(e.toString).linesIterator.next())
+
+  /** Why a `type_map` entry is refused, naming the entry and what to write instead. */
+  def collisionMessage(bad: Seq[(String, String)]): String =
+    val entries = bad.map((glob, t) => s"`\"$glob\": $t`").mkString(", ")
+    s"sync.yaml type_map injects a type a register owns: $entries — " +
+      s"a mirrored document would be pulled into that register and judged against a schema that is not its own; " +
+      s"name what the file is instead (e.g. `Decision Source`). Register-owned: ${KbRegisters.ownedTypes.mkString(", ")}"
 
   def parseLock(raw: String): Either[String, SyncLock] =
     try
@@ -430,24 +520,35 @@ object KbSync:
           case Some(h) if h == base => if localChanged then SyncState.LocalOnly else SyncState.Clean
           case Some(_) => if localChanged then SyncState.Diverged else SyncState.UpstreamOnly
 
-  /** Reads a mirrored file and reduces it to the bytes it would go back upstream as.
+  /** A mirrored file as it sits on disk: the bytes it would go back upstream as, and — for a concept — the text they
+    * came from, which is the only place the injected block can be read.
     *
-    * Bytes, not text: an asset is whatever upstream stores, and decoding one as UTF-8 to hash or export it would
-    * replace any invalid sequence with U+FFFD. That makes a freshly pulled binary look locally modified, and then
-    * writes the corruption out on push. Only concepts are text, because only concepts carry a frontmatter fence.
+    * Bytes, not text, for the upstream form: an asset is whatever upstream stores, and decoding one as UTF-8 to hash
+    * or export it would replace any invalid sequence with U+FFFD. That makes a freshly pulled binary look locally
+    * modified, and then writes the corruption out on push. Only concepts are text, because only concepts carry a
+    * frontmatter fence — which is also why `text` is None for an asset.
     */
-  private def upstreamFormOf(sb: SyncBundle, rel: String, kind: SyncKind)
-      : Option[Either[String, Array[Byte]]] < (Sync & Abort[Throwable]) =
+  private case class LocalCopy(upstreamForm: Either[String, Array[Byte]], text: Option[String])
+
+  /** Reads a mirrored file into its [[LocalCopy]], or None when the mirror does not have it. */
+  private def localCopyOf(sb: SyncBundle, rel: String, kind: SyncKind)
+      : Option[LocalCopy] < (Sync & Abort[Throwable]) =
     val f = sb.localFile(rel)
     f.exists.map {
-      case false => (None: Option[Either[String, Array[Byte]]])
+      case false => (None: Option[LocalCopy])
       case true =>
         readBytes(f).map { bytes =>
           Some(kind match
-            case SyncKind.Concept => project(String(bytes, "UTF-8")).map(_.getBytes("UTF-8"))
-            case SyncKind.Asset => Right(bytes))
+            case SyncKind.Concept =>
+              val text = String(bytes, "UTF-8")
+              LocalCopy(project(text).map(_.getBytes("UTF-8")), Some(text))
+            case SyncKind.Asset => LocalCopy(Right(bytes), None))
         }
     }
+
+  private def upstreamFormOf(sb: SyncBundle, rel: String, kind: SyncKind)
+      : Option[Either[String, Array[Byte]]] < (Sync & Abort[Throwable]) =
+    localCopyOf(sb, rel, kind).map(_.map(_.upstreamForm))
 
   def status(sb: SyncBundle, upstreamRoot: Option[Path]): Seq[FileStatus] < (Sync & Abort[Throwable]) =
     for
@@ -461,7 +562,8 @@ object KbSync:
       rows <- Kyo.foreach(Chunk.from(paths)) { rel =>
         val entry = sb.lock.get(rel)
         val kind = entry.map(_.kind).getOrElse(sb.manifest.kindOf(rel))
-        upstreamFormOf(sb, rel, kind).map { local =>
+        localCopyOf(sb, rel, kind).map { copy =>
+          val local = copy.map(_.upstreamForm)
           val up = upstreamHashes.get(rel)
           val goneUpstream = entry.isDefined && upstreamRoot.isDefined && up.isEmpty
           // A file upstream has deleted but we have since edited is a conflict, not a clean deletion. Reporting it
@@ -478,7 +580,10 @@ object KbSync:
           val detail = local match
             case Some(Left(err)) => err
             case _ => ""
-          FileStatus(rel, kind, state, detail)
+          // Derived from the local file alone, so it is decided with or without a reference checkout — a manifest
+          // edit that was never applied is visible from `kb check` and `kb sync status --no-upstream` both.
+          val stale = copy.flatMap(_.text).exists(injectionStale(sb.manifest, rel, _))
+          FileStatus(rel, kind, state, detail, stale)
         }
       }
     yield rows.toSeq
@@ -486,6 +591,26 @@ object KbSync:
   // -------------------------------------------------------------------- pull
 
   case class PullResult(actions: Seq[SyncAction], lock: SyncLock, refused: Seq[FileStatus])
+
+  /** Rewrites a mirrored concept's fenced block to what the manifest now implies, when the two have parted company.
+    *
+    * Reported as its own verb rather than folded into `updated`: nothing came from upstream, and a bulk re-injection
+    * across a whole mirror should not read as an import. Silent when the file cannot be taken apart — that is the
+    * `unreadable` state, and it has its own finding.
+    */
+  private def reinjectIfStale(sb: SyncBundle, st: FileStatus, dryRun: Boolean)
+      : Option[SyncAction] < (Sync & Abort[Throwable]) =
+    if !st.injectionStale then (None: Option[SyncAction] < (Sync & Abort[Throwable]))
+    else
+      sb.localFile(st.path).read.map { text =>
+        reinjected(sb.manifest, st.path, text) match
+          case Left(_) => (None: Option[SyncAction] < (Sync & Abort[Throwable]))
+          case Right(out) =>
+            val write =
+              if dryRun then ((): Unit < (Sync & Abort[Throwable]))
+              else writeBytes(sb.localFile(st.path), out.getBytes("UTF-8"))
+            write.andThen(Some(SyncAction("re-injected", st.path, "the manifest implies different keys")))
+      }
 
   def pull(
       sb: SyncBundle,
@@ -532,12 +657,23 @@ object KbSync:
           else
             // A clean file whose recorded hash is stale — both sides moved to the same content, which is what an
             // export leaves behind — gets its baseline refreshed. No write, just the lock catching up.
-            readBytes(resolve(upstreamRoot, rel)).map { bytes =>
-              val hash = sha256(bytes)
-              val entry = sb.lock.get(rel).map(e => e.copy(upstreamSha256 = hash))
-              val rebaselined = sb.lock.get(rel).exists(_.upstreamSha256 != hash)
-              Chunk((Option.when(rebaselined)(SyncAction("rebaselined", rel, "already in step upstream")), entry, None))
-            }
+            //
+            // And a file whose injected block no longer matches the manifest is rewritten in place. Nothing else
+            // would ever reach it: the block is invisible to `stateOf`, so an otherwise clean file is passed over
+            // and a `type_map` edit never lands. Re-injection touches only the fence, so the upstream form and the
+            // hash beside it are unchanged — which is why this can be done to a `local-only` file just as safely.
+            for
+              bytes <- readBytes(resolve(upstreamRoot, rel))
+              hash = sha256(bytes)
+              entry = sb.lock.get(rel).map(e => e.copy(upstreamSha256 = hash))
+              rebaselined = sb.lock.get(rel).exists(_.upstreamSha256 != hash)
+              reinjection <- reinjectIfStale(sb, st, dryRun)
+            yield
+              val baseline: (Option[SyncAction], Option[LockEntry], Option[FileStatus]) =
+                (Option.when(rebaselined)(SyncAction("rebaselined", rel, "already in step upstream")), entry, None)
+              val reinjected: Seq[(Option[SyncAction], Option[LockEntry], Option[FileStatus])] =
+                reinjection.map(a => (Some(a), None, None)).toSeq
+              Chunk(baseline) ++ Chunk.from(reinjected)
         else
           val src = resolve(upstreamRoot, rel)
           readBytes(src).map { bytes =>
@@ -669,7 +805,19 @@ object KbSync:
     status(sb, upstreamRoot).map { rows =>
       rows.flatMap { r =>
         val where = kb.rel(sb.localFile(r.path))
-        r.state match
+        // Only where nothing else is already saying "pull this". A file that has drifted upstream will be re-injected
+        // by the same import that takes upstream's change, so reporting both would be two findings for one action.
+        val staleFindings = Option.when(
+          r.injectionStale && (r.state == SyncState.Clean || r.state == SyncState.LocalOnly)
+        )(Finding(
+          Severity.Warn,
+          "sync-injection-stale",
+          where,
+          None,
+          "the `# kb:begin` block does not say what sync.yaml now implies",
+          Some("run `kb sync pull` — it rewrites the block in place; keys you added inside the fence are kept")
+        )).toSeq
+        staleFindings ++ (r.state match
           case SyncState.Unreadable =>
             Seq(Finding(
               Severity.Error,
@@ -733,7 +881,7 @@ object KbSync:
               "no longer present upstream",
               Some("`kb sync pull --prune` removes it here too, if that is what you want")
             ))
-          case SyncState.Clean | SyncState.LocalOnly => Nil
+          case SyncState.Clean | SyncState.LocalOnly => Nil)
       }
     }
 
@@ -744,7 +892,13 @@ object KbSync:
       ujson.write(
         ujson.Obj(
           "files" -> ujson.Arr.from(rows.map(r =>
-            ujson.Obj("path" -> r.path, "kind" -> r.kind.label, "state" -> r.state.label, "detail" -> r.detail)
+            ujson.Obj(
+              "path" -> r.path,
+              "kind" -> r.kind.label,
+              "state" -> r.state.label,
+              "detail" -> r.detail,
+              "injectionStale" -> r.injectionStale
+            )
           )),
           "summary" -> ujson.Obj.from(
             rows.groupBy(_.state.label).map((k, v) => k -> ujson.Num(v.size.toDouble)).toSeq
@@ -754,17 +908,22 @@ object KbSync:
       ) + "\n"
     else
       val sbuf = StringBuilder()
-      val interesting = rows.filter(_.state != SyncState.Clean)
+      // A stale block is interesting whatever the state says: it is the one thing `stateOf` cannot see, so leaving
+      // it out of an otherwise clean listing is exactly how a manifest edit goes unnoticed.
+      val interesting = rows.filter(r => r.state != SyncState.Clean || r.injectionStale)
       val shown = if verbose then rows else interesting
       if shown.isEmpty then sbuf ++= s"${rows.size} file(s), all clean\n"
       else
         shown.sortBy(r => (r.state.label, r.path)).foreach { r =>
           sbuf ++= f"${r.state.label}%-17s ${r.path}"
+          if r.injectionStale then sbuf ++= "  [injection stale]"
           if r.detail.nonEmpty then sbuf ++= s"  — ${r.detail}"
           sbuf ++= "\n"
         }
         sbuf ++= "\n"
         rows.groupBy(_.state.label).toSeq.sortBy(_._1).foreach((k, v) => sbuf ++= s"$k: ${v.size}\n")
+        val stale = rows.count(_.injectionStale)
+        if stale > 0 then sbuf ++= s"injection stale: $stale\n"
       sbuf.toString
 
   def renderActions(actions: Seq[SyncAction], refused: Seq[FileStatus], dryRun: Boolean, json: Boolean): String =

--- a/.claude/skills/kb/KbTests.scala
+++ b/.claude/skills/kb/KbTests.scala
@@ -542,6 +542,66 @@ class KbSyncSpec extends Test[Any]:
     }
   }
 
+  "re-injection" - {
+    val manifest = KbSync.parseManifest(
+      "upstream:\n  repo: acme/spec\nmappings:\n  - \"docs/**\"\ntype_map:\n  \"docs/**\": Design Source\n"
+    ).toOption.get
+
+    "rewrites the keys the injection owns" in {
+      val before = KbSync.inject("---\ntitle: Types\ndescription: The types.\n---\n\n# Types\n", keys)
+      val after = KbSync.reinjected(manifest, "docs/types.md", before).toOption.get
+      assert(after.contains("type: Design Source"), s"got: $after")
+      assert(!after.contains("Specification Source"), "the old value goes")
+      assert(after.contains("title: Types"), "upstream's own keys are outside the fence and untouched")
+    }
+    "keeps keys a human added inside the fence" in {
+      val before = KbSync.inject("---\ntitle: Types\n---\n\n# Types\n", keys)
+        .replace("# kb:end", "reviewed_by: us\n# kb:end")
+      val after = KbSync.reinjected(manifest, "docs/types.md", before).toOption.get
+      assert(after.contains("reviewed_by: us"), s"a hand-added key must survive: $after")
+      assert(after.contains("type: Design Source"), "while the generated ones are recomputed")
+    }
+    "leaves the upstream form exactly as it was" in {
+      // The whole point: re-injection is a change to our block, never to the bytes an export would send.
+      corpus.foreach { (label, text) =>
+        val injected = KbSync.inject(text, keys)
+        val after = KbSync.reinjected(manifest, "docs/types.md", injected).toOption.get
+        assert(KbSync.project(after) == Right(text), s"round-trip changed the bytes for $label")
+      }
+    }
+    "is idempotent, so a second pull finds nothing to do" in {
+      val once = KbSync.reinjected(manifest, "docs/types.md", KbSync.inject(corpus.head._2, keys)).toOption.get
+      assert(!KbSync.injectionStale(manifest, "docs/types.md", once), "the first pass settles it")
+      assert(KbSync.reinjected(manifest, "docs/types.md", once) == Right(once))
+    }
+    "gives a fence to a mirrored file that has lost one" in {
+      val after = KbSync.reinjected(manifest, "docs/types.md", "---\ntitle: Types\n---\n\n# Types\n").toOption.get
+      assert(after.contains("# kb:begin"), s"got: $after")
+      assert(after.contains("type: Design Source"))
+    }
+    "refuses a damaged fence rather than rewriting it" in {
+      val broken = "---\ntitle: X\n# kb:begin\ntype: Y\n---\n\nBody.\n"
+      assert(KbSync.reinject(broken, keys).isLeft)
+      assert(!KbSync.injectionStale(manifest, "docs/types.md", broken), "and it is reported as unreadable, not stale")
+    }
+    "drops an injected fallback upstream has since supplied itself" in {
+      // The file was seeded when upstream had neither key, and upstream has since added both. Keeping ours would
+      // leave `title` in the frontmatter twice, which SnakeYAML refuses outright — the document would stop loading.
+      val stale =
+        "---\ntitle: Types\ndescription: Theirs.\n" +
+          "# kb:begin — added by the knowledge base; removed on export\n" +
+          "type: Design Source\ntitle: Types\n" +
+          "description: \"Upstream source document acme/spec:docs/types.md.\"\n" +
+          "kb_upstream: docs/types.md\n# kb:end\n---\n\n# Types\n"
+      assert(KbSync.injectionStale(manifest, "docs/types.md", stale), "a duplicated key is staleness by any reading")
+      val after = KbSync.reinjected(manifest, "docs/types.md", stale).toOption.get
+      assert(after.linesIterator.count(_.startsWith("title: ")) == 1, s"one title, not two: $after")
+      assert(!after.contains("Upstream source document"), s"and the fallback description goes with it: $after")
+      val fm = KbSync.split(after).flatMap(s => KbStore.parseFrontmatter(s.fm).toOption)
+      assert(fm.flatMap(_.description).contains("Theirs."), s"leaving upstream's own: $fm")
+    }
+  }
+
   "relative links in mirrored documents" - {
     "regression: a sibling link resolves to an absolute path that exists" in {
       // resolveLink rebuilt the path from a segment list, dropping the leading empty segment of an absolute path
@@ -606,6 +666,29 @@ class KbSyncSpec extends Test[Any]:
       assert(m.selects("website/static/schemas/x.yaml"))
       assert(!m.selects("website/static/schemas/x.json"), "mapping-level exclude")
       assert(!m.selects("website/static/schemas/big.yaml"), "manifest-level exclude")
+    }
+    "refuses a type_map entry naming a type a register owns" in {
+      // The live instance: `docs/adr/**` mapped to `Decision Record`, which is exactly what KbDecision discovers by.
+      // Upstream's ADRs were pulled into our register and judged against a schema that is not theirs — four errors
+      // per file, none fixable from this side.
+      val bad = KbSync.parseManifest(
+        "upstream:\n  repo: a/b\nmappings:\n  - docs/**\ntype_map:\n  \"docs/adr/**\": Decision Record\n"
+      )
+      assert(bad.isLeft, "a manifest may not inject a register-owned type")
+      assert(bad.left.toOption.exists(_.contains("docs/adr/**")), s"and must say which entry: $bad")
+      assert(
+        KbSync.parseManifest(
+          "upstream:\n  repo: a/b\nmappings:\n  - docs/**\ntype_map:\n  \"docs/adr/**\": Decision Source\n"
+        ).isRight,
+        "naming what the file *is* stays allowed"
+      )
+      // Case and surrounding space cannot be used to smuggle one past: the register matches by `equalsIgnoreCase`.
+      assert(
+        KbSync.parseManifest(
+          "upstream:\n  repo: a/b\nmappings:\n  - docs/**\ntype_map:\n  \"docs/adr/**\": \" decision record \"\n"
+        ).isLeft,
+        "the comparison is the register's own, not a literal one"
+      )
     }
     "classifies markdown as a concept and everything else as an asset" in {
       val m = KbSync.parseManifest("upstream:\n  repo: a/b\nmappings:\n  - \"**\"\n").toOption.get
@@ -726,6 +809,96 @@ class KbSyncSpec extends Test[Any]:
       assert(!KbSync.safeRelative("../escaped.md"))
       assert(!KbSync.safeRelative("/etc/passwd"))
       assert(KbSync.safeRelative("docs/spec/types.md"))
+    }
+  }
+
+  /** Rewrites the fixture's manifest with a different `type_map`, which is the edit that used to have no effect. */
+  private def retype(bundleRoot: Path, t: String): Unit < (Sync & Abort[Throwable]) =
+    (bundleRoot / "sync.yaml").write(
+      "upstream:\n  repo: acme/spec\n  refs_path: acme/spec\nroot: sources\n" +
+        s"mappings:\n  - \"docs/**\"\n  - \"schemas/**\"\ntype_map:\n  \"docs/**\": $t\n"
+    )
+
+  "the injected block follows the manifest" - {
+    "regression: a type_map edit reaches a file that is already clean" in {
+      // The bug behind #947. `stateOf` compares projected forms, so the injected block is invisible to status and
+      // pull passed over every clean file — a manifest edit was write-once, and a wrong `type` sat there forever.
+      for
+        (kbRoot, bundleRoot, upstream) <- syncFixture
+        (_, sb0) <- loadSync(kbRoot)
+        first <- KbSync.pull(sb0, upstream, "deadbeef", today, dryRun = false, theirs = false, prune = false)
+        _ <- KbSync.writeLock(sb0, first.lock)
+        _ <- retype(bundleRoot, "Design Source")
+        (_, sb) <- loadSync(kbRoot)
+        rows <- KbSync.status(sb, Some(upstream))
+        again <- KbSync.pull(sb, upstream, "deadbeef", today, dryRun = false, theirs = false, prune = false)
+        after <- sb.localFile("docs/types.md").read
+        (_, sb2) <- loadSync(kbRoot)
+        settled <- KbSync.status(sb2, Some(upstream))
+      yield
+        assert(
+          rows.filter(_.injectionStale).map(_.path) == Seq("docs/index.md", "docs/types.md"),
+          s"both concepts are stale, the asset is not: ${rows.map(r => r.path -> r.injectionStale)}"
+        )
+        assert(
+          rows.forall(_.state == SyncState.Clean),
+          s"and staleness is orthogonal to state: ${rows.map(r => r.path -> r.state.label)}"
+        )
+        assert(again.actions.count(_.verb == "re-injected") == 2, s"got ${again.actions}")
+        assert(after.contains("type: Design Source"), s"got: $after")
+        assert(after.contains("title: Types"), "upstream's frontmatter is untouched")
+        assert(settled.forall(!_.injectionStale), "and a second pass has nothing left to do")
+    }
+    "keeps a key added inside the fence by hand" in {
+      for
+        (kbRoot, bundleRoot, upstream) <- syncFixture
+        (_, sb0) <- loadSync(kbRoot)
+        first <- KbSync.pull(sb0, upstream, "deadbeef", today, dryRun = false, theirs = false, prune = false)
+        _ <- KbSync.writeLock(sb0, first.lock)
+        before <- sb0.localFile("docs/types.md").read
+        _ <- sb0.localFile("docs/types.md").write(before.replace("# kb:end", "reviewed_by: us\n# kb:end"))
+        _ <- retype(bundleRoot, "Design Source")
+        (_, sb) <- loadSync(kbRoot)
+        _ <- KbSync.pull(sb, upstream, "deadbeef", today, dryRun = false, theirs = false, prune = false)
+        after <- sb.localFile("docs/types.md").read
+        rows <- KbSync.status(sb, Some(upstream))
+      yield
+        assert(after.contains("reviewed_by: us"), s"the hand-added key survives: $after")
+        assert(after.contains("type: Design Source"), "and the generated one is corrected")
+        assert(
+          rows.find(_.path == "docs/types.md").exists(_.state == SyncState.Clean),
+          s"re-injection does not disturb the upstream form: ${rows.map(r => r.path -> r.state.label)}"
+        )
+    }
+    "reports the rewrite under --dry-run without performing it" in {
+      for
+        (kbRoot, bundleRoot, upstream) <- syncFixture
+        (_, sb0) <- loadSync(kbRoot)
+        first <- KbSync.pull(sb0, upstream, "deadbeef", today, dryRun = false, theirs = false, prune = false)
+        _ <- KbSync.writeLock(sb0, first.lock)
+        _ <- retype(bundleRoot, "Design Source")
+        (_, sb) <- loadSync(kbRoot)
+        dry <- KbSync.pull(sb, upstream, "deadbeef", today, dryRun = true, theirs = false, prune = false)
+        after <- sb.localFile("docs/types.md").read
+      yield
+        assert(dry.actions.count(_.verb == "re-injected") == 2, s"got ${dry.actions}")
+        // Its own verb, so a bulk re-injection across a mirror does not read as an import from upstream.
+        assert(dry.actions.forall(a => a.verb != "added" && a.verb != "updated"), s"got ${dry.actions}")
+        assert(after.contains("type: Specification Source"), "dry run must not write")
+    }
+    "reports a stale block through kb check, without a reference checkout" in {
+      for
+        (kbRoot, bundleRoot, upstream) <- syncFixture
+        (_, sb0) <- loadSync(kbRoot)
+        first <- KbSync.pull(sb0, upstream, "deadbeef", today, dryRun = false, theirs = false, prune = false)
+        _ <- KbSync.writeLock(sb0, first.lock)
+        _ <- retype(bundleRoot, "Design Source")
+        (kb, sb) <- loadSync(kbRoot)
+        findings <- KbSync.checkFindings(kb, sb, None)
+      yield assert(
+        findings.count(f => f.check == "sync-injection-stale" && f.severity == Severity.Warn) == 2,
+        s"got ${findings.map(f => f.check -> f.path)}"
+      )
     }
   }
 

--- a/.claude/skills/kb/kb.scala
+++ b/.claude/skills/kb/kb.scala
@@ -387,7 +387,18 @@ object KbCli:
   def allSyncFindings(kb: Kb, refs: Path, useUpstream: Boolean): Seq[Finding] < (Sync & Abort[Throwable]) =
     Kyo.foreach(Chunk.from(kb.bundles.filter(_.mirror.isDefined))) { b =>
       KbSync.load(b).map {
-        case Left(_) => (Chunk.empty[Finding]: Chunk[Finding] < (Sync & Abort[Throwable]))
+        // These bundles have a sync.yaml by construction — `mirror` is read from it — so a failure to load is a
+        // manifest this tooling refuses, and used to pass in silence because every sync command was refusing it too.
+        // An error rather than a warning: nothing can be pulled or exported until it is fixed.
+        case Left(err) =>
+          (Chunk(Finding(
+            Severity.Error,
+            "sync-manifest-invalid",
+            kb.rel(b.root / KbSync.ManifestName),
+            None,
+            err,
+            Some("`kb sync status` reports the same failure; fix sync.yaml and re-run `kb sync pull`")
+          )): Chunk[Finding] < (Sync & Abort[Throwable]))
         case Right(sb) =>
           val up = if useUpstream then upstreamRoot(refs, sb) else (None: Option[Path] < (Sync & Abort[Throwable]))
           up.map(KbSync.checkFindings(kb, sb, _).map(Chunk.from))
@@ -832,7 +843,11 @@ object KbApp extends CommandsEntryPoint:
           up <- if o.noUpstream then (None: Option[Path] < (Sync & Abort[Throwable])) else KbCli.upstreamRoot(refs, sb)
           rows <- KbSync.status(sb, up)
           _ <- Console.print(KbSync.renderStatus(rows, o.sync.common.json, o.verbose))
-          bad = rows.count(r => r.state == SyncState.Diverged || r.state == SyncState.Unreadable)
+          // A stale injection counts as strict-bad: it means sync.yaml was edited and never applied, which is a
+          // manifest that is only true on paper. CI runs this, and `kb sync pull` fixes it mechanically.
+          bad = rows.count(r =>
+            r.state == SyncState.Diverged || r.state == SyncState.Unreadable || r.injectionStale
+          )
           _ <-
             if o.strict && bad > 0 then Sync.defer(java.lang.System.exit(1))
             else ((): Unit < (Sync & Abort[Throwable]))

--- a/.claude/skills/kb/references/checks.md
+++ b/.claude/skills/kb/references/checks.md
@@ -32,6 +32,7 @@ Exit code is non-zero when there is at least one error, or with `--strict`, at l
 | `decision-withdrawn-no-reason` | `state: Withdrawn` with no `reason` | Say why. A withdrawal without a reason is worthless six months on |
 | `sync-projection-broken` | A mirrored file cannot be reduced to its upstream form — its `# kb:begin` … `# kb:end` region is damaged | See below |
 | `sync-lock-drift` | `sync.lock.yaml` lists a mirrored file that is not in the mirror | See below |
+| `sync-manifest-invalid` | A bundle has a `sync.yaml` this tooling refuses — most often a `type_map` naming a type one of the registers owns | See below |
 
 A broken link is an error here even though OKF treats dangling links as "not-yet-written knowledge" — because OKF is
 describing *consumers*, and this is a producer-side linter. Nothing reading a bundle should fail on a dangling link;
@@ -64,6 +65,7 @@ warning. Otherwise, if you mean to point at something unwritten, say so in prose
 | `sync-diverged` | A mirrored file changed both here and upstream since the last import | Reconcile by hand; `kb sync diff <path>` shows both sides. `kb sync pull --theirs` discards the local side |
 | `sync-deleted-upstream` | A mirrored file is no longer present upstream | `kb sync pull --prune` removes it here too, if that is what you want |
 | `sync-deleted-upstream-edited` | Gone upstream, but carrying local edits — an **error**, because the edit is unrecoverable if discarded | Restore the file upstream and export, or revert the edit. Nothing prunes or overwrites it in the meantime. |
+| `sync-injection-stale` | A mirrored file's `# kb:begin` block does not say what `sync.yaml` now implies — usually a `type_map` edit that was never applied | `kb sync pull` rewrites the block in place. Keys you added inside the fence are kept |
 
 ### On `index-description-drift`
 
@@ -92,7 +94,8 @@ stance as `source-commit-drift`, for the same reason: drift is a prompt, not a f
 apart from upstream is the normal state of anything being worked on, and the tooling's job is to tell you *which
 way* it moved, not to insist you reconcile it now.
 
-Two are errors, and only two, because they are the states in which an export would send the wrong bytes:
+Two are errors because they are the states in which an export would send the wrong bytes, and a third because it is a
+manifest no command will accept:
 
 - **`sync-projection-broken`.** The `# kb:begin` … `# kb:end` region is the only part of a mirrored file the
   knowledge base owns, and removing exactly that region is what recovers upstream's bytes. When the fence is
@@ -102,8 +105,17 @@ Two are errors, and only two, because they are the states in which an export wou
 - **`sync-lock-drift`.** The lockfile names a file the mirror does not have, so the two disagree about what is
   vendored. `kb sync pull` restores it from upstream. If upstream dropped the file deliberately, `kb sync pull
   --prune` removes the entry instead.
+- **`sync-manifest-invalid`.** The manifest itself is refused, so no sync command will run — this finding is how you
+  see that from `kb check` rather than only from `kb sync`. The usual cause is a `type_map` entry naming a type a
+  register discovers by, such as `Decision Record`: a mirrored document injected with one is pulled into that register
+  and judged against a schema it was never written to. Type a mirrored file by what it *is* — `Decision Source` — and
+  → [sync.md](sync.md#type_map-may-not-name-a-register-owned-type) for why the constraint is general.
 
-Without a reference checkout under `.refs/` — or with `--no-provenance` — only those two can fire. The other four
+`sync-injection-stale` also fires without a checkout: it compares the file on disk against what the manifest implies,
+which needs nothing from upstream. That is the point — a `type_map` edit that was never applied is otherwise invisible,
+because status compares projected forms and the injected block is stripped before the comparison.
+
+Without a reference checkout under `.refs/` — or with `--no-provenance` — only those four can fire. The other four
 are all comparisons against upstream, and there is nothing to compare against.
 
 Mirrored documents are also held to a *looser* structural standard than authored ones, because their frontmatter

--- a/.claude/skills/kb/references/commands.md
+++ b/.claude/skills/kb/references/commands.md
@@ -263,18 +263,26 @@ What has moved, here and upstream. Clean files are omitted unless you ask for th
 | ---- | ------- |
 | `--no-upstream` | Do not consult the upstream checkout — compare the mirror against the lockfile only |
 | `--verbose` | List clean files too |
-| `--strict` | Exit non-zero when anything is `diverged` or `unreadable` |
+| `--strict` | Exit non-zero when anything is `diverged`, `unreadable`, or carrying a stale injected block |
+
+A file whose `# kb:begin` block no longer matches `sync.yaml` is listed as `[injection stale]` whatever its state,
+and is counted separately in the summary. That comparison needs no upstream checkout, so `--no-upstream` still makes
+it.
 
 ```bash
 .claude/skills/kb/kb sync status
 ```
 
-JSON gives `{files[{path, kind, state, detail}], summary{<state>: <count>}}`.
+JSON gives `{files[{path, kind, state, detail, injectionStale}], summary{<state>: <count>}}`.
 
 ### `sync pull`
 
-Imports upstream, rewrites `sync.lock.yaml`, then regenerates the bundle index below the `<!-- kb:sources -->`
-marker. `base_commit` is the checkout's current HEAD.
+Imports upstream, re-injects any block the manifest no longer implies, rewrites `sync.lock.yaml`, then regenerates
+the bundle index below the `<!-- kb:sources -->` marker. `base_commit` is the checkout's current HEAD.
+
+Re-injection is reported under its own verb, `re-injected`, and is what makes a `type_map` edit take effect on files
+that are already clean. It rewrites only the fenced region — keys added inside the fence by hand are kept, and the
+bytes an export would send are unchanged.
 
 | Flag | Meaning |
 | ---- | ------- |

--- a/.claude/skills/kb/references/sync.md
+++ b/.claude/skills/kb/references/sync.md
@@ -39,6 +39,19 @@ commands.
 Globs are matched against `/`-separated upstream-relative paths and support `*` (stops at a separator), `?` and
 `**`. `**/` also matches zero directories, so `docs/**/x.md` finds `docs/x.md`.
 
+### `type_map` may not name a register-owned type
+
+A register that discovers its records by `type:` claims that value across the whole knowledge base — `kb decision`
+collects every concept whose `type` is `Decision Record` wherever it sits, by design. Injecting one into a mirrored
+document conscripts upstream's file into a register whose schema it was never written against: an ADR imported from
+`finos/morphir` keeps its id in an `ADR-0001-…` filename and its status in the body, where this register expects a
+`NNNN-` prefix and frontmatter, so it fails four checks that nobody on this side can fix.
+
+So a mirrored document is typed by **what it is**, not by which of our registers would like it: `Decision Source`,
+not `Decision Record`. `kb sync` refuses a manifest that names an owned type — every command, not just `pull` — and
+`kb check` reports the same refusal as `sync-manifest-invalid` so it is caught without a reference checkout. The set
+lives in `KbRegisters.ownedTypes`; a register that starts discovering by `type:` adds itself there.
+
 ```yaml
 # What this bundle mirrors from finos/morphir, and where it lands.
 upstream:
@@ -140,6 +153,32 @@ The `block` flag exists because a document whose upstream frontmatter is an *emp
 indistinguishable from one that had none, and export would delete a block upstream actually has. The whole block is
 removed only when we created it *and* nobody has since added a key of their own alongside it.
 
+### The block is manifest-derived, and self-correcting
+
+Everything inside the fence is *generated*: `type` from `type_map`, `kb_upstream` from the path, `title` and
+`description` from the fallbacks. Edit the manifest and the next `kb sync pull` rewrites the block in place — it does
+not wait for upstream to touch the file, and it does not need the file to have drifted.
+
+This is not free, and it is worth knowing why it exists. `status` compares *projected* forms, so the injected block is
+invisible to it by construction — which is right for detecting upstream drift, and is exactly why nothing used to
+notice when our own injection went stale. A clean file was passed over on every pull, so a `type_map` edit had no
+effect on anything already imported and the manifest was effectively write-once. Instead of a second hash in the
+lockfile, `pull` compares each file against what the manifest now implies and rewrites the ones that disagree:
+
+- The comparison uses the local file alone, so `kb sync status` and `kb check` report staleness with **no reference
+  checkout** — a manifest edit that was never applied shows up offline.
+- `status` marks such a file `[injection stale]` whatever its state, and `--strict` fails on it. It is not a
+  `SyncState`: a file can have drifted upstream *and* carry a stale block, and collapsing the two would lose one.
+- `pull` reports the rewrite as its own verb, `re-injected`, and `--dry-run` lists it without writing. A bulk
+  re-injection across a whole mirror should not read as an import from upstream.
+- Re-injection changes only the fenced region, so the upstream form — and the hash beside it in the lockfile — is
+  unchanged. That is why it is safe to do to a `local-only` file: the edit you mean to export is outside the fence.
+- **Keys you add inside the fence by hand survive.** `type`, `title`, `description` and `kb_upstream` are ours and are
+  recomputed; anything else in there is left alone. The four are fixed rather than taken from the file, because the
+  day upstream supplies a `title` of its own, ours has to go or the frontmatter carries the key twice and stops
+  parsing.
+- A damaged fence is refused, not guessed at. That file is `unreadable` and has its own finding.
+
 ### The round-trip invariant
 
 ```
@@ -197,12 +236,14 @@ Full flag tables live in [commands.md](commands.md); this is what each one is fo
 
 **`kb sync status`** — what has moved, on both sides. It degrades gracefully: with no reference checkout, or with
 `--no-upstream`, it compares the mirror against the lockfile alone and reports only the states that comparison can
-decide. `--verbose` lists clean files too; `--strict` exits non-zero when anything is `diverged` or `unreadable`.
+decide. `--verbose` lists clean files too; `--strict` exits non-zero when anything is `diverged`, `unreadable`, or
+carrying a stale injected block — that last one is a manifest edit that was never applied, which is a manifest true
+only on paper.
 
-**`kb sync pull`** — import. Requires the reference checkout. It writes the mirrored files, rewrites
-`sync.lock.yaml` with the checkout's current HEAD as `base_commit`, then regenerates the bundle index below the
-`<!-- kb:sources -->` marker. `--dry-run` reports and writes nothing; `--theirs` takes upstream's version of files
-that changed on both sides; `--prune` deletes what upstream has removed.
+**`kb sync pull`** — import. Requires the reference checkout. It writes the mirrored files, re-injects any block that
+no longer matches the manifest, rewrites `sync.lock.yaml` with the checkout's current HEAD as `base_commit`, then
+regenerates the bundle index below the `<!-- kb:sources -->` marker. `--dry-run` reports and writes nothing;
+`--theirs` takes upstream's version of files that changed on both sides; `--prune` deletes what upstream has removed.
 
 The index is generated because forty hand-written bullets rot on the first pull. Everything above the marker is
 yours; everything below it is rewritten. Bullet text is the concept's own `description`, verbatim — that equality is
@@ -219,8 +260,9 @@ an export would actually send. Take the path from `sync status`; it is relative 
 ## Checks
 
 `kb check` folds sync findings in alongside the rest, for every bundle that has a `sync.yaml`. Drift is a prompt,
-not a failure — only `sync-projection-broken` and `sync-lock-drift` are errors, because those are the two states in
-which an export would send the wrong bytes.
+not a failure — only `sync-projection-broken`, `sync-lock-drift` and `sync-manifest-invalid` are errors: the first
+two are the states in which an export would send the wrong bytes, and the third is a manifest no command will accept.
+A stale injected block is `sync-injection-stale`, a warning, because `kb sync pull` fixes it mechanically.
 
 Mirrored documents also get relaxed structural checks: their frontmatter is upstream's, so `title`, `description`,
 `status` and unknown-key findings are suppressed, and a broken link becomes `link-broken-upstream` (a warning)

--- a/kb/AGENTS.md
+++ b/kb/AGENTS.md
@@ -60,6 +60,11 @@ edited with the edits sent back. Use it when a paraphrase will not do; use `sour
   fenced `# kb:begin` … `# kb:end` region inside it, holding the `type` OKF requires and the upstream path.
   `kb sync push` deletes exactly that region to recover upstream's bytes, so do not edit inside the fence by hand,
   and do not reformat anything outside it.
+- **The fence is generated from `sync.yaml`.** `kb sync pull` rewrites it whenever the manifest implies different
+  keys, so an edit to `type`, `title`, `description` or `kb_upstream` there will not survive; change the manifest
+  instead. A mirrored document is typed by what it *is* — `Decision Source`, not `Decision Record` — because the
+  registers below discover their records by `type:` wherever those sit, and upstream's file would be judged against
+  a schema it was never written to. `kb sync` refuses a `type_map` that names a register-owned type.
 - **Everything that is not markdown is an asset** — schemas, fixtures, `.mdx` pages, sidebar descriptors. Assets are
   mirrored byte-for-byte and tracked, but never parsed, so they carry no frontmatter and need no `type`.
 - **`index.md` and `log.md` are reserved only outside the mirror.** Inside it those names belong to upstream,

--- a/kb/bundles/morphir/morphir-upstream/sources/docs/adr/ADR-0001-morphir-ir-sum-types-in-go.md
+++ b/kb/bundles/morphir/morphir-upstream/sources/docs/adr/ADR-0001-morphir-ir-sum-types-in-go.md
@@ -1,6 +1,6 @@
 ---
 # kb:begin block — added by the knowledge base; removed on export
-type: Decision Record
+type: Decision Source
 title: ADR 0001 Morphir Ir Sum Types In Go
 description: "Upstream source document finos/morphir:docs/adr/ADR-0001-morphir-ir-sum-types-in-go.md."
 kb_upstream: docs/adr/ADR-0001-morphir-ir-sum-types-in-go.md

--- a/kb/bundles/morphir/morphir-upstream/sources/docs/adr/ADR-0002-processing-pipeline.md
+++ b/kb/bundles/morphir/morphir-upstream/sources/docs/adr/ADR-0002-processing-pipeline.md
@@ -1,6 +1,6 @@
 ---
 # kb:begin block — added by the knowledge base; removed on export
-type: Decision Record
+type: Decision Source
 title: ADR 0002 Processing Pipeline
 description: "Upstream source document finos/morphir:docs/adr/ADR-0002-processing-pipeline.md."
 kb_upstream: docs/adr/ADR-0002-processing-pipeline.md

--- a/kb/bundles/morphir/morphir-upstream/sync.yaml
+++ b/kb/bundles/morphir/morphir-upstream/sync.yaml
@@ -35,8 +35,13 @@ mappings:
   - "docs/adr/**"
 
 # First match wins, so the narrower globs come first.
+#
+# Every value describes what the file *is*, and stays out of the vocabulary this knowledge base's own registers
+# discover by — `Decision Source`, not `Decision Record`. A mirrored ADR is upstream's, written to upstream's
+# conventions; injecting the register's type would conscript it into a register whose schema it fails by construction,
+# and the findings would be unfixable from here. `kb sync` refuses a type_map that names one.
 type_map:
   "docs/design/**": Design Source
-  "docs/adr/**": Decision Record
+  "docs/adr/**": Decision Source
   "docs/spec/**": Specification Source
   "wit/**": Interface Definition


### PR DESCRIPTION
Fixes #947.

`kb sync` decides a mirrored document's `type` from the bundle manifest's `type_map` and injects it into a fenced
`# kb:begin` block. Two things were wrong with that arrangement, and one instance of the resulting bug was live in
`kb/bundles/morphir/morphir-upstream/`.

## The two problems

**A manifest could inject a type one of our registers owns.** `docs/adr/**` mapped to `Decision Record`, which is
precisely the value the Decision Record register discovers by — `KbDecision.decisions` collects every concept whose
`type` matches, wherever it sits, by design. So upstream's two ADRs were pulled into our register and judged against a
schema that is not theirs: ids come from a `NNNN-` filename prefix and upstream names them `ADR-0001-…`; `state` and
`decided` are frontmatter fields here and prose in the body there. Four errors per file, none fixable from this side.

**The injected block was never revisited.** `stateOf` compares the lockfile hash, the *projected* local form and the
upstream hash. Projection strips the fenced region, so the injected block is invisible to status by construction —
the right call for detecting upstream drift, and the reason nothing noticed when our own injection went stale. `pull`
then passed over any file that was `Clean`, so after a `type_map` edit it reported nothing to do and the old type
stayed forever. Editing the manifest and re-pulling — the obvious fix — did not work.

## What changed

**Register-owned types are named in one place, and refused.** `KbRegisters.ownedTypes` in `KbModel.scala` holds the
`type:` values a register claims, with the constraint written down; `DecisionType.Name` re-exports it, so there is one
source of the string. `parseManifest` rejects a `type_map` naming one, which means every sync command refuses it
rather than each having to remember to ask, and `kb check` reports the same refusal as `sync-manifest-invalid` — an
error, needing no `.refs/` checkout. That path previously swallowed a failed manifest load in silence, so a broken
`sync.yaml` produced no findings at all.

**The live instance is fixed.** `docs/adr/**` maps to `Decision Source`, consistent with its neighbours, and the two
mirrored ADRs on disk carry it. `kb decision list` is back to our 10 records.

**The block is now manifest-derived and self-correcting.** `reinject` / `reinjected` / `injectionStale` re-derive the
fenced region from the manifest, comparing the local file alone:

- `pull` rewrites a clean or local-only file whose block has parted company with the manifest, under its own verb
  `re-injected` — a bulk rewrite across 82 files should not read as an import from upstream. `--dry-run` lists it
  without writing.
- `FileStatus.injectionStale` sits alongside `SyncState` rather than becoming another case of it, because a file can
  have drifted upstream *and* carry a stale block, and collapsing the two would lose one. `kb sync status` marks such
  a file `[injection stale]` whatever its state, counts it in the summary, exposes it in JSON, and `--strict` exits
  non-zero on it — so a manifest edit that was never applied fails CI (`mise run kb:sync`) instead of sitting
  unnoticed.
- Because the comparison needs only the local file, staleness is reported offline: `kb check` and
  `kb sync status --no-upstream` both see it. `kb check` warns `sync-injection-stale` only where nothing else already
  says "pull", so a file that has drifted upstream does not produce two findings for one action.
- **Keys added inside the fence by hand survive.** The four generated keys (`type`, `title`, `description`,
  `kb_upstream`) are fixed rather than taken from the file, because the day upstream supplies a `title` of its own,
  ours has to go or the frontmatter carries the key twice and stops parsing.
- Re-injection touches only the fenced region, so the upstream form — and the hash beside it in the lockfile — is
  unchanged. That is why it is safe to do to a `local-only` file: the edit you mean to export lives outside the fence.
- A damaged fence is refused rather than rewritten. That file is `unreadable` and already has its own finding.

No lockfile schema change: drift cannot accumulate, because the manifest is compared against each file directly.

## Not changed

#942's `KbDecision.findings` skip of vendored documents stays. It is correct independently — a mirrored document's
frontmatter belongs to upstream whether we injected it or upstream wrote it — and is defence in depth rather than the
fix.

## Verification

`mise run kb:test` — **50 passed / 0 failed** in `KbSyncSpec` (was 38), whole suite green. New tests:

- the manifest refuses a register-owned type, including a case- and whitespace-padded variant
- re-injection rewrites the owned keys, keeps hand-added ones, drops a fallback upstream has since supplied, gives a
  fence to a file that lost one, refuses a damaged one, and is idempotent
- `project(reinject(x)) == project(x)` over the same hostile corpus the round-trip invariant uses — CRLF, nested YAML,
  fractional numbers, a `---` in the body, no frontmatter at all
- end to end: a `type_map` edit reaches an already-clean file; a hand-added key survives it; `--dry-run` reports
  without writing; `kb check` reports it with no reference checkout

Two paths live in `kb.scala`, which `KbTests` does not depend on, and were verified by hand against the real knowledge
base: `kb check` reporting `sync-manifest-invalid`, and `kb sync status --strict` exiting non-zero on a stale block.
Both temporary edits were reverted.

`mise run kb:check` reports 0 errors and `mise run kb:sync` reports 82 files, all clean.
