### PR TITLE
fix(release): stop a breaking-change label from drafting a 1.0.0 release

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -23,12 +23,34 @@ categories:
   - title: 'Dependency Updates'
     label: 'type: dependencies'
 
+# Pre-1.0 version resolution.
+#
+# This project is on the 0.x line, where semver says the leading zero is the
+# signal of instability and "anything MAY change at any time" (semver.org §4).
+# The practical convention that follows — the same one Cargo and npm assume — is
+# that under 0.x the MINOR position does the job MAJOR does after 1.0.
+#
+# So `type: breaking` resolves to a minor bump, not a major one. It used to
+# resolve to major, which meant a single breaking PR drafted a release as
+# 1.0.0 — declaring API stability as a side effect of labelling a PR, which is
+# not a decision that should be made by a label.
+#
+# Nothing resolves to major on purpose. A 1.0 release is a deliberate act, so
+# it should be tagged by hand rather than drafted.
+#
+# WHEN 1.0 SHIPS: move 'type: breaking' back under `major`, and move
+# 'type: feature' to `minor` if it is not already there. Until then, breaking
+# and feature both land on minor — which is the correct reading of a 0.x minor
+# bump, namely "this may contain breaking changes". The Breaking category above
+# is what makes the distinction visible in the notes.
+#
+# Note also that the current tags are milestone-shaped (v0.5.0-M04), which no
+# resolver will continue on its own. Treat $RESOLVED_VERSION as a starting
+# point and set the tag deliberately while that scheme is in use.
 version-resolver:
-  major:
-    labels:
-      - 'type: breaking'
   minor:
     labels:
+      - 'type: breaking'
       - 'type: feature'
       - 'type: deprecation'
   patch:


### PR DESCRIPTION
`type: breaking` resolved to a **major** bump in `version-resolver`, so a single labelled PR drafted the next release as `1.0.0`.

That means labelling a pull request declares API stability as a side effect. It is not a decision a label should be able to make, and on a `0.x` line it is very unlikely to be what anyone intended.

## The change

`type: breaking` moves from `major` to `minor`, joining `type: feature` and `type: deprecation`.

Semver says the leading zero is the signal of instability, and that under `0.y.z` anything may change at any time ([semver.org §4](https://semver.org/#spec-item-4)). The convention that follows — the one Cargo and npm both assume — is that under `0.x` the **minor** position does the job **major** does after 1.0. So a breaking change bumps `0.5.0` to `0.6.0`, not to `1.0.0`.

Nothing resolves to `major` now, deliberately. A 1.0 release is an act of intent; it should be tagged by hand rather than arrived at by a resolver reacting to a label.

Breaking and feature sharing the minor bump is the correct reading of a `0.x` minor — it means "this may contain breaking changes". The **Breaking** category in the notes template is what keeps the distinction visible to a reader, and that is unchanged.

## Also recorded in the config

- What to change when 1.0 ships: move `type: breaking` back under `major`.
- That the current tags are milestone-shaped (`v0.5.0-M04`), which no resolver will continue on its own — so `$RESOLVED_VERSION` is a starting point rather than an answer while that scheme is in use.

## Why now

Found while labelling #950, which genuinely is breaking: it removes `org.finos.morphir:morphir-runtime_3` in favour of `morphir-runtime-classic_3`. Labelling it correctly would have drafted a 1.0.0 release.

This is deliberately a separate PR from #950 so it can land on its own — it touches no build input and affects only release drafting.

## Validation

Config parses; `version-resolver` resolves to `minor` and `patch` only, with `type: breaking` under `minor` and the nine categories unchanged. There is no behaviour to exercise until a release is drafted.
