### PR TITLE
feat: add develop snapshots and safe refresh

### DIFF
--- a/.claude/skills/squire/README.md
+++ b/.claude/skills/squire/README.md
@@ -1,15 +1,33 @@
 # Squire
 
-A Claude Code project skill for the morphir-scala repository that diagnoses and unblocks common development environment issues.
+A Claude Code project skill for morphir-scala development environment diagnostics, reference repositories, safe post-squash branch refreshes, task tracking, and Morphir specification/schema workflows.
 
 ## Overview
 
-Squire is invoked as a slash command within Claude Code. It provides targeted guidance when Claude hits build, network, or sandbox failures — rather than blindly retrying or guessing at fixes.
+Squire is invoked as a slash command within Claude Code. It routes each maintained command to focused guidance and project-local automation.
 
 ```text
-/squire ai env info   — Report sandbox/network status as structured JSON
-/squire doctor        — Run a full environment diagnostic
+/squire ai env info          — Report sandbox/network status as structured JSON
+/squire doctor               — Run a full environment diagnostic
+/squire reference repo ...   — Manage repositories under .refs/
+/squire branch refresh       — Refresh develop from main after a squash merge
+/squire tracking ...         — Resolve and maintain optional beads tracking
+/squire spec sync|export     — Round-trip the Morphir IR specification
+/squire schemas              — Build and check generated IR JSON schemas
 ```
+
+The branch refresh workflow is deliberately two-step:
+
+```bash
+python3 .claude/skills/squire/scripts/branch-refresh.py --dry-run
+python3 .claude/skills/squire/scripts/branch-refresh.py
+
+# Parameterized target
+python3 .claude/skills/squire/scripts/branch-refresh.py --dry-run --target <branch>
+python3 .claude/skills/squire/scripts/branch-refresh.py --target <branch>
+```
+
+See [references/branch.md](references/branch.md) for the complete safety proof and failure recovery.
 
 ## How It Works
 
@@ -25,19 +43,44 @@ The skill is structured in layers to keep each file focused:
 .claude/skills/squire/
 ├── SKILL.md              # Entry point — command list and when to invoke
 ├── references/
+│   ├── branch.md         # Post-squash branch refresh lifecycle and safety proof
+│   ├── cellar.md         # JVM dependency API inspection
 │   ├── doctor.md         # Full diagnostic procedure and issue catalogue
-│   └── env.md            # ai env info — sandbox/network detection reference
-└── scripts/
+│   ├── env.md            # ai env info — sandbox/network detection reference
+│   ├── repo.md           # Reference repository management
+│   ├── spec-sync.md      # Morphir IR import/export workflow
+│   └── tracking.md       # Optional beads tracking configuration
+├── scripts/
     ├── ai-env-info.py            # Structured sandbox/network detection (JSON)
+    ├── branch-refresh.py         # Proves and refreshes a post-squash target
+    ├── cellar-query.py           # Runs project-configured JVM API queries
     ├── check-mill-daemon.py      # Probes mill daemon TCP connectivity
     ├── check-var-folders.py      # Probes /var/folders write access
-    └── check-project-config.py  # Checks project config correctness
+    ├── check-project-config.py   # Checks project config correctness
+    ├── repo-*.py                 # Manages entries under .refs/
+    ├── schemas-to-json.ts        # Builds/checks mirrored JSON schemas
+    ├── spec-*.py                 # Imports/exports the Morphir IR spec
+    └── tracking-*.py             # Resolves and repairs tracking guidance
+└── tests/
+    └── test_branch_refresh.py    # Branch refresh safety and CLI tests
 ```
 
 `scripts/lib/mill-flags.sh` (repo root, not under `.claude/`) is a shell consumer
 of `ai-env-info.py` — see [references/env.md](references/env.md).
 
-`SKILL.md` is concise — Claude reads it on every invocation. `references/doctor.md` is only loaded when running `/squire doctor`, keeping context usage low. Scripts are called via `${CLAUDE_PLUGIN_ROOT}` which resolves to the skill's root directory at runtime.
+`SKILL.md` is concise — Claude reads it on every invocation. The matching reference is loaded completely only when its command is used, keeping context usage low. Scripts are normally called from the repository root; references that support plugin installation may use `${CLAUDE_PLUGIN_ROOT}` for the skill root.
+
+### Maintained command areas
+
+| Area | Command or entry point | Full reference |
+|------|-------------------------|----------------|
+| Environment | `/squire ai env info`, `/squire doctor` | `references/env.md`, `references/doctor.md` |
+| Reference repos | `/squire reference repo add\|list\|status\|remove` | `references/repo.md` |
+| Branch lifecycle | `/squire branch refresh` | `references/branch.md` |
+| Task tracking | `/squire tracking status\|sync\|doctor` | `references/tracking.md` |
+| Morphir spec | `/squire spec sync`, `/squire spec export` | `references/spec-sync.md` |
+| Schemas | `/squire schemas` | `SKILL.md` |
+| JVM API inspection | `cellar-query.py` | `references/cellar.md` |
 
 ### `/squire doctor`
 

--- a/.claude/skills/squire/README.md
+++ b/.claude/skills/squire/README.md
@@ -51,16 +51,16 @@ The skill is structured in layers to keep each file focused:
 │   ├── spec-sync.md      # Morphir IR import/export workflow
 │   └── tracking.md       # Optional beads tracking configuration
 ├── scripts/
-    ├── ai-env-info.py            # Structured sandbox/network detection (JSON)
-    ├── branch-refresh.py         # Proves and refreshes a post-squash target
-    ├── cellar-query.py           # Runs project-configured JVM API queries
-    ├── check-mill-daemon.py      # Probes mill daemon TCP connectivity
-    ├── check-var-folders.py      # Probes /var/folders write access
-    ├── check-project-config.py   # Checks project config correctness
-    ├── repo-*.py                 # Manages entries under .refs/
-    ├── schemas-to-json.ts        # Builds/checks mirrored JSON schemas
-    ├── spec-*.py                 # Imports/exports the Morphir IR spec
-    └── tracking-*.py             # Resolves and repairs tracking guidance
+│   ├── ai-env-info.py            # Structured sandbox/network detection (JSON)
+│   ├── branch-refresh.py         # Proves and refreshes a post-squash target
+│   ├── cellar-query.py           # Runs project-configured JVM API queries
+│   ├── check-mill-daemon.py      # Probes mill daemon TCP connectivity
+│   ├── check-var-folders.py      # Probes /var/folders write access
+│   ├── check-project-config.py   # Checks project config correctness
+│   ├── repo-*.py                 # Manages entries under .refs/
+│   ├── schemas-to-json.ts        # Builds/checks mirrored JSON schemas
+│   ├── spec-*.py                 # Imports/exports the Morphir IR spec
+│   └── tracking-*.py             # Resolves and repairs tracking guidance
 └── tests/
     └── test_branch_refresh.py    # Branch refresh safety and CLI tests
 ```

--- a/.claude/skills/squire/README.md
+++ b/.claude/skills/squire/README.md
@@ -62,7 +62,9 @@ The skill is structured in layers to keep each file focused:
 │   ├── spec-*.py                 # Imports/exports the Morphir IR spec
 │   └── tracking-*.py             # Resolves and repairs tracking guidance
 └── tests/
-    └── test_branch_refresh.py    # Branch refresh safety and CLI tests
+    ├── test_branch_refresh.py    # Branch refresh safety and CLI tests
+    ├── test_ci_policy.py        # Hosted CI and publishing policy tests
+    └── test_mise_task_policy.py # Local CI task metadata tests
 ```
 
 `scripts/lib/mill-flags.sh` (repo root, not under `.claude/`) is a shell consumer

--- a/.claude/skills/squire/SKILL.md
+++ b/.claude/skills/squire/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: squire
-description: "Development environment diagnostics and unblocking for the morphir-scala project. Use when hitting build tool failures, sandbox restrictions, mill daemon errors, or SSL/network issues. Also manages reference repositories under .refs/ — invoke when asked to add, list, check, or remove a reference repo, clone a repo for reference, or work with a local copy of an upstream project. And round-trips the Morphir IR specification between finos/morphir and the knowledge base — invoke when asked to sync, import or export the spec, schemas or upstream docs, refresh the mirrored upstream bundle, or prepare spec changes to send back upstream. Also owns task-tracking configuration — invoke before tracking work to resolve whether beads (bd) is in use for this checkout, and when asked to opt out of beads, change tracking settings, or repair beads guidance that a bd command re-added to AGENTS.md/CLAUDE.md."
+description: "Use when morphir-scala work needs environment diagnostics or build/network/sandbox unblocking; reference repository management; branch lifecycle refresh after squash-merging a target branch into main; Morphir IR spec/schema sync or export; or task-tracking configuration and beads mode resolution."
 allowed-tools: Bash(cat *), Bash(ls *), Bash(find *), Bash(python3 *), Bash(git *), Bash(gh *), Read, Edit, Write
 metadata:
-  version: 0.4.0
+  version: 0.5.0
 ---
 
 # Squire — morphir-scala Dev Environment Assistant
 
-Squire diagnoses and unblocks development environment issues, manages reference repositories, and owns task-tracking configuration for the morphir-scala project.
+Squire diagnoses and unblocks development environment issues, manages reference repositories and branch lifecycle, and owns task-tracking configuration for the morphir-scala project.
 
 ## Commands
 
@@ -40,6 +40,15 @@ Read the full reference before running:
 **When to invoke:** When asked to add a reference repo, clone an upstream project, list or check existing references, or when context about an external codebase is needed locally.
 
 Sub-commands: `squire reference repo add`, `squire reference repo list`, `squire reference repo status`, `squire reference repo remove`
+
+### `/squire branch refresh`
+
+Safely refreshes a remote target branch from `origin/main` after its target-to-main pull request has been squash-merged. The target defaults to `develop`; use `--dry-run` to prove the refresh without pushing.
+
+Read the full reference completely before running:
+→ [references/branch.md](references/branch.md)
+
+**When to invoke:** After squash-merging an integration branch into `main`, when the remote target should begin its next lifecycle at the new `main` tip.
 
 ### `/squire tracking`
 

--- a/.claude/skills/squire/references/branch.md
+++ b/.claude/skills/squire/references/branch.md
@@ -5,14 +5,17 @@
 `--target` parameter defaults to `develop`; pass another branch name when
 refreshing a different integration branch.
 
-The command updates remote refs directly. It does **not** check out or switch a
-branch, reset the current branch, modify files, stage changes, or otherwise
-affect the dirty worktree.
+The command does **not** check out or switch a branch, reset the current branch,
+modify files, stage changes, or otherwise affect the dirty worktree. Its fetch
+does update local `origin/main` and `origin/<target>` remote-tracking refs and
+`FETCH_HEAD`; because it uses `--prune`, it may also remove stale local
+remote-tracking refs. The remote target branch is unchanged unless the final
+leased push succeeds.
 
 ## Expected workflow
 
-Use this after GitHub reports that the target-to-main PR was squash-merged and
-the merge commit is visible on `origin/main`:
+Use this only after a maintainer confirms in GitHub that the target-to-main PR
+was squash-merged and its merge commit is visible on `origin/main`:
 
 ```bash
 # Prove that develop can be refreshed, without pushing.
@@ -29,13 +32,14 @@ python3 .claude/skills/squire/scripts/branch-refresh.py --dry-run --target <bran
 python3 .claude/skills/squire/scripts/branch-refresh.py --target <branch>
 ```
 
-`--dry-run` performs every fetch and safety check but never pushes. Run it
-first, then run the same command without `--dry-run` only after reviewing the
-validated target and SHAs.
+`--dry-run` performs every fetch and safety check but never pushes. It therefore
+still updates the local fetch metadata described above. Run it first, then run
+the same command without `--dry-run` only after reviewing the validated target
+and SHAs.
 
 ## Safety proof
 
-Before any mutation, the script:
+Before changing the remote target branch, the script:
 
 1. Validates the target branch name and refuses `main` as the target.
 2. Explicitly fetches the authoritative `origin/main` and `origin/<target>`
@@ -45,11 +49,18 @@ Before any mutation, the script:
    freshly fetched refs are equal.
 4. Otherwise requires the current `origin/<target>` SHA to exactly equal the
    `headRefOid` of a merged `<target>`-to-`main` pull request.
-5. Requires that PR's squash merge commit to be reachable from the freshly
-   fetched `origin/main`.
-6. On a non-dry run, performs only this mutation: an explicit
+5. Requires the merge commit returned for that PR to exist and be reachable
+   from the freshly fetched `origin/main`.
+6. On a non-dry run, performs only this remote mutation: an explicit
    `--force-with-lease` push whose lease expects the validated target SHA and
    whose source is the validated `origin/main` tracking ref.
+
+Squash merge is a maintainer workflow precondition, not something the script
+can prove. The GitHub fields it queries identify a merged PR, its `headRefOid`,
+and its merge commit, but do not distinguish squash from other merge methods.
+The operator must confirm the PR was squash-merged before running the command;
+the script then proves the exact target-head match and merge-commit reachability
+described above.
 
 The resulting push has this exact shape:
 

--- a/.claude/skills/squire/references/branch.md
+++ b/.claude/skills/squire/references/branch.md
@@ -2,7 +2,7 @@
 
 `/squire branch refresh` safely moves a remote target branch to the current
 `origin/main` after the target-to-main pull request has been squash-merged. The
-The `--target` parameter defaults to `develop`; pass another branch name when
+`--target` parameter defaults to `develop`; pass another branch name when
 refreshing a different integration branch.
 
 The command updates remote refs directly. It does **not** check out or switch a
@@ -50,6 +50,16 @@ Before any mutation, the script:
 6. On a non-dry run, performs only this mutation: an explicit
    `--force-with-lease` push whose lease expects the validated target SHA and
    whose source is the validated `origin/main` tracking ref.
+
+The resulting push has this exact shape:
+
+```bash
+git push --force-with-lease=refs/heads/<target>:<validated-target-sha> origin refs/remotes/origin/main:refs/heads/<target>
+```
+
+`<validated-target-sha>` is the freshly fetched target SHA that exactly matched
+the merged PR's `headRefOid`. If the remote target no longer has that SHA, the
+lease rejects the push.
 
 The exact head match is deliberate. If the target advanced after the matching
 PR merged, the proof fails and the script refuses to push. It never retries

--- a/.claude/skills/squire/references/branch.md
+++ b/.claude/skills/squire/references/branch.md
@@ -1,0 +1,74 @@
+# Squire branch refresh — Post-squash Branch Lifecycle
+
+`/squire branch refresh` safely moves a remote target branch to the current
+`origin/main` after the target-to-main pull request has been squash-merged. The
+The `--target` parameter defaults to `develop`; pass another branch name when
+refreshing a different integration branch.
+
+The command updates remote refs directly. It does **not** check out or switch a
+branch, reset the current branch, modify files, stage changes, or otherwise
+affect the dirty worktree.
+
+## Expected workflow
+
+Use this after GitHub reports that the target-to-main PR was squash-merged and
+the merge commit is visible on `origin/main`:
+
+```bash
+# Prove that develop can be refreshed, without pushing.
+python3 .claude/skills/squire/scripts/branch-refresh.py --dry-run
+
+# Repeat the proof and refresh develop.
+python3 .claude/skills/squire/scripts/branch-refresh.py
+```
+
+For another target branch, supply the `--target` parameter:
+
+```bash
+python3 .claude/skills/squire/scripts/branch-refresh.py --dry-run --target <branch>
+python3 .claude/skills/squire/scripts/branch-refresh.py --target <branch>
+```
+
+`--dry-run` performs every fetch and safety check but never pushes. Run it
+first, then run the same command without `--dry-run` only after reviewing the
+validated target and SHAs.
+
+## Safety proof
+
+Before any mutation, the script:
+
+1. Validates the target branch name and refuses `main` as the target.
+2. Explicitly fetches the authoritative `origin/main` and `origin/<target>`
+   branch heads into their remote-tracking refs. It does not rely on a clone's
+   configured fetch refspec or potentially stale local refs.
+3. Returns `already-current` without querying GitHub or pushing when those two
+   freshly fetched refs are equal.
+4. Otherwise requires the current `origin/<target>` SHA to exactly equal the
+   `headRefOid` of a merged `<target>`-to-`main` pull request.
+5. Requires that PR's squash merge commit to be reachable from the freshly
+   fetched `origin/main`.
+6. On a non-dry run, performs only this mutation: an explicit
+   `--force-with-lease` push whose lease expects the validated target SHA and
+   whose source is the validated `origin/main` tracking ref.
+
+The exact head match is deliberate. If the target advanced after the matching
+PR merged, the proof fails and the script refuses to push. It never retries
+with, suggests, or offers an unconditional force push.
+
+## Failure recovery
+
+- **Fetch, authentication, or GitHub CLI failure:** fix network or `git`/`gh`
+  authentication, then rerun the dry run. Do not bypass the proof.
+- **No merged PR matches the target SHA:** the wrong target may have been
+  selected, or the target advanced after the PR. Inspect the remote target and
+  merged PR, preserve any new commits through a new PR, and rerun the dry run
+  only after the branch lifecycle is understood.
+- **Merge commit is not reachable from `origin/main`:** confirm the PR was
+  squash-merged into `main` and that GitHub exposes the merge on the expected
+  repository. Retry later if the remote view has not converged.
+- **Lease rejection:** the target changed after validation. Fetch and inspect
+  the new tip, then rerun `--dry-run`; never replace the lease with `--force`.
+
+After a successful refresh, `origin/<target>` and `origin/main` point at the
+same commit. Existing local branches are intentionally left alone; collaborators
+can update their local view with their normal fetch/rebase workflow.

--- a/.claude/skills/squire/scripts/branch-refresh.py
+++ b/.claude/skills/squire/scripts/branch-refresh.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+
+SOURCE = "main"
+REMOTE = "origin"
+
+
+class RefreshError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class RefreshResult:
+    kind: str
+    target: str
+    old_sha: str
+    new_sha: str
+    pull_request: int | None = None
+
+
+Runner = Callable[[Sequence[str]], str]
+
+
+def run_command(argv: Sequence[str]) -> str:
+    try:
+        return subprocess.run(
+            argv,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.strip() or error.stdout.strip() or str(error)
+        raise RefreshError(f"command failed: {' '.join(argv)}: {detail}") from error
+
+
+def parser() -> argparse.ArgumentParser:
+    argument_parser = argparse.ArgumentParser(
+        description="Safely refresh a branch from origin/main after its squash merge."
+    )
+    argument_parser.add_argument("target", nargs="?", default="develop")
+    argument_parser.add_argument("--dry-run", action="store_true")
+    return argument_parser
+
+
+def refresh(target: str, dry_run: bool, run: Runner = run_command) -> RefreshResult:
+    if target == SOURCE:
+        raise RefreshError(f"target branch must not be {SOURCE}")
+
+    try:
+        run(("git", "check-ref-format", "--branch", target))
+        run(("git", "fetch", "--prune", REMOTE, SOURCE, target))
+        source_sha = run(
+            ("git", "rev-parse", f"refs/remotes/{REMOTE}/{SOURCE}")
+        ).strip()
+        target_sha = run(
+            ("git", "rev-parse", f"refs/remotes/{REMOTE}/{target}")
+        ).strip()
+    except RefreshError:
+        raise
+    except Exception as error:
+        raise RefreshError(f"could not inspect target branch {target}: {error}") from error
+
+    if source_sha == target_sha:
+        return RefreshResult("already-current", target, target_sha, source_sha)
+
+    proof_context = f"target {target} requires a merged {target}-to-{SOURCE} PR"
+    try:
+        repository = run(
+            (
+                "gh",
+                "repo",
+                "view",
+                "--json",
+                "nameWithOwner",
+                "--jq",
+                ".nameWithOwner",
+            )
+        ).strip()
+        pull_requests_json = run(
+            (
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                repository,
+                "--base",
+                SOURCE,
+                "--head",
+                target,
+                "--state",
+                "merged",
+                "--limit",
+                "100",
+                "--json",
+                "number,headRefOid,mergeCommit,url,mergedAt",
+            )
+        )
+    except Exception as error:
+        raise RefreshError(f"{proof_context}; GitHub command failed: {error}") from error
+
+    try:
+        pull_requests = json.loads(pull_requests_json)
+    except (json.JSONDecodeError, TypeError) as error:
+        raise RefreshError(f"{proof_context}; GitHub returned malformed JSON") from error
+    if not isinstance(pull_requests, list):
+        raise RefreshError(f"{proof_context}; GitHub PR response must be an array")
+
+    matching_pr = next(
+        (
+            pull_request
+            for pull_request in pull_requests
+            if isinstance(pull_request, dict)
+            and pull_request.get("headRefOid") == target_sha
+        ),
+        None,
+    )
+    if matching_pr is None:
+        raise RefreshError(
+            f"{proof_context} whose head SHA exactly matches {target_sha}"
+        )
+
+    merge_commit = matching_pr.get("mergeCommit")
+    merge_sha = merge_commit.get("oid") if isinstance(merge_commit, dict) else None
+    if not isinstance(merge_sha, str) or not merge_sha:
+        raise RefreshError(f"{proof_context}; matching PR has no merge commit SHA")
+
+    try:
+        run(
+            (
+                "git",
+                "merge-base",
+                "--is-ancestor",
+                merge_sha,
+                f"refs/remotes/{REMOTE}/{SOURCE}",
+            )
+        )
+    except Exception as error:
+        raise RefreshError(
+            f"{proof_context}; merge commit {merge_sha} is not reachable from "
+            f"{REMOTE}/{SOURCE}: {error}"
+        ) from error
+
+    pull_request_number = matching_pr.get("number")
+    if dry_run:
+        return RefreshResult(
+            "validated",
+            target,
+            target_sha,
+            source_sha,
+            pull_request=pull_request_number,
+        )
+
+    try:
+        run(
+            (
+                "git",
+                "push",
+                f"--force-with-lease=refs/heads/{target}:{target_sha}",
+                REMOTE,
+                f"refs/remotes/{REMOTE}/{SOURCE}:refs/heads/{target}",
+            )
+        )
+    except Exception as error:
+        raise RefreshError(f"failed to refresh target {target}: {error}") from error
+
+    return RefreshResult(
+        "updated",
+        target,
+        target_sha,
+        source_sha,
+        pull_request=pull_request_number,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        result = refresh(args.target, args.dry_run)
+    except RefreshError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    print(f"{result.kind}: {result.target} {result.old_sha} -> {result.new_sha}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/squire/scripts/branch-refresh.py
+++ b/.claude/skills/squire/scripts/branch-refresh.py
@@ -63,7 +63,16 @@ def refresh(target: str, dry_run: bool, run: Runner = run_command) -> RefreshRes
         ) from error
 
     try:
-        run(("git", "fetch", "--prune", REMOTE, SOURCE, target))
+        run(
+            (
+                "git",
+                "fetch",
+                "--prune",
+                REMOTE,
+                f"+refs/heads/{SOURCE}:refs/remotes/{REMOTE}/{SOURCE}",
+                f"+refs/heads/{target}:refs/remotes/{REMOTE}/{target}",
+            )
+        )
     except Exception as error:
         raise RefreshError(
             f"could not fetch origin branches for {proof_context}: {error}"

--- a/.claude/skills/squire/scripts/branch-refresh.py
+++ b/.claude/skills/squire/scripts/branch-refresh.py
@@ -153,7 +153,7 @@ def refresh(target: str, dry_run: bool, run: Runner = run_command) -> RefreshRes
     )
     if matching_pr is None:
         raise RefreshError(
-            f"{proof_context} whose head SHA exactly matches {target_sha}"
+            f"could not find {proof_context} whose head SHA exactly matches {target_sha}"
         )
 
     pull_request_number = matching_pr.get("number")

--- a/.claude/skills/squire/scripts/branch-refresh.py
+++ b/.claude/skills/squire/scripts/branch-refresh.py
@@ -45,7 +45,7 @@ def parser() -> argparse.ArgumentParser:
     argument_parser = argparse.ArgumentParser(
         description="Safely refresh a branch from origin/main after its squash merge."
     )
-    argument_parser.add_argument("target", nargs="?", default="develop")
+    argument_parser.add_argument("--target", default="develop")
     argument_parser.add_argument("--dry-run", action="store_true")
     return argument_parser
 

--- a/.claude/skills/squire/scripts/branch-refresh.py
+++ b/.claude/skills/squire/scripts/branch-refresh.py
@@ -71,7 +71,7 @@ def refresh(target: str, dry_run: bool, run: Runner = run_command) -> RefreshRes
     if source_sha == target_sha:
         return RefreshResult("already-current", target, target_sha, source_sha)
 
-    proof_context = f"target {target} requires a merged {target}-to-{SOURCE} PR"
+    proof_context = f"target {target} and its required {target}-to-{SOURCE} PR"
     try:
         repository = run(
             (
@@ -84,6 +84,12 @@ def refresh(target: str, dry_run: bool, run: Runner = run_command) -> RefreshRes
                 ".nameWithOwner",
             )
         ).strip()
+    except Exception as error:
+        raise RefreshError(
+            f"could not identify repository while proving {proof_context}: {error}"
+        ) from error
+
+    try:
         pull_requests_json = run(
             (
                 "gh",
@@ -104,7 +110,9 @@ def refresh(target: str, dry_run: bool, run: Runner = run_command) -> RefreshRes
             )
         )
     except Exception as error:
-        raise RefreshError(f"{proof_context}; GitHub command failed: {error}") from error
+        raise RefreshError(
+            f"could not list merged PRs while proving {proof_context}: {error}"
+        ) from error
 
     try:
         pull_requests = json.loads(pull_requests_json)
@@ -127,6 +135,10 @@ def refresh(target: str, dry_run: bool, run: Runner = run_command) -> RefreshRes
             f"{proof_context} whose head SHA exactly matches {target_sha}"
         )
 
+    pull_request_number = matching_pr.get("number")
+    if type(pull_request_number) is not int:
+        raise RefreshError(f"{proof_context} is malformed: PR number must be an integer")
+
     merge_commit = matching_pr.get("mergeCommit")
     merge_sha = merge_commit.get("oid") if isinstance(merge_commit, dict) else None
     if not isinstance(merge_sha, str) or not merge_sha:
@@ -144,11 +156,10 @@ def refresh(target: str, dry_run: bool, run: Runner = run_command) -> RefreshRes
         )
     except Exception as error:
         raise RefreshError(
-            f"{proof_context}; merge commit {merge_sha} is not reachable from "
+            f"could not verify merge ancestry for {proof_context} in "
             f"{REMOTE}/{SOURCE}: {error}"
         ) from error
 
-    pull_request_number = matching_pr.get("number")
     if dry_run:
         return RefreshResult(
             "validated",
@@ -169,7 +180,9 @@ def refresh(target: str, dry_run: bool, run: Runner = run_command) -> RefreshRes
             )
         )
     except Exception as error:
-        raise RefreshError(f"failed to refresh target {target}: {error}") from error
+        raise RefreshError(
+            f"could not push leased update for {proof_context}: {error}"
+        ) from error
 
     return RefreshResult(
         "updated",

--- a/.claude/skills/squire/scripts/branch-refresh.py
+++ b/.claude/skills/squire/scripts/branch-refresh.py
@@ -54,24 +54,36 @@ def refresh(target: str, dry_run: bool, run: Runner = run_command) -> RefreshRes
     if target == SOURCE:
         raise RefreshError(f"target branch must not be {SOURCE}")
 
+    proof_context = f"target {target} and its required {target}-to-{SOURCE} PR"
     try:
         run(("git", "check-ref-format", "--branch", target))
+    except Exception as error:
+        raise RefreshError(
+            f"could not validate target branch for {proof_context}: {error}"
+        ) from error
+
+    try:
         run(("git", "fetch", "--prune", REMOTE, SOURCE, target))
+    except Exception as error:
+        raise RefreshError(
+            f"could not fetch origin branches for {proof_context}: {error}"
+        ) from error
+
+    try:
         source_sha = run(
             ("git", "rev-parse", f"refs/remotes/{REMOTE}/{SOURCE}")
         ).strip()
         target_sha = run(
             ("git", "rev-parse", f"refs/remotes/{REMOTE}/{target}")
         ).strip()
-    except RefreshError:
-        raise
     except Exception as error:
-        raise RefreshError(f"could not inspect target branch {target}: {error}") from error
+        raise RefreshError(
+            f"could not resolve remote refs for {proof_context}: {error}"
+        ) from error
 
     if source_sha == target_sha:
         return RefreshResult("already-current", target, target_sha, source_sha)
 
-    proof_context = f"target {target} and its required {target}-to-{SOURCE} PR"
     try:
         repository = run(
             (

--- a/.claude/skills/squire/tests/test_branch_refresh.py
+++ b/.claude/skills/squire/tests/test_branch_refresh.py
@@ -1,0 +1,269 @@
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "branch-refresh.py"
+SPEC = importlib.util.spec_from_file_location("squire_branch_refresh", SCRIPT)
+assert SPEC is not None
+assert SPEC.loader is not None
+branch_refresh = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = branch_refresh
+SPEC.loader.exec_module(branch_refresh)
+
+
+class RecordingRunner:
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = []
+
+    def __call__(self, argv):
+        command = tuple(argv)
+        self.calls.append(command)
+        response = self.responses[command]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class BranchRefreshTest(unittest.TestCase):
+    source_sha = "1" * 40
+    target_sha = "2" * 40
+    merge_sha = "3" * 40
+
+    def proof_responses(self, pull_requests):
+        return {
+            ("git", "check-ref-format", "--branch", "develop"): "develop\n",
+            ("git", "fetch", "--prune", "origin", "main", "develop"): "",
+            ("git", "rev-parse", "refs/remotes/origin/main"): f"{self.source_sha}\n",
+            ("git", "rev-parse", "refs/remotes/origin/develop"): f"{self.target_sha}\n",
+            (
+                "gh",
+                "repo",
+                "view",
+                "--json",
+                "nameWithOwner",
+                "--jq",
+                ".nameWithOwner",
+            ): "finos/morphir-scala\n",
+            (
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                "finos/morphir-scala",
+                "--base",
+                "main",
+                "--head",
+                "develop",
+                "--state",
+                "merged",
+                "--limit",
+                "100",
+                "--json",
+                "number,headRefOid,mergeCommit,url,mergedAt",
+            ): json.dumps(pull_requests),
+        }
+
+    def matching_pull_request(self):
+        return {
+            "number": 42,
+            "headRefOid": self.target_sha,
+            "mergeCommit": {"oid": self.merge_sha},
+            "url": "https://github.com/finos/morphir-scala/pull/42",
+            "mergedAt": "2026-08-07T12:00:00Z",
+        }
+
+    def successful_proof_responses(self):
+        responses = self.proof_responses([self.matching_pull_request()])
+        responses[
+            (
+                "git",
+                "merge-base",
+                "--is-ancestor",
+                self.merge_sha,
+                "refs/remotes/origin/main",
+            )
+        ] = ""
+        return responses
+
+    def assert_never_pushed(self, runner):
+        self.assertFalse(any(command[:2] == ("git", "push") for command in runner.calls))
+
+    def test_parser_defaults_to_develop_and_not_dry_run(self):
+        args = branch_refresh.parser().parse_args([])
+
+        self.assertEqual(args.target, "develop")
+        self.assertFalse(args.dry_run)
+
+    def test_equal_remote_refs_are_already_current_without_github_call(self):
+        sha = "a" * 40
+        runner = RecordingRunner(
+            {
+                ("git", "check-ref-format", "--branch", "develop"): "develop\n",
+                ("git", "fetch", "--prune", "origin", "main", "develop"): "",
+                ("git", "rev-parse", "refs/remotes/origin/main"): f"{sha}\n",
+                ("git", "rev-parse", "refs/remotes/origin/develop"): f"{sha}\n",
+            }
+        )
+
+        result = branch_refresh.refresh("develop", False, run=runner)
+
+        self.assertEqual(result.kind, "already-current")
+        self.assertEqual(result.target, "develop")
+        self.assertEqual(result.old_sha, sha)
+        self.assertEqual(result.new_sha, sha)
+        self.assertFalse(any(command[0] == "gh" for command in runner.calls))
+
+    def test_exact_target_head_match_with_reachable_merge_is_validated(self):
+        responses = self.successful_proof_responses()
+        ancestor = (
+            "git",
+            "merge-base",
+            "--is-ancestor",
+            self.merge_sha,
+            "refs/remotes/origin/main",
+        )
+        runner = RecordingRunner(responses)
+
+        result = branch_refresh.refresh("develop", True, run=runner)
+
+        self.assertEqual(result.kind, "validated")
+        self.assertEqual(result.pull_request, 42)
+        self.assertIn(ancestor, runner.calls)
+        self.assert_never_pushed(runner)
+
+    def test_successful_refresh_uses_exact_force_with_lease(self):
+        push = (
+            "git",
+            "push",
+            f"--force-with-lease=refs/heads/develop:{self.target_sha}",
+            "origin",
+            "refs/remotes/origin/main:refs/heads/develop",
+        )
+        responses = self.successful_proof_responses()
+        responses[push] = ""
+        runner = RecordingRunner(responses)
+
+        result = branch_refresh.refresh("develop", False, run=runner)
+
+        self.assertEqual(result.kind, "updated")
+        self.assertEqual(result.old_sha, self.target_sha)
+        self.assertEqual(result.new_sha, self.source_sha)
+        self.assertEqual(result.pull_request, 42)
+        self.assertEqual(runner.calls[-1], push)
+
+    def test_push_failure_surfaces_without_retry_or_unleased_force(self):
+        push = (
+            "git",
+            "push",
+            f"--force-with-lease=refs/heads/develop:{self.target_sha}",
+            "origin",
+            "refs/remotes/origin/main:refs/heads/develop",
+        )
+        responses = self.successful_proof_responses()
+        responses[push] = RuntimeError("lease rejected")
+        runner = RecordingRunner(responses)
+
+        with self.assertRaisesRegex(branch_refresh.RefreshError, "lease rejected"):
+            branch_refresh.refresh("develop", False, run=runner)
+
+        self.assertEqual(runner.calls.count(push), 1)
+        push_calls = [command for command in runner.calls if command[:2] == ("git", "push")]
+        self.assertEqual(push_calls, [push])
+
+    def test_no_pull_request_matching_exact_target_head_is_rejected(self):
+        other = self.matching_pull_request()
+        other["headRefOid"] = "4" * 40
+        runner = RecordingRunner(self.proof_responses([other]))
+
+        with self.assertRaisesRegex(
+            branch_refresh.RefreshError, "develop.*develop-to-main PR"
+        ):
+            branch_refresh.refresh("develop", True, run=runner)
+
+        self.assert_never_pushed(runner)
+
+    def test_matching_pull_request_without_merge_sha_is_rejected(self):
+        pull_request = self.matching_pull_request()
+        pull_request["mergeCommit"] = None
+        runner = RecordingRunner(self.proof_responses([pull_request]))
+
+        with self.assertRaisesRegex(
+            branch_refresh.RefreshError, "develop.*develop-to-main PR.*merge commit"
+        ):
+            branch_refresh.refresh("develop", True, run=runner)
+
+        self.assert_never_pushed(runner)
+
+    def test_merge_commit_not_reachable_from_origin_main_is_rejected(self):
+        responses = self.proof_responses([self.matching_pull_request()])
+        ancestor = (
+            "git",
+            "merge-base",
+            "--is-ancestor",
+            self.merge_sha,
+            "refs/remotes/origin/main",
+        )
+        responses[ancestor] = RuntimeError("not an ancestor")
+        runner = RecordingRunner(responses)
+
+        with self.assertRaisesRegex(
+            branch_refresh.RefreshError, "develop.*develop-to-main PR.*origin/main"
+        ):
+            branch_refresh.refresh("develop", True, run=runner)
+
+        self.assert_never_pushed(runner)
+
+    def test_malformed_pull_request_json_is_rejected_with_context(self):
+        responses = self.proof_responses([])
+        pr_list = next(
+            command for command in responses if command[:3] == ("gh", "pr", "list")
+        )
+        responses[pr_list] = "not json"
+        runner = RecordingRunner(responses)
+
+        with self.assertRaisesRegex(
+            branch_refresh.RefreshError, "develop.*develop-to-main PR.*JSON"
+        ):
+            branch_refresh.refresh("develop", True, run=runner)
+
+        self.assert_never_pushed(runner)
+
+    def test_malformed_pull_request_shape_is_rejected_with_context(self):
+        responses = self.proof_responses([])
+        pr_list = next(
+            command for command in responses if command[:3] == ("gh", "pr", "list")
+        )
+        responses[pr_list] = json.dumps({"number": 42})
+        runner = RecordingRunner(responses)
+
+        with self.assertRaisesRegex(
+            branch_refresh.RefreshError, "develop.*develop-to-main PR.*array"
+        ):
+            branch_refresh.refresh("develop", True, run=runner)
+
+        self.assert_never_pushed(runner)
+
+    def test_github_command_failure_is_rejected_with_context(self):
+        responses = self.proof_responses([])
+        repo_view = next(
+            command
+            for command in responses
+            if command[:3] == ("gh", "repo", "view")
+        )
+        responses[repo_view] = RuntimeError("gh unavailable")
+        runner = RecordingRunner(responses)
+
+        with self.assertRaisesRegex(
+            branch_refresh.RefreshError, "develop.*develop-to-main PR.*gh unavailable"
+        ):
+            branch_refresh.refresh("develop", True, run=runner)
+
+        self.assert_never_pushed(runner)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/squire/tests/test_branch_refresh.py
+++ b/.claude/skills/squire/tests/test_branch_refresh.py
@@ -421,7 +421,8 @@ class BranchRefreshTest(unittest.TestCase):
         runner = RecordingRunner(self.proof_responses([other]))
 
         with self.assertRaisesRegex(
-            branch_refresh.RefreshError, "develop.*develop-to-main PR"
+            branch_refresh.RefreshError,
+            "could not find.*develop.*develop-to-main PR.*head SHA exactly matches",
         ):
             branch_refresh.refresh("develop", True, run=runner)
 

--- a/.claude/skills/squire/tests/test_branch_refresh.py
+++ b/.claude/skills/squire/tests/test_branch_refresh.py
@@ -117,6 +117,47 @@ class BranchRefreshTest(unittest.TestCase):
         self.assertEqual(result.new_sha, sha)
         self.assertFalse(any(command[0] == "gh" for command in runner.calls))
 
+    def test_pre_proof_command_failures_include_operation_and_pr_context(self):
+        sha = "a" * 40
+        base_responses = {
+            ("git", "check-ref-format", "--branch", "develop"): "develop\n",
+            ("git", "fetch", "--prune", "origin", "main", "develop"): "",
+            ("git", "rev-parse", "refs/remotes/origin/main"): f"{sha}\n",
+            ("git", "rev-parse", "refs/remotes/origin/develop"): f"{sha}\n",
+        }
+        cases = (
+            (
+                ("git", "check-ref-format", "--branch", "develop"),
+                "validate target branch",
+                "invalid ref",
+            ),
+            (
+                ("git", "fetch", "--prune", "origin", "main", "develop"),
+                "fetch origin branches",
+                "network unavailable",
+            ),
+            (
+                ("git", "rev-parse", "refs/remotes/origin/main"),
+                "resolve remote refs",
+                "missing origin main",
+            ),
+        )
+
+        for command, operation, detail in cases:
+            with self.subTest(operation=operation):
+                responses = dict(base_responses)
+                responses[command] = branch_refresh.RefreshError(detail)
+                runner = RecordingRunner(responses)
+
+                with self.assertRaisesRegex(
+                    branch_refresh.RefreshError,
+                    f"{operation}.*develop.*develop-to-main PR.*{detail}",
+                ):
+                    branch_refresh.refresh("develop", False, run=runner)
+
+                self.assertFalse(any(call[0] == "gh" for call in runner.calls))
+                self.assert_never_pushed(runner)
+
     def test_exact_target_head_match_with_reachable_merge_is_validated(self):
         responses = self.successful_proof_responses()
         ancestor = (

--- a/.claude/skills/squire/tests/test_branch_refresh.py
+++ b/.claude/skills/squire/tests/test_branch_refresh.py
@@ -1,9 +1,11 @@
 import importlib.util
+import io
 import json
 import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 
 
@@ -126,6 +128,22 @@ class BranchRefreshTest(unittest.TestCase):
 
         self.assertEqual(args.target, "develop")
         self.assertFalse(args.dry_run)
+
+    def test_parser_accepts_target_option(self):
+        with redirect_stderr(io.StringIO()):
+            try:
+                args = branch_refresh.parser().parse_args(
+                    ["--target", "release-line"]
+                )
+            except SystemExit as error:
+                self.fail(f"--target was rejected with exit code {error.code}")
+
+        self.assertEqual(args.target, "release-line")
+
+    def test_parser_rejects_bare_positional_target(self):
+        with redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit):
+                branch_refresh.parser().parse_args(["release-line"])
 
     def test_equal_remote_refs_are_already_current_without_github_call(self):
         sha = "a" * 40

--- a/.claude/skills/squire/tests/test_branch_refresh.py
+++ b/.claude/skills/squire/tests/test_branch_refresh.py
@@ -167,7 +167,10 @@ class BranchRefreshTest(unittest.TestCase):
         responses[push] = RuntimeError("lease rejected")
         runner = RecordingRunner(responses)
 
-        with self.assertRaisesRegex(branch_refresh.RefreshError, "lease rejected"):
+        with self.assertRaisesRegex(
+            branch_refresh.RefreshError,
+            "push leased update.*develop.*develop-to-main PR.*lease rejected",
+        ):
             branch_refresh.refresh("develop", False, run=runner)
 
         self.assertEqual(runner.calls.count(push), 1)
@@ -198,6 +201,42 @@ class BranchRefreshTest(unittest.TestCase):
 
         self.assert_never_pushed(runner)
 
+    def test_matching_pull_request_without_number_is_rejected(self):
+        pull_request = self.matching_pull_request()
+        del pull_request["number"]
+        responses = self.successful_proof_responses()
+        pr_list = next(
+            command for command in responses if command[:3] == ("gh", "pr", "list")
+        )
+        responses[pr_list] = json.dumps([pull_request])
+        runner = RecordingRunner(responses)
+
+        with self.assertRaisesRegex(
+            branch_refresh.RefreshError,
+            "develop.*develop-to-main PR.*number.*integer",
+        ):
+            branch_refresh.refresh("develop", True, run=runner)
+
+        self.assert_never_pushed(runner)
+
+    def test_matching_pull_request_with_non_integer_number_is_rejected(self):
+        pull_request = self.matching_pull_request()
+        pull_request["number"] = "42"
+        responses = self.successful_proof_responses()
+        pr_list = next(
+            command for command in responses if command[:3] == ("gh", "pr", "list")
+        )
+        responses[pr_list] = json.dumps([pull_request])
+        runner = RecordingRunner(responses)
+
+        with self.assertRaisesRegex(
+            branch_refresh.RefreshError,
+            "develop.*develop-to-main PR.*number.*integer",
+        ):
+            branch_refresh.refresh("develop", True, run=runner)
+
+        self.assert_never_pushed(runner)
+
     def test_merge_commit_not_reachable_from_origin_main_is_rejected(self):
         responses = self.proof_responses([self.matching_pull_request()])
         ancestor = (
@@ -211,7 +250,8 @@ class BranchRefreshTest(unittest.TestCase):
         runner = RecordingRunner(responses)
 
         with self.assertRaisesRegex(
-            branch_refresh.RefreshError, "develop.*develop-to-main PR.*origin/main"
+            branch_refresh.RefreshError,
+            "verify merge ancestry.*develop.*develop-to-main PR.*origin/main.*not an ancestor",
         ):
             branch_refresh.refresh("develop", True, run=runner)
 
@@ -258,7 +298,24 @@ class BranchRefreshTest(unittest.TestCase):
         runner = RecordingRunner(responses)
 
         with self.assertRaisesRegex(
-            branch_refresh.RefreshError, "develop.*develop-to-main PR.*gh unavailable"
+            branch_refresh.RefreshError,
+            "identify repository.*develop.*develop-to-main PR.*gh unavailable",
+        ):
+            branch_refresh.refresh("develop", True, run=runner)
+
+        self.assert_never_pushed(runner)
+
+    def test_pull_request_list_failure_is_rejected_with_context(self):
+        responses = self.proof_responses([])
+        pr_list = next(
+            command for command in responses if command[:3] == ("gh", "pr", "list")
+        )
+        responses[pr_list] = RuntimeError("PR listing unavailable")
+        runner = RecordingRunner(responses)
+
+        with self.assertRaisesRegex(
+            branch_refresh.RefreshError,
+            "list merged PRs.*develop.*develop-to-main PR.*PR listing unavailable",
         ):
             branch_refresh.refresh("develop", True, run=runner)
 

--- a/.claude/skills/squire/tests/test_branch_refresh.py
+++ b/.claude/skills/squire/tests/test_branch_refresh.py
@@ -1,6 +1,8 @@
 import importlib.util
 import json
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -28,6 +30,26 @@ class RecordingRunner:
         return response
 
 
+class LocalGitRunner:
+    def __init__(self, cwd, responses):
+        self.cwd = cwd
+        self.responses = responses
+        self.calls = []
+
+    def __call__(self, argv):
+        command = tuple(argv)
+        self.calls.append(command)
+        if command[0] == "git":
+            return subprocess.run(
+                command,
+                cwd=self.cwd,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+        return self.responses[command]
+
+
 class BranchRefreshTest(unittest.TestCase):
     source_sha = "1" * 40
     target_sha = "2" * 40
@@ -36,7 +58,14 @@ class BranchRefreshTest(unittest.TestCase):
     def proof_responses(self, pull_requests):
         return {
             ("git", "check-ref-format", "--branch", "develop"): "develop\n",
-            ("git", "fetch", "--prune", "origin", "main", "develop"): "",
+            (
+                "git",
+                "fetch",
+                "--prune",
+                "origin",
+                "+refs/heads/main:refs/remotes/origin/main",
+                "+refs/heads/develop:refs/remotes/origin/develop",
+            ): "",
             ("git", "rev-parse", "refs/remotes/origin/main"): f"{self.source_sha}\n",
             ("git", "rev-parse", "refs/remotes/origin/develop"): f"{self.target_sha}\n",
             (
@@ -103,7 +132,14 @@ class BranchRefreshTest(unittest.TestCase):
         runner = RecordingRunner(
             {
                 ("git", "check-ref-format", "--branch", "develop"): "develop\n",
-                ("git", "fetch", "--prune", "origin", "main", "develop"): "",
+                (
+                    "git",
+                    "fetch",
+                    "--prune",
+                    "origin",
+                    "+refs/heads/main:refs/remotes/origin/main",
+                    "+refs/heads/develop:refs/remotes/origin/develop",
+                ): "",
                 ("git", "rev-parse", "refs/remotes/origin/main"): f"{sha}\n",
                 ("git", "rev-parse", "refs/remotes/origin/develop"): f"{sha}\n",
             }
@@ -117,11 +153,147 @@ class BranchRefreshTest(unittest.TestCase):
         self.assertEqual(result.new_sha, sha)
         self.assertFalse(any(command[0] == "gh" for command in runner.calls))
 
+    def test_fetch_refreshes_both_tracking_refs_in_single_branch_clone(self):
+        def git(cwd, *args):
+            return subprocess.run(
+                ("git", *args),
+                cwd=cwd,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            origin = root / "origin.git"
+            seed = root / "seed"
+            clone = root / "clone"
+
+            git(root, "init", "--bare", str(origin))
+            git(root, "init", "-b", "main", str(seed))
+            git(seed, "config", "user.name", "Branch Refresh Test")
+            git(seed, "config", "user.email", "branch-refresh@example.invalid")
+            (seed / "main.txt").write_text("main one\n")
+            git(seed, "add", "main.txt")
+            git(seed, "commit", "-m", "main one")
+            git(seed, "remote", "add", "origin", str(origin))
+            git(seed, "push", "-u", "origin", "main")
+
+            git(seed, "switch", "-c", "develop")
+            (seed / "develop.txt").write_text("develop one\n")
+            git(seed, "add", "develop.txt")
+            git(seed, "commit", "-m", "develop one")
+            git(seed, "push", "-u", "origin", "develop")
+
+            git(
+                root,
+                "clone",
+                "--single-branch",
+                "--branch",
+                "main",
+                str(origin),
+                str(clone),
+            )
+            cloned_main_sha = git(clone, "rev-parse", "refs/remotes/origin/main")
+
+            git(seed, "switch", "main")
+            (seed / "main.txt").write_text("main two\n")
+            git(seed, "add", "main.txt")
+            git(seed, "commit", "-m", "main two")
+            git(seed, "push", "origin", "main")
+            main_tip = git(origin, "rev-parse", "refs/heads/main")
+
+            git(seed, "switch", "develop")
+            (seed / "develop.txt").write_text("develop two\n")
+            git(seed, "add", "develop.txt")
+            git(seed, "commit", "-m", "develop two")
+            git(seed, "push", "origin", "develop")
+            develop_tip = git(origin, "rev-parse", "refs/heads/develop")
+
+            self.assertNotEqual(cloned_main_sha, main_tip)
+            develop_ref = "refs/remotes/origin/develop"
+            self.assertNotEqual(
+                subprocess.run(
+                    ("git", "show-ref", "--verify", "--quiet", develop_ref),
+                    cwd=clone,
+                ).returncode,
+                0,
+            )
+
+            pull_request = {
+                "number": 42,
+                "headRefOid": develop_tip,
+                "mergeCommit": {"oid": main_tip},
+                "url": "https://github.com/finos/morphir-scala/pull/42",
+                "mergedAt": "2026-08-07T12:00:00Z",
+            }
+            runner = LocalGitRunner(
+                clone,
+                {
+                    (
+                        "gh",
+                        "repo",
+                        "view",
+                        "--json",
+                        "nameWithOwner",
+                        "--jq",
+                        ".nameWithOwner",
+                    ): "finos/morphir-scala\n",
+                    (
+                        "gh",
+                        "pr",
+                        "list",
+                        "--repo",
+                        "finos/morphir-scala",
+                        "--base",
+                        "main",
+                        "--head",
+                        "develop",
+                        "--state",
+                        "merged",
+                        "--limit",
+                        "100",
+                        "--json",
+                        "number,headRefOid,mergeCommit,url,mergedAt",
+                    ): json.dumps([pull_request]),
+                },
+            )
+
+            try:
+                result = branch_refresh.refresh("develop", True, run=runner)
+            except branch_refresh.RefreshError as error:
+                current_main = git(clone, "rev-parse", "refs/remotes/origin/main")
+                develop_exists = (
+                    subprocess.run(
+                        ("git", "show-ref", "--verify", "--quiet", develop_ref),
+                        cwd=clone,
+                    ).returncode
+                    == 0
+                )
+                self.fail(
+                    "production fetch left remote-tracking refs stale or absent: "
+                    f"origin/main={current_main}, expected={main_tip}; "
+                    f"origin/develop exists={develop_exists}; error={error}"
+                )
+
+            self.assertEqual(result.kind, "validated")
+            self.assertEqual(
+                git(clone, "rev-parse", "refs/remotes/origin/main"), main_tip
+            )
+            self.assertEqual(git(clone, "rev-parse", develop_ref), develop_tip)
+
     def test_pre_proof_command_failures_include_operation_and_pr_context(self):
         sha = "a" * 40
         base_responses = {
             ("git", "check-ref-format", "--branch", "develop"): "develop\n",
-            ("git", "fetch", "--prune", "origin", "main", "develop"): "",
+            (
+                "git",
+                "fetch",
+                "--prune",
+                "origin",
+                "+refs/heads/main:refs/remotes/origin/main",
+                "+refs/heads/develop:refs/remotes/origin/develop",
+            ): "",
             ("git", "rev-parse", "refs/remotes/origin/main"): f"{sha}\n",
             ("git", "rev-parse", "refs/remotes/origin/develop"): f"{sha}\n",
         }
@@ -132,7 +304,14 @@ class BranchRefreshTest(unittest.TestCase):
                 "invalid ref",
             ),
             (
-                ("git", "fetch", "--prune", "origin", "main", "develop"),
+                (
+                    "git",
+                    "fetch",
+                    "--prune",
+                    "origin",
+                    "+refs/heads/main:refs/remotes/origin/main",
+                    "+refs/heads/develop:refs/remotes/origin/develop",
+                ),
                 "fetch origin branches",
                 "network unavailable",
             ),

--- a/.claude/skills/squire/tests/test_ci_policy.py
+++ b/.claude/skills/squire/tests/test_ci_policy.py
@@ -25,14 +25,26 @@ SNAPSHOT_COMMANDS = (
 
 
 def indented_block(text: str, header: str, indent: int) -> str:
-    pattern = re.compile(
-        rf"(?ms)^{re.escape(' ' * indent + header)}\n"
-        rf"(?P<body>(?:^(?:{' ' * (indent + 1)}.*|\s*)\n?)*)"
+    lines = text.splitlines(keepends=True)
+    expected_header = " " * indent + header
+    start = next(
+        (
+            index
+            for index, line in enumerate(lines)
+            if line.rstrip("\r\n") == expected_header
+        ),
+        None,
     )
-    match = pattern.search(text)
-    if match is None:
+    if start is None:
         raise AssertionError(f"missing block: {header}")
-    return match.group("body")
+
+    body = []
+    for line in lines[start + 1 :]:
+        if not line.strip() or len(line) - len(line.lstrip(" ")) > indent:
+            body.append(line)
+        else:
+            break
+    return "".join(body)
 
 
 def inline_list(block: str, key: str) -> list[str]:
@@ -75,6 +87,9 @@ def assert_publish_policy(workflow: str) -> None:
         raise AssertionError("publish predicate does not match the release allowlist")
     if len(re.findall(r"(?m)^      - name: Release\s*$", publish)) != 1:
         raise AssertionError("publish job must contain exactly one Release step")
+    release = indented_block(publish, "- name: Release", 6)
+    if release.count("mise run publish:sonatype") != 1:
+        raise AssertionError("Release step must contain the Sonatype publish invocation")
     if workflow.count("mise run publish:sonatype") != 1:
         raise AssertionError("workflow must contain exactly one Sonatype publish invocation")
 
@@ -169,6 +184,17 @@ class CiPolicyTest(unittest.TestCase):
             "          mise run publish:sonatype\n          mise run publish:sonatype",
             1,
         )
+        unguarded_publish_path = self.workflow.replace(
+            "          mise run publish:sonatype",
+            "          echo release command moved",
+            1,
+        ) + (
+            "\n  unguarded-publish:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - name: Bypass Release\n"
+            "        run: mise run publish:sonatype\n"
+        )
 
         mutations = (
             ("extra push branch", assert_branch_policy, push_with_extra_branch),
@@ -187,6 +213,11 @@ class CiPolicyTest(unittest.TestCase):
                 "duplicate publish command",
                 assert_publish_policy,
                 duplicate_publish_path,
+            ),
+            (
+                "publish command moved to unguarded job",
+                assert_publish_policy,
+                unguarded_publish_path,
             ),
         )
         for name, validator, mutation in mutations:

--- a/.claude/skills/squire/tests/test_ci_policy.py
+++ b/.claude/skills/squire/tests/test_ci_policy.py
@@ -1,3 +1,9 @@
+"""CI policy checks use stdlib text parsing intentionally.
+
+Canonical formatting keeps security-sensitive Actions expressions reviewable while
+avoiding YAML 1.1 coercion surprises and dependencies on YAML or expression parsers.
+"""
+
 import re
 import unittest
 from pathlib import Path
@@ -12,11 +18,11 @@ PUBLISH_PREDICATE = (
     "github.ref == 'refs/heads/develop' || "
     "startsWith(github.ref, 'refs/tags/'))"
 )
-CACHE_PREDICATES = (
-    "github.ref == 'refs/heads/main'",
-    "github.ref == 'refs/heads/0.4.x'",
-    "github.ref == 'refs/heads/develop'",
-    "startsWith(github.ref, 'refs/tags/')",
+CACHE_PREDICATE = (
+    "github.ref == 'refs/heads/main' || "
+    "github.ref == 'refs/heads/0.4.x' || "
+    "github.ref == 'refs/heads/develop' || "
+    "startsWith(github.ref, 'refs/tags/')"
 )
 SNAPSHOT_COMMANDS = (
     'echo "MORPHIR_PUBLISH_MODE=snapshot" >> "$GITHUB_ENV"',
@@ -63,6 +69,10 @@ def scalar(block: str, key: str) -> str:
     if match is None:
         raise AssertionError(f"missing scalar: {key}")
     return match.group(1)
+
+
+def normalize_expression(expression: str) -> str:
+    return " ".join(expression.split())
 
 
 def publish_block(workflow: str) -> str:
@@ -130,9 +140,8 @@ def assert_cache_policy(workflow: str) -> None:
         job = indented_block(workflow, job_name, 2)
         step = indented_block(job, f"- name: {step_name}", 6)
         condition = scalar(step, "if")
-        missing = [predicate for predicate in CACHE_PREDICATES if predicate not in condition]
-        if missing:
-            raise AssertionError(f"{step_name} is missing predicates: {missing!r}")
+        if normalize_expression(condition) != normalize_expression(CACHE_PREDICATE):
+            raise AssertionError(f"{step_name} has an unapproved condition: {condition}")
 
 
 def replace_in_job(workflow: str, job_name: str, old: str, new: str) -> str:
@@ -225,10 +234,28 @@ class CiPolicyTest(unittest.TestCase):
                 self.assertRaises(AssertionError, validator, mutation)
 
     def test_cache_validator_rejects_every_required_predicate_removed_from_each_job(self):
+        required_predicates = (
+            "github.ref == 'refs/heads/main'",
+            "github.ref == 'refs/heads/0.4.x'",
+            "github.ref == 'refs/heads/develop'",
+            "startsWith(github.ref, 'refs/tags/')",
+        )
         for job_name in ("test-js:", "test-jvm:"):
-            for predicate in CACHE_PREDICATES:
+            for predicate in required_predicates:
                 with self.subTest(job=job_name, removed=predicate):
                     mutation = replace_in_job(self.workflow, job_name, predicate, "false")
+                    self.assertRaises(AssertionError, assert_cache_policy, mutation)
+
+    def test_cache_validator_rejects_disabled_or_broadened_conditions(self):
+        for job_name in ("test-js:", "test-jvm:"):
+            for label, condition in (
+                ("disabled", f"false && ({CACHE_PREDICATE})"),
+                ("broadened", f"({CACHE_PREDICATE}) || true"),
+            ):
+                with self.subTest(job=job_name, mutation=label):
+                    mutation = replace_in_job(
+                        self.workflow, job_name, CACHE_PREDICATE, condition
+                    )
                     self.assertRaises(AssertionError, assert_cache_policy, mutation)
 
 

--- a/.claude/skills/squire/tests/test_ci_policy.py
+++ b/.claude/skills/squire/tests/test_ci_policy.py
@@ -150,12 +150,12 @@ def assert_squire_ci_policy(workflow: str) -> None:
         raise AssertionError(f"workflow must contain exactly one {step_name} step")
 
     lint = indented_block(workflow, "lint:", 2)
-    step_names = re.findall(r"(?m)^      - name: (.+?)\s*$", lint)
+    step_headers = re.findall(r"(?m)^      - (.+?)\s*$", lint)
     try:
-        lint_index = step_names.index("Lint code")
+        lint_index = step_headers.index("name: Lint code")
     except ValueError as error:
         raise AssertionError("lint job must contain the Lint code step") from error
-    if step_names[lint_index + 1 : lint_index + 2] != [step_name]:
+    if step_headers[lint_index + 1 : lint_index + 2] != [f"name: {step_name}"]:
         raise AssertionError(f"{step_name} must immediately follow Lint code")
 
     step = indented_block(lint, f"- name: {step_name}", 6)
@@ -201,6 +201,11 @@ class CiPolicyTest(unittest.TestCase):
             policy_step * 2,
             1,
         )
+        unnamed_intermediate_step = self.workflow.replace(
+            policy_step,
+            "      - run: echo intermediate\n" + policy_step,
+            1,
+        )
         wrong_job = self.workflow.replace(policy_step, "", 1) + (
             "\n  bypass-policy:\n"
             "    runs-on: ubuntu-latest\n"
@@ -209,6 +214,7 @@ class CiPolicyTest(unittest.TestCase):
         )
         for name, mutation in (
             ("duplicate step", duplicate_step),
+            ("unnamed intermediate step", unnamed_intermediate_step),
             ("step in another job", wrong_job),
         ):
             with self.subTest(mutation=name):

--- a/.claude/skills/squire/tests/test_ci_policy.py
+++ b/.claude/skills/squire/tests/test_ci_policy.py
@@ -1,0 +1,96 @@
+import re
+import unittest
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).parents[4] / ".github/workflows/ci.yml"
+
+
+def indented_block(text: str, header: str, indent: int) -> str:
+    pattern = re.compile(
+        rf"(?ms)^{re.escape(' ' * indent + header)}\n"
+        rf"(?P<body>(?:^(?:{' ' * (indent + 1)}.*|\s*)\n?)*)"
+    )
+    match = pattern.search(text)
+    if match is None:
+        raise AssertionError(f"missing block: {header}")
+    return match.group("body")
+
+
+def inline_list(block: str, key: str) -> set[str]:
+    match = re.search(rf"(?m)^\s*{re.escape(key)}:\s*\[(?P<items>[^]]*)]$", block)
+    if match is None:
+        raise AssertionError(f"missing inline list: {key}")
+    return {
+        item.strip().strip('"\'')
+        for item in match.group("items").split(",")
+        if item.strip()
+    }
+
+
+class CiPolicyTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_pull_requests_and_pushes_target_supported_branches(self):
+        events = indented_block(self.workflow, "on:", 0)
+        pull_request = indented_block(events, "pull_request:", 2)
+        push = indented_block(events, "push:", 2)
+
+        expected = {"main", "0.4.x", "develop"}
+        self.assertEqual(inline_list(pull_request, "branches"), expected)
+        self.assertTrue(expected <= inline_list(push, "branches"))
+
+    def test_publish_waits_for_ci_and_accepts_only_owned_release_refs(self):
+        publish = indented_block(self.workflow, "publish:", 2)
+        self.assertRegex(publish, r"(?m)^\s+needs:\s*\[ci]$")
+
+        predicate = re.search(r"(?m)^\s+if:\s*(.+)$", publish)
+        self.assertIsNotNone(predicate)
+        self.assertEqual(
+            predicate.group(1),
+            "github.repository == 'finos/morphir-scala' && "
+            "(github.ref == 'refs/heads/main' || "
+            "github.ref == 'refs/heads/0.4.x' || "
+            "github.ref == 'refs/heads/develop' || "
+            "startsWith(github.ref, 'refs/tags/'))",
+        )
+        self.assertNotIn("refs/pull", predicate.group(1))
+
+    def test_develop_snapshot_configuration_is_scoped_and_precedes_release(self):
+        publish = indented_block(self.workflow, "publish:", 2)
+        snapshot = indented_block(
+            publish, "- name: Configure develop snapshot version", 6
+        )
+        self.assertIn("if: github.ref == 'refs/heads/develop'", snapshot)
+        self.assertIn(
+            'echo "MORPHIR_PUBLISH_MODE=snapshot" >> "$GITHUB_ENV"', snapshot
+        )
+        self.assertIn(
+            'echo "MORPHIR_PUBLISH_BRANCH=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"',
+            snapshot,
+        )
+        self.assertLess(
+            publish.index("- name: Configure develop snapshot version"),
+            publish.index("- name: Release"),
+        )
+        self.assertEqual(publish.count("MORPHIR_PUBLISH_MODE="), 1)
+        self.assertEqual(publish.count("MORPHIR_PUBLISH_BRANCH="), 1)
+
+    def test_js_and_jvm_cache_saves_include_develop_and_tags(self):
+        for job_name, step_name in (
+            ("test-js:", "Cache JS build output"),
+            ("test-jvm:", "Cache JVM build output"),
+        ):
+            with self.subTest(job=job_name):
+                job = indented_block(self.workflow, job_name, 2)
+                step = indented_block(job, f"- name: {step_name}", 6)
+                condition = re.search(r"(?m)^\s+if:\s*(.+)$", step)
+                self.assertIsNotNone(condition)
+                self.assertIn("github.ref == 'refs/heads/develop'", condition.group(1))
+                self.assertIn("startsWith(github.ref, 'refs/tags/')", condition.group(1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/squire/tests/test_ci_policy.py
+++ b/.claude/skills/squire/tests/test_ci_policy.py
@@ -144,6 +144,27 @@ def assert_cache_policy(workflow: str) -> None:
             raise AssertionError(f"{step_name} has an unapproved condition: {condition}")
 
 
+def assert_squire_ci_policy(workflow: str) -> None:
+    step_name = "Test Squire and release policy"
+    if len(re.findall(rf"(?m)^      - name: {re.escape(step_name)}\s*$", workflow)) != 1:
+        raise AssertionError(f"workflow must contain exactly one {step_name} step")
+
+    lint = indented_block(workflow, "lint:", 2)
+    step_names = re.findall(r"(?m)^      - name: (.+?)\s*$", lint)
+    try:
+        lint_index = step_names.index("Lint code")
+    except ValueError as error:
+        raise AssertionError("lint job must contain the Lint code step") from error
+    if step_names[lint_index + 1 : lint_index + 2] != [step_name]:
+        raise AssertionError(f"{step_name} must immediately follow Lint code")
+
+    step = indented_block(lint, f"- name: {step_name}", 6)
+    if scalar(step, "run") != "mise run test:squire":
+        raise AssertionError(f"{step_name} must run mise run test:squire exactly")
+    if workflow.count("mise run test:squire") != 1:
+        raise AssertionError("workflow must invoke test:squire exactly once")
+
+
 def replace_in_job(workflow: str, job_name: str, old: str, new: str) -> str:
     job = indented_block(workflow, job_name, 2)
     if old not in job:
@@ -167,6 +188,31 @@ class CiPolicyTest(unittest.TestCase):
 
     def test_each_js_and_jvm_cache_save_retains_all_release_refs(self):
         assert_cache_policy(self.workflow)
+
+    def test_lint_job_runs_squire_and_release_policy_exactly_once_after_lint(self):
+        assert_squire_ci_policy(self.workflow)
+
+        policy_step = (
+            "      - name: Test Squire and release policy\n"
+            "        run: mise run test:squire\n"
+        )
+        duplicate_step = self.workflow.replace(
+            policy_step,
+            policy_step * 2,
+            1,
+        )
+        wrong_job = self.workflow.replace(policy_step, "", 1) + (
+            "\n  bypass-policy:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            f"{policy_step}"
+        )
+        for name, mutation in (
+            ("duplicate step", duplicate_step),
+            ("step in another job", wrong_job),
+        ):
+            with self.subTest(mutation=name):
+                self.assertRaises(AssertionError, assert_squire_ci_policy, mutation)
 
     def test_policy_validators_reject_representative_regressions(self):
         push_with_extra_branch = self.workflow.replace(

--- a/.claude/skills/squire/tests/test_ci_policy.py
+++ b/.claude/skills/squire/tests/test_ci_policy.py
@@ -4,6 +4,24 @@ from pathlib import Path
 
 
 WORKFLOW = Path(__file__).parents[4] / ".github/workflows/ci.yml"
+SUPPORTED_BRANCHES = ["main", "0.4.x", "develop"]
+PUBLISH_PREDICATE = (
+    "github.repository == 'finos/morphir-scala' && "
+    "(github.ref == 'refs/heads/main' || "
+    "github.ref == 'refs/heads/0.4.x' || "
+    "github.ref == 'refs/heads/develop' || "
+    "startsWith(github.ref, 'refs/tags/'))"
+)
+CACHE_PREDICATES = (
+    "github.ref == 'refs/heads/main'",
+    "github.ref == 'refs/heads/0.4.x'",
+    "github.ref == 'refs/heads/develop'",
+    "startsWith(github.ref, 'refs/tags/')",
+)
+SNAPSHOT_COMMANDS = (
+    'echo "MORPHIR_PUBLISH_MODE=snapshot" >> "$GITHUB_ENV"',
+    'echo "MORPHIR_PUBLISH_BRANCH=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"',
+)
 
 
 def indented_block(text: str, header: str, indent: int) -> str:
@@ -17,15 +35,96 @@ def indented_block(text: str, header: str, indent: int) -> str:
     return match.group("body")
 
 
-def inline_list(block: str, key: str) -> set[str]:
+def inline_list(block: str, key: str) -> list[str]:
     match = re.search(rf"(?m)^\s*{re.escape(key)}:\s*\[(?P<items>[^]]*)]$", block)
     if match is None:
         raise AssertionError(f"missing inline list: {key}")
-    return {
+    return [
         item.strip().strip('"\'')
         for item in match.group("items").split(",")
         if item.strip()
-    }
+    ]
+
+
+def scalar(block: str, key: str) -> str:
+    match = re.search(rf"(?m)^\s+{re.escape(key)}:\s*(.+)$", block)
+    if match is None:
+        raise AssertionError(f"missing scalar: {key}")
+    return match.group(1)
+
+
+def publish_block(workflow: str) -> str:
+    if len(re.findall(r"(?m)^  publish:\s*$", workflow)) != 1:
+        raise AssertionError("workflow must contain exactly one publish job")
+    return indented_block(workflow, "publish:", 2)
+
+
+def assert_branch_policy(workflow: str) -> None:
+    events = indented_block(workflow, "on:", 0)
+    for event in ("pull_request:", "push:"):
+        branches = inline_list(indented_block(events, event, 2), "branches")
+        if branches != SUPPORTED_BRANCHES:
+            raise AssertionError(f"{event} branches were {branches!r}")
+
+
+def assert_publish_policy(workflow: str) -> None:
+    publish = publish_block(workflow)
+    if scalar(publish, "needs") != "[ci]":
+        raise AssertionError("publish must depend only on aggregate ci")
+    if scalar(publish, "if") != PUBLISH_PREDICATE:
+        raise AssertionError("publish predicate does not match the release allowlist")
+    if len(re.findall(r"(?m)^      - name: Release\s*$", publish)) != 1:
+        raise AssertionError("publish job must contain exactly one Release step")
+    if workflow.count("mise run publish:sonatype") != 1:
+        raise AssertionError("workflow must contain exactly one Sonatype publish invocation")
+
+
+def assert_snapshot_policy(workflow: str) -> None:
+    publish = publish_block(workflow)
+    snapshot = indented_block(
+        publish, "- name: Configure develop snapshot version", 6
+    )
+    if scalar(snapshot, "if") != "github.ref == 'refs/heads/develop'":
+        raise AssertionError("snapshot step must run only on develop")
+
+    run = re.search(r"(?m)^        run: \|\n(?P<body>(?:^          .*\n?)*)", snapshot)
+    if run is None:
+        raise AssertionError("snapshot step must have a literal run block")
+    commands = tuple(line[10:] for line in run.group("body").splitlines())
+    if commands != SNAPSHOT_COMMANDS:
+        raise AssertionError(f"unexpected snapshot commands: {commands!r}")
+    if publish.index("- name: Configure develop snapshot version") >= publish.index(
+        "- name: Release"
+    ):
+        raise AssertionError("snapshot configuration must precede Release")
+    for assignment in (
+        "MORPHIR_PUBLISH_MODE=snapshot",
+        "MORPHIR_PUBLISH_BRANCH=${GITHUB_REF_NAME}",
+    ):
+        if workflow.count(assignment) != 1:
+            raise AssertionError(
+                f"snapshot assignment must occur exactly once: {assignment}"
+            )
+
+
+def assert_cache_policy(workflow: str) -> None:
+    for job_name, step_name in (
+        ("test-js:", "Cache JS build output"),
+        ("test-jvm:", "Cache JVM build output"),
+    ):
+        job = indented_block(workflow, job_name, 2)
+        step = indented_block(job, f"- name: {step_name}", 6)
+        condition = scalar(step, "if")
+        missing = [predicate for predicate in CACHE_PREDICATES if predicate not in condition]
+        if missing:
+            raise AssertionError(f"{step_name} is missing predicates: {missing!r}")
+
+
+def replace_in_job(workflow: str, job_name: str, old: str, new: str) -> str:
+    job = indented_block(workflow, job_name, 2)
+    if old not in job:
+        raise AssertionError(f"mutation target not found in {job_name}: {old}")
+    return workflow.replace(job, job.replace(old, new, 1), 1)
 
 
 class CiPolicyTest(unittest.TestCase):
@@ -33,63 +132,73 @@ class CiPolicyTest(unittest.TestCase):
     def setUpClass(cls):
         cls.workflow = WORKFLOW.read_text(encoding="utf-8")
 
-    def test_pull_requests_and_pushes_target_supported_branches(self):
-        events = indented_block(self.workflow, "on:", 0)
-        pull_request = indented_block(events, "pull_request:", 2)
-        push = indented_block(events, "push:", 2)
+    def test_pull_requests_and_pushes_target_exact_supported_branches(self):
+        assert_branch_policy(self.workflow)
 
-        expected = {"main", "0.4.x", "develop"}
-        self.assertEqual(inline_list(pull_request, "branches"), expected)
-        self.assertTrue(expected <= inline_list(push, "branches"))
+    def test_publish_waits_for_ci_and_has_one_owned_release_path(self):
+        assert_publish_policy(self.workflow)
 
-    def test_publish_waits_for_ci_and_accepts_only_owned_release_refs(self):
-        publish = indented_block(self.workflow, "publish:", 2)
-        self.assertRegex(publish, r"(?m)^\s+needs:\s*\[ci]$")
+    def test_develop_snapshot_configuration_is_exact_scoped_and_unique(self):
+        assert_snapshot_policy(self.workflow)
 
-        predicate = re.search(r"(?m)^\s+if:\s*(.+)$", publish)
-        self.assertIsNotNone(predicate)
-        self.assertEqual(
-            predicate.group(1),
-            "github.repository == 'finos/morphir-scala' && "
-            "(github.ref == 'refs/heads/main' || "
-            "github.ref == 'refs/heads/0.4.x' || "
-            "github.ref == 'refs/heads/develop' || "
-            "startsWith(github.ref, 'refs/tags/'))",
-        )
-        self.assertNotIn("refs/pull", predicate.group(1))
+    def test_each_js_and_jvm_cache_save_retains_all_release_refs(self):
+        assert_cache_policy(self.workflow)
 
-    def test_develop_snapshot_configuration_is_scoped_and_precedes_release(self):
-        publish = indented_block(self.workflow, "publish:", 2)
-        snapshot = indented_block(
-            publish, "- name: Configure develop snapshot version", 6
+    def test_policy_validators_reject_representative_regressions(self):
+        push_with_extra_branch = self.workflow.replace(
+            '  push:\n    branches: ["main", "0.4.x", "develop"]',
+            '  push:\n    branches: ["main", "0.4.x", "develop", "feature"]',
+            1,
         )
-        self.assertIn("if: github.ref == 'refs/heads/develop'", snapshot)
-        self.assertIn(
-            'echo "MORPHIR_PUBLISH_MODE=snapshot" >> "$GITHUB_ENV"', snapshot
+        broad_snapshot_condition = self.workflow.replace(
+            "        if: github.ref == 'refs/heads/develop'\n        run: |",
+            "        if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'\n        run: |",
+            1,
         )
-        self.assertIn(
-            'echo "MORPHIR_PUBLISH_BRANCH=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"',
-            snapshot,
+        extra_snapshot_write = self.workflow.replace(
+            f"          {SNAPSHOT_COMMANDS[1]}",
+            f"          {SNAPSHOT_COMMANDS[1]}\n          echo EXTRA=true >> \"$GITHUB_ENV\"",
+            1,
         )
-        self.assertLess(
-            publish.index("- name: Configure develop snapshot version"),
-            publish.index("- name: Release"),
+        duplicate_snapshot_assignment = (
+            self.workflow
+            + '\nenv:\n  DUPLICATE: "MORPHIR_PUBLISH_MODE=snapshot"\n'
         )
-        self.assertEqual(publish.count("MORPHIR_PUBLISH_MODE="), 1)
-        self.assertEqual(publish.count("MORPHIR_PUBLISH_BRANCH="), 1)
+        duplicate_publish_path = self.workflow.replace(
+            "          mise run publish:sonatype",
+            "          mise run publish:sonatype\n          mise run publish:sonatype",
+            1,
+        )
 
-    def test_js_and_jvm_cache_saves_include_develop_and_tags(self):
-        for job_name, step_name in (
-            ("test-js:", "Cache JS build output"),
-            ("test-jvm:", "Cache JVM build output"),
-        ):
-            with self.subTest(job=job_name):
-                job = indented_block(self.workflow, job_name, 2)
-                step = indented_block(job, f"- name: {step_name}", 6)
-                condition = re.search(r"(?m)^\s+if:\s*(.+)$", step)
-                self.assertIsNotNone(condition)
-                self.assertIn("github.ref == 'refs/heads/develop'", condition.group(1))
-                self.assertIn("startsWith(github.ref, 'refs/tags/')", condition.group(1))
+        mutations = (
+            ("extra push branch", assert_branch_policy, push_with_extra_branch),
+            (
+                "broadened snapshot condition",
+                assert_snapshot_policy,
+                broad_snapshot_condition,
+            ),
+            ("extra snapshot write", assert_snapshot_policy, extra_snapshot_write),
+            (
+                "duplicate snapshot assignment",
+                assert_snapshot_policy,
+                duplicate_snapshot_assignment,
+            ),
+            (
+                "duplicate publish command",
+                assert_publish_policy,
+                duplicate_publish_path,
+            ),
+        )
+        for name, validator, mutation in mutations:
+            with self.subTest(mutation=name):
+                self.assertRaises(AssertionError, validator, mutation)
+
+    def test_cache_validator_rejects_every_required_predicate_removed_from_each_job(self):
+        for job_name in ("test-js:", "test-jvm:"):
+            for predicate in CACHE_PREDICATES:
+                with self.subTest(job=job_name, removed=predicate):
+                    mutation = replace_in_job(self.workflow, job_name, predicate, "false")
+                    self.assertRaises(AssertionError, assert_cache_policy, mutation)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/squire/tests/test_mise_task_policy.py
+++ b/.claude/skills/squire/tests/test_mise_task_policy.py
@@ -1,0 +1,55 @@
+"""Regression tests for Squire's Mise task integration."""
+
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).parents[4]
+CI_DEPENDENCIES = [
+    "setup",
+    "lint",
+    "test:squire",
+    "build:morphir-elm",
+    "test:jvm",
+    "test:js",
+    "test:native",
+]
+
+
+def mise(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["mise", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+class MiseTaskPolicyTest(unittest.TestCase):
+    def test_local_ci_resolves_squire_task_metadata_and_dependency(self):
+        ci_info = json.loads(mise("task", "info", "ci:local", "--json").stdout)
+        squire_info = json.loads(
+            mise("task", "info", "test:squire", "--json").stdout
+        )
+
+        dependency_names = [
+            dependency
+            if isinstance(dependency, str)
+            else dependency["task"]
+            for dependency in ci_info["depends"]
+        ]
+        self.assertEqual(dependency_names, CI_DEPENDENCIES)
+        self.assertEqual(
+            squire_info["description"],
+            "Test Squire commands and build/release policy",
+        )
+
+        dry_run = mise("run", "--dry-run", "ci:local")
+        self.assertIn("test:squire", dry_run.stdout + dry_run.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/squire/tests/test_mise_task_policy.py
+++ b/.claude/skills/squire/tests/test_mise_task_policy.py
@@ -42,6 +42,7 @@ class MiseTaskPolicyTest(unittest.TestCase):
             for dependency in ci_info["depends"]
         ]
         self.assertEqual(dependency_names, CI_DEPENDENCIES)
+        self.assertEqual(ci_info["description"], "Run the core CI workflow locally")
         self.assertEqual(
             squire_info["description"],
             "Test Squire commands and build/release policy",

--- a/.config/mise/tasks/ci/local
+++ b/.config/mise/tasks/ci/local
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # MISE description="Run the core CI workflow locally"
-# MISE depends=["setup", "lint", "build:morphir-elm", "test:jvm", "test:js", "test:native"]
+# MISE depends=["setup", "lint", "test:squire", "build:morphir-elm", "test:jvm", "test:js", "test:native"]
 
 echo "ci:local complete"

--- a/.config/mise/tasks/ci/local
+++ b/.config/mise/tasks/ci/local
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # MISE description="Run the core CI workflow locally"
-# MISE depends=["setup", "lint", "test:squire", "build:morphir-elm", "test:jvm", "test:js", "test:native"]
+#MISE depends=["setup", "lint", "test:squire", "build:morphir-elm", "test:jvm", "test:js", "test:native"]
 
 echo "ci:local complete"

--- a/.config/mise/tasks/ci/local
+++ b/.config/mise/tasks/ci/local
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# MISE description="Run the core CI workflow locally"
+#MISE description="Run the core CI workflow locally"
 #MISE depends=["setup", "lint", "test:squire", "build:morphir-elm", "test:jvm", "test:js", "test:native"]
 
 echo "ci:local complete"

--- a/.config/mise/tasks/test/squire
+++ b/.config/mise/tasks/test/squire
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# MISE description="Test Squire commands and build/release policy"
+set -euo pipefail
+python3 -m unittest discover -s .claude/skills/squire/tests -p 'test_*.py' -v
+./mill --ticker false mill-build/test/SnapshotVersionTests.scala

--- a/.config/mise/tasks/test/squire
+++ b/.config/mise/tasks/test/squire
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# MISE description="Test Squire commands and build/release policy"
+#MISE description="Test Squire commands and build/release policy"
 set -euo pipefail
 python3 -m unittest discover -s .claude/skills/squire/tests -p 'test_*.py' -v
 ./mill --ticker false mill-build/test/SnapshotVersionTests.scala

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,9 @@ env:
 
 on:
   pull_request:
+    branches: ["main", "0.4.x", "develop"]
   push:
-    branches: ["main", "0.4.x"]
+    branches: ["main", "0.4.x", "develop"]
   release:
     types:
       - published
@@ -126,7 +127,7 @@ jobs:
 
       - name: Cache JS build output
         # when in master repo: all commits to main branch and all additional tags
-        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.4.x') || ((github.ref != 'refs/heads/main' && github.ref != 'refs/heads/0.4.x') && startsWith( github.ref, 'refs/tags/') )
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.4.x' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/')
         uses: actions/cache/save@v6
         with:
           path: |
@@ -229,7 +230,7 @@ jobs:
 
       - name: Cache JVM build output
         # when in master repo: all commits to main branch and all additional tags
-        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.4.x') || ((github.ref != 'refs/heads/main' && github.ref != 'refs/heads/0.4.x') && startsWith( github.ref, 'refs/tags/') )
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.4.x' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/')
         uses: actions/cache/save@v6
         with:
           path: |
@@ -240,7 +241,7 @@ jobs:
 
   publish:
     # when in master repo: all commits to main branch and all additional tags
-    if: github.repository == 'finos/morphir-scala' && ( github.ref == 'refs/heads/main' || github.ref == 'refs/head/0.4.x' || (github.ref != 'refs/heads/main' && github.ref != 'refs/heads/0.4.x' && startsWith( github.ref, 'refs/tags/') ) )
+    if: github.repository == 'finos/morphir-scala' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.4.x' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/'))
     needs: [ci]
 
     runs-on: ubuntu-latest
@@ -297,6 +298,12 @@ jobs:
           path: |
             out/morphir/**/js/
           key: ${{ runner.os }}-mill-js-25-${{ github.sha }}
+
+      - name: Configure develop snapshot version
+        if: github.ref == 'refs/heads/develop'
+        run: |
+          echo "MORPHIR_PUBLISH_MODE=snapshot" >> "$GITHUB_ENV"
+          echo "MORPHIR_PUBLISH_BRANCH=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
 
       - name: Release
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
           ELM_TOOLING_INSTALL=1 mise run setup
       - name: Lint code
         run: mise run lint
+      - name: Test Squire and release policy
+        run: mise run test:squire
 
   knowledge-base:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,10 @@ snapshot repository and depend on the exact coordinate they intend to test:
 https://central.sonatype.com/repository/maven-snapshots
 ```
 
-Snapshot artifacts may be replaced or resolved according to the repository's snapshot behavior. The branch,
-distance, and revision components make the requested source state explicit even when repository metadata changes.
+The revision-bearing logical version is traceable, but its `-SNAPSHOT` artifact is mutable and may be overwritten.
+[Sonatype's snapshot documentation](https://central.sonatype.org/publish/publish-portal-snapshots/) says snapshots
+are currently cleaned up after 90 days. Do not treat this coordinate as an immutable, reproducible-release lock;
+resolution and availability follow the snapshot repository's behavior.
 
 Publication from `main`, `0.4.x`, and tags continues to use the ordinary VCS-derived milestone and release flow. The
 snapshot environment is configured only for `develop`, never for `main` or tags.
@@ -49,8 +51,18 @@ Maintainers open a `develop`-to-`main` release pull request and **MUST squash-me
 in GitHub is an operator precondition: the refresh script can prove the merged pull request and its ancestry, but it
 cannot determine which merge method GitHub used.
 
-After the squash merge is visible on `origin/main`, first prove the default `develop` refresh without pushing, review
-the reported branch and SHAs, and then perform it:
+After the squash merge is visible on `origin/main`, verify that `origin` is the intended canonical repository and that
+the GitHub CLI is authenticated and resolves the same repository:
+
+```bash
+git remote get-url origin
+gh auth status
+gh repo view --json nameWithOwner --jq .nameWithOwner
+```
+
+Stop if the remote is not the canonical `finos/morphir-scala` repository or the final command does not print
+`finos/morphir-scala`. Then prove the default `develop` refresh without pushing, review the reported branch and SHAs,
+and perform it:
 
 ```bash
 python3 .claude/skills/squire/scripts/branch-refresh.py --dry-run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,57 @@ Before making a contribution, please take the following steps:
 
 NOTE: All contributors must have a contributor license agreement (CLA) on file with FINOS before their pull requests will be merged. Please review the FINOS [contribution requirements](https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/75530375/Contribution+Compliance+Requirements) and submit (or have your employer submit) the required CLA before submitting a pull request.
 
+## Development and snapshot releases
+
+Feature and contributor pull requests target `develop`. Pull-request events run the validation jobs, but never
+publish artifacts. After a pull request is merged, a successful push to `develop` runs the full aggregate CI gate and
+then automatically publishes a traceable snapshot from the canonical `finos/morphir-scala` repository. Publication
+credentials remain in that repository's CI environment; contributors neither need nor receive them locally. An
+administrator must first enable snapshot support for the project's Sonatype namespace.
+
+Each snapshot uses an exact coordinate such as:
+
+```text
+0.5.0-M04-develop.57.gbd4cd2-SNAPSHOT
+0.5.0-develop.57.gbd4cd2-SNAPSHOT
+```
+
+The coordinate contains the release line (`0.5.0`), an optional release-line qualifier (`M04`), the branch
+(`develop`), the commit distance from the nearest version tag (`57`), a `g` followed by the first six hexadecimal
+characters of the Git revision (`bd4cd2`), and the terminal `SNAPSHOT` marker. Consumers must add the Sonatype
+snapshot repository and depend on the exact coordinate they intend to test:
+
+```text
+https://central.sonatype.com/repository/maven-snapshots
+```
+
+Snapshot artifacts may be replaced or resolved according to the repository's snapshot behavior. The branch,
+distance, and revision components make the requested source state explicit even when repository metadata changes.
+
+Publication from `main`, `0.4.x`, and tags continues to use the ordinary VCS-derived milestone and release flow. The
+snapshot environment is configured only for `develop`, never for `main` or tags.
+
+### Promoting `develop` to `main`
+
+Maintainers open a `develop`-to-`main` release pull request and **MUST squash-merge it**. Confirming the squash merge
+in GitHub is an operator precondition: the refresh script can prove the merged pull request and its ancestry, but it
+cannot determine which merge method GitHub used.
+
+After the squash merge is visible on `origin/main`, first prove the default `develop` refresh without pushing, review
+the reported branch and SHAs, and then perform it:
+
+```bash
+python3 .claude/skills/squire/scripts/branch-refresh.py --dry-run
+python3 .claude/skills/squire/scripts/branch-refresh.py
+```
+
+The equivalent assisted workflow is `/squire branch refresh`. The command defaults to `develop`; for a different
+integration branch, pass `--target <branch>` to both Python invocations. It fetches remote-tracking refs but does not
+check out a branch or mutate the working tree. Before updating the remote target, it requires the target SHA to match
+the merged pull request's exact head and requires that pull request's merge commit to be an ancestor of
+`origin/main`. It therefore refuses to refresh if `develop` advanced after the matching pull request. The only remote
+update it can make is protected by `--force-with-lease`; it never uses or recommends unconditional force.
+
 ## Governance
 
 ### Roles

--- a/build.mill
+++ b/build.mill
@@ -58,9 +58,10 @@ object scoverage extends ScoverageReport {
 trait MorphirPublishModule extends PublishModule with JavaModule with Mima with SonatypeCentralPublishModule {
   import mill.scalalib.publish.*
 
+  def publishVersionEnvironment = Task.Input { Task.env }
   def publishVersion = Task {
     SnapshotVersion
-      .select(VcsVersion.vcsState(), Task.env)
+      .select(VcsVersion.vcsState(), publishVersionEnvironment())
       .fold(message => throw new IllegalArgumentException(message), identity)
   }
   def packageDescription: String = s"The $artifactName package"

--- a/build.mill
+++ b/build.mill
@@ -58,7 +58,11 @@ object scoverage extends ScoverageReport {
 trait MorphirPublishModule extends PublishModule with JavaModule with Mima with SonatypeCentralPublishModule {
   import mill.scalalib.publish.*
 
-  def publishVersionEnvironment = Task.Input { Task.env }
+  def publishVersionEnvironment = Task.Input {
+    Seq("MORPHIR_PUBLISH_MODE", "MORPHIR_PUBLISH_BRANCH")
+      .flatMap(name => Task.env.get(name).map(name -> _))
+      .toMap
+  }
   def publishVersion = Task {
     SnapshotVersion
       .select(VcsVersion.vcsState(), publishVersionEnvironment())

--- a/build.mill
+++ b/build.mill
@@ -58,7 +58,11 @@ object scoverage extends ScoverageReport {
 trait MorphirPublishModule extends PublishModule with JavaModule with Mima with SonatypeCentralPublishModule {
   import mill.scalalib.publish.*
 
-  def publishVersion             = VcsVersion.vcsState().format()
+  def publishVersion = Task {
+    SnapshotVersion
+      .select(VcsVersion.vcsState(), Task.env)
+      .fold(message => throw new IllegalArgumentException(message), identity)
+  }
   def packageDescription: String = s"The $artifactName package"
   def pomSettings                = PomSettings(
     description = packageDescription,

--- a/kb/bundles/morphir/morphir-scala/continuous-integration.md
+++ b/kb/bundles/morphir/morphir-scala/continuous-integration.md
@@ -14,16 +14,29 @@ GitHub Actions runs linting, cross-platform tests and knowledge base checks on e
 
 | Job | Runs |
 | --- | ---- |
-| `lint` | `mise run lint` — scalafmt check across the Scala sources |
+| `lint` | `mise run lint` plus `mise run test:squire` — scalafmt and Squire/release-policy gates |
 | `knowledge-base` | `kb check` and `kb intent check` |
 | `test-jvm` | JVM tests, including the Cucumber/JUnit5 `langkit.itest` suite |
 | `test-js` | ScalaJS tests, including the WebAssembly link variants |
 | `test-native` | Scala Native tests |
-| `publish` | Sonatype publication, on main and tags only |
+| `publish` | Sonatype publication on `main`, `0.4.x`, tags, and `develop` snapshots |
 | `ci` | Aggregate gate — depends on lint, knowledge-base and all three test jobs |
 
-CI runs on pull requests, pushes to `main` and `0.4.x`, published releases, and manual dispatch. Older runs of the
-same pull request are cancelled automatically.
+CI runs on pull requests into `main`, `0.4.x`, and `develop`; pushes to those same branches; published releases; and
+manual dispatch. Older runs of the same pull request are cancelled automatically.
+
+## Develop snapshots
+
+A push or merge to `develop` must pass the full aggregate `ci` gate before publishing. The resulting exact coordinate
+is branch-qualified and traceable, for example `0.5.0-M04-develop.57.gbd4cd2-SNAPSHOT` or
+`0.5.0-develop.57.gbd4cd2-SNAPSHOT`: the release line may have a qualifier, and the coordinate records `develop`, the
+distance from the nearest version tag, and a six-character Git abbreviation before the terminal `SNAPSHOT` marker.
+
+Only non-PR runs in the canonical `finos/morphir-scala` repository can reach publication and its credentials. Pull
+requests validate without publishing, and contributors do not receive publication credentials locally. Consumers
+add `https://central.sonatype.com/repository/maven-snapshots` and select the exact coordinate; resolution and
+replacement follow the snapshot repository's behavior. Publication from `main`, `0.4.x`, and tags keeps the ordinary
+VCS-derived milestone and release flow, with no snapshot environment on `main` or tags.
 
 ## The knowledge-base job
 
@@ -41,6 +54,8 @@ warning that fails the build is a warning people route around.
 
 ```bash
 mise run kb:check
+mise run test:squire
 ```
 
-Same checks, same exit codes.
+These run the knowledge-base checks and the Squire/release-policy tests with the same exit codes used by CI.
+`mise run ci:local` includes `test:squire` in the full local aggregate workflow.

--- a/kb/bundles/morphir/morphir-scala/continuous-integration.md
+++ b/kb/bundles/morphir/morphir-scala/continuous-integration.md
@@ -1,14 +1,15 @@
 ---
 type: Capability
 title: Continuous Integration
-description: "GitHub Actions runs linting, cross-platform tests and knowledge base checks on every pull request."
+description: "GitHub Actions runs linting, cross-platform tests and knowledge base checks on pull requests targeting supported branches."
 tags: [ci, build]
 status: stable
 ---
 
 # Continuous Integration
 
-GitHub Actions runs linting, cross-platform tests and knowledge base checks on every pull request.
+GitHub Actions runs linting, cross-platform tests and knowledge base checks on pull requests targeting supported
+branches.
 
 ## Jobs
 
@@ -35,8 +36,11 @@ distance from the nearest version tag, and a six-character Git abbreviation befo
 Only non-PR runs in the canonical `finos/morphir-scala` repository can reach publication and its credentials. Pull
 requests validate without publishing, and contributors do not receive publication credentials locally. Consumers
 add `https://central.sonatype.com/repository/maven-snapshots` and select the exact coordinate; resolution and
-replacement follow the snapshot repository's behavior. Publication from `main`, `0.4.x`, and tags keeps the ordinary
-VCS-derived milestone and release flow, with no snapshot environment on `main` or tags.
+availability follow the snapshot repository's behavior. The revision-bearing logical version is traceable, but its
+`-SNAPSHOT` artifact is mutable and may be overwritten. Sonatype says snapshots are
+[currently cleaned up after 90 days](https://central.sonatype.org/publish/publish-portal-snapshots/), so the coordinate
+must not be treated as an immutable, reproducible-release lock. Publication from `main`, `0.4.x`, and tags keeps the
+ordinary VCS-derived milestone and release flow, with no snapshot environment on `main` or tags.
 
 ## The knowledge-base job
 

--- a/kb/bundles/morphir/morphir-scala/index.md
+++ b/kb/bundles/morphir/morphir-scala/index.md
@@ -14,7 +14,7 @@ immutable: why it is shaped that way, and what would have to change for the answ
 ## Orientation
 
 * [Knowledge Base Tooling](/knowledge-base-tooling.md) - The kb skill manages the OKF knowledge base and the intent recorded in it, from the command line.
-* [Continuous Integration](/continuous-integration.md) - GitHub Actions runs linting, cross-platform tests and knowledge base checks on every pull request.
+* [Continuous Integration](/continuous-integration.md) - GitHub Actions runs linting, cross-platform tests and knowledge base checks on pull requests targeting supported branches.
 * [Build System](/build-system.md) - Mill drives the build from per-directory package.mill.yaml files, with mise as the task runner.
 * [Cross-Platform Targets](/cross-platform-targets.md) - Modules compile to the JVM, ScalaJS, WebAssembly and Scala Native from one shared source layout.
 

--- a/kb/bundles/morphir/morphir-scala/log.md
+++ b/kb/bundles/morphir/morphir-scala/log.md
@@ -1,5 +1,10 @@
 # Log
 
+## 2026-08-07
+
+* **Update**: CI now validates pull requests into `develop` and, after the aggregate gate, publishes traceable
+  `develop` snapshots as described in [Continuous Integration](/continuous-integration.md).
+
 ## 2026-08-06
 
 * **Creation**: Accepted [Runtime closures retain parameter patterns](/decisions/0011-runtime-closures-retain-parameter-patterns.md), resolving the pre-release closure wire format.

--- a/mill-build/src/millbuild/SnapshotVersion.scala
+++ b/mill-build/src/millbuild/SnapshotVersion.scala
@@ -7,8 +7,14 @@ import mill.util.VcsVersion
 import java.util.Locale
 
 object SnapshotVersion {
-  private val SemverTag = raw"^v?(\d+\.\d+\.\d+)(?:-([0-9A-Za-z][0-9A-Za-z.-]*))?$$".r
-  private val Revision  = raw"^[0-9a-fA-F]{7,40}$$".r
+  private val SemverTag =
+    raw"^v?((?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$$".r
+  private val Revision = raw"^[0-9a-fA-F]{7,40}$$".r
+
+  private def validPrerelease(qualifier: String): Boolean =
+    qualifier.split('.').forall { identifier =>
+      !identifier.forall(_.isDigit) || identifier == "0" || !identifier.startsWith("0")
+    }
 
   def format(state: VcsVersion.State, branch: String): Either[String, String] =
     for {
@@ -30,8 +36,8 @@ object SnapshotVersion {
         "revision must be 7 to 40 hexadecimal characters"
       )
       releaseLine <- state.lastTag match {
-        case None                                => Right("0.0.0")
-        case Some(SemverTag(version, qualifier)) =>
+        case None => Right("0.0.0")
+        case Some(SemverTag(version, qualifier)) if Option(qualifier).forall(validPrerelease) =>
           Right(Option(qualifier).fold(version)(value => s"$version-$value"))
         case Some(tag) => Left(s"nearest tag '$tag' is not a semantic version")
       }

--- a/mill-build/src/millbuild/SnapshotVersion.scala
+++ b/mill-build/src/millbuild/SnapshotVersion.scala
@@ -1,0 +1,53 @@
+//| mvnDeps: ["com.lihaoyi::mill-libs-util:$MILL_VERSION"]
+
+package millbuild
+
+import mill.util.VcsVersion
+
+import java.util.Locale
+
+object SnapshotVersion {
+  private val SemverTag = raw"^v?(\d+\.\d+\.\d+)(?:-([0-9A-Za-z][0-9A-Za-z.-]*))?$$".r
+  private val Revision  = raw"^[0-9a-fA-F]{7,40}$$".r
+
+  def format(state: VcsVersion.State, branch: String): Either[String, String] =
+    for {
+      _ <- Either.cond(state.dirtyHash.isEmpty, (), "working tree is dirty")
+      _ <- Either.cond(
+        state.commitsSinceLastTag >= 0,
+        (),
+        "commit distance must not be negative"
+      )
+      normalizedBranch = branch
+        .toLowerCase(Locale.ROOT)
+        .replaceAll("[^a-z0-9]+", ".")
+        .stripPrefix(".")
+        .stripSuffix(".")
+      _ <- Either.cond(normalizedBranch.nonEmpty, (), "publish branch must not be empty")
+      _ <- Either.cond(
+        Revision.matches(state.currentRevision),
+        (),
+        "revision must be 7 to 40 hexadecimal characters"
+      )
+      releaseLine <- state.lastTag match {
+        case None                                => Right("0.0.0")
+        case Some(SemverTag(version, qualifier)) =>
+          Right(Option(qualifier).fold(version)(value => s"$version-$value"))
+        case Some(tag) => Left(s"nearest tag '$tag' is not a semantic version")
+      }
+    } yield {
+      val revision = state.currentRevision.take(6).toLowerCase(Locale.ROOT)
+      s"$releaseLine-$normalizedBranch.${state.commitsSinceLastTag}.g$revision-SNAPSHOT"
+    }
+
+  def select(state: VcsVersion.State, env: Map[String, String]): Either[String, String] =
+    env.get("MORPHIR_PUBLISH_MODE") match {
+      case None | Some("")  => Right(state.format())
+      case Some("snapshot") =>
+        env.get("MORPHIR_PUBLISH_BRANCH").filter(_.nonEmpty) match {
+          case Some(branch) => format(state, branch)
+          case None         => Left("MORPHIR_PUBLISH_BRANCH is required in snapshot mode")
+        }
+      case Some(mode) => Left(s"unsupported MORPHIR_PUBLISH_MODE '$mode'")
+    }
+}

--- a/mill-build/test/SnapshotVersionTests.scala
+++ b/mill-build/test/SnapshotVersionTests.scala
@@ -1,0 +1,88 @@
+//| moduleDeps: ["//mill-build/src/millbuild/SnapshotVersion.scala"]
+
+import mill.util.VcsVersion
+import millbuild.SnapshotVersion
+
+def assertEquals[A](actual: A, expected: A): Unit =
+  assert(actual == expected, s"Expected $expected, got $actual")
+
+def assertLeft(result: Either[String, String], clue: String): Unit =
+  assert(result.isLeft, s"Expected failure for $clue, got $result")
+
+def state(
+    tag: Option[String] = Some("v0.5.0-M04"),
+    distance: Int = 57,
+    revision: String = "bd4cd2cc1234567890abcdef1234567890abcdef",
+    dirtyHash: Option[String] = None
+): VcsVersion.State =
+  VcsVersion.State(revision, tag, distance, dirtyHash, Some(VcsVersion.git))
+
+@main def runSnapshotVersionTests(): Unit =
+  assertEquals(
+    SnapshotVersion.format(state(), "develop"),
+    Right("0.5.0-M04-develop.57.gbd4cd2-SNAPSHOT")
+  )
+
+  assertEquals(
+    SnapshotVersion.format(state(tag = Some("v0.5.0")), "develop"),
+    Right("0.5.0-develop.57.gbd4cd2-SNAPSHOT")
+  )
+  assertEquals(
+    SnapshotVersion.format(state(tag = None), "develop"),
+    Right("0.0.0-develop.57.gbd4cd2-SNAPSHOT")
+  )
+  assertEquals(
+    SnapshotVersion.format(state(distance = 0), "develop"),
+    Right("0.5.0-M04-develop.0.gbd4cd2-SNAPSHOT")
+  )
+  assertEquals(
+    SnapshotVersion.format(state(), "Feature///HELLO__World--"),
+    Right("0.5.0-M04-feature.hello.world.57.gbd4cd2-SNAPSHOT")
+  )
+  assertEquals(
+    SnapshotVersion.format(state(revision = "ABCDEF012345678901234567890123456789ABCD"), "DEVELOP"),
+    Right("0.5.0-M04-develop.57.gabcdef-SNAPSHOT")
+  )
+  assertEquals(
+    SnapshotVersion.format(state(revision = "1234567"), "develop"),
+    Right("0.5.0-M04-develop.57.g123456-SNAPSHOT")
+  )
+
+  assertLeft(SnapshotVersion.format(state(), "---"), "an empty normalized branch")
+  assertLeft(SnapshotVersion.format(state(revision = "123456"), "develop"), "a short revision")
+  assertLeft(SnapshotVersion.format(state(revision = "123456g"), "develop"), "a nonhex revision")
+  assertLeft(
+    SnapshotVersion.format(state(revision = "12345678901234567890123456789012345678901"), "develop"),
+    "an overlong revision"
+  )
+  assertLeft(SnapshotVersion.format(state(dirtyHash = Some("dirty")), "develop"), "a dirty state")
+  assertLeft(SnapshotVersion.format(state(distance = -1), "develop"), "negative distance")
+  assertLeft(SnapshotVersion.format(state(tag = Some("release-five")), "develop"), "a non-version tag")
+
+  assertEquals(SnapshotVersion.select(state(), Map.empty), Right(state().format()))
+  assertEquals(
+    SnapshotVersion.select(state(), Map("MORPHIR_PUBLISH_MODE" -> "")),
+    Right(state().format())
+  )
+  assertEquals(
+    SnapshotVersion.select(
+      state(),
+      Map("MORPHIR_PUBLISH_MODE" -> "snapshot", "MORPHIR_PUBLISH_BRANCH" -> "Develop")
+    ),
+    Right("0.5.0-M04-develop.57.gbd4cd2-SNAPSHOT")
+  )
+  assertLeft(
+    SnapshotVersion.select(state(), Map("MORPHIR_PUBLISH_MODE" -> "snapshot")),
+    "snapshot mode without a branch"
+  )
+  assertLeft(
+    SnapshotVersion.select(
+      state(),
+      Map("MORPHIR_PUBLISH_MODE" -> "snapshot", "MORPHIR_PUBLISH_BRANCH" -> "")
+    ),
+    "snapshot mode with an empty branch"
+  )
+  assertLeft(
+    SnapshotVersion.select(state(), Map("MORPHIR_PUBLISH_MODE" -> "release")),
+    "an unknown publish mode"
+  )

--- a/mill-build/test/SnapshotVersionTests.scala
+++ b/mill-build/test/SnapshotVersionTests.scala
@@ -28,6 +28,10 @@ def state(
     Right("0.5.0-develop.57.gbd4cd2-SNAPSHOT")
   )
   assertEquals(
+    SnapshotVersion.format(state(tag = Some("v0.5.0-alpha.1")), "develop"),
+    Right("0.5.0-alpha.1-develop.57.gbd4cd2-SNAPSHOT")
+  )
+  assertEquals(
     SnapshotVersion.format(state(tag = None), "develop"),
     Right("0.0.0-develop.57.gbd4cd2-SNAPSHOT")
   )
@@ -58,6 +62,16 @@ def state(
   assertLeft(SnapshotVersion.format(state(dirtyHash = Some("dirty")), "develop"), "a dirty state")
   assertLeft(SnapshotVersion.format(state(distance = -1), "develop"), "negative distance")
   assertLeft(SnapshotVersion.format(state(tag = Some("release-five")), "develop"), "a non-version tag")
+  Seq(
+    "v01.2.3",
+    "v1.02.3",
+    "v1.2.03",
+    "v0.5.0-alpha.",
+    "v0.5.0-alpha..beta",
+    "v0.5.0-01"
+  ).foreach { tag =>
+    assertLeft(SnapshotVersion.format(state(tag = Some(tag)), "develop"), s"invalid SemVer tag $tag")
+  }
 
   assertEquals(SnapshotVersion.select(state(), Map.empty), Right(state().format()))
   assertEquals(


### PR DESCRIPTION
## Summary

- add a safe, parameterized Squire branch refresh command that defaults to `develop` and proves the previous target tip reached `main` before a leased update
- run CI for pull requests and pushes to `develop`, then publish branch-aware Sonatype SNAPSHOT versions after the aggregate CI gate
- document the develop lifecycle, snapshot consumption/retention semantics, and refresh procedure in CONTRIBUTING and the knowledge base

## Snapshot format

Examples include `0.5.0-M04-develop.80.gf5a188-SNAPSHOT` when a release-line tag exists and `0.5.0-develop.57.gbd4cd2-SNAPSHOT` when it does not.

## Test plan

- [x] `mise run test:squire` (27 tests)
- [x] `mise run lint`
- [x] `mise run kb:check` (0 errors; existing upstream-link and released-intent warnings only)
- [x] `mise run test:jvm` (3355/3355 tasks)
- [x] `mise run test:js` (3019/3019 tasks, including Wasm variants)
- [x] `mise run test:native` (893/893 tasks)
- [x] `actionlint .github/workflows/ci.yml`
- [x] evaluate ordinary and snapshot Mill versions, including invalid-mode rejection
- [x] exercise `branch-refresh.py --target develop --dry-run` against the canonical repository; it safely refused because the current develop tip has not yet been merged to main
