### PR TITLE
fix(ci): serialize Sonatype publish to avoid SubstituteLogger crash

### DIFF
--- a/.config/mise/tasks/publish/sonatype
+++ b/.config/mise/tasks/publish/sonatype
@@ -202,14 +202,8 @@ test_gpg_key() {
 run_publish() {
     log_info "Starting Sonatype Central publish..."
 
-    if [[ "${DRY_RUN:-}" == "true" ]]; then
-        log_warn "DRY_RUN mode - skipping actual publish"
-        log_info "Would run: ./mill -i morphir.{modules}.publishSonatypeCentral"
-        return 0
-    fi
-
-    # Run Mill publish for all morphir modules except the mill-morphir-elm plugin
-    # The plugin depends on mill-scalalib which isn't on Maven Central
+    # Publish covers all morphir modules except the mill-morphir-elm plugin.
+    # The plugin depends on mill-scalalib which isn't on Maven Central.
     #
     # INVARIANT: this list must cover every module extending MorphirPublishModule,
     # minus that plugin. Check with:
@@ -226,19 +220,67 @@ run_publish() {
     # Omitting it publishes a POM pointing at an artifact that is not on
     # Sonatype, which breaks resolution for every consumer of `morphir` — not
     # just for consumers of the new modules.
-    ./mill -i \
-        morphir.main.publishSonatypeCentral \
-        + morphir.jvm.publishSonatypeCentral \
-        + morphir.js.publishSonatypeCentral \
-        + morphir.naming.__.publishSonatypeCentral \
-        + morphir.model.__.publishSonatypeCentral \
-        + morphir.runtime.__.publishSonatypeCentral \
-        + morphir.tools.__.publishSonatypeCentral \
-        + morphir.extensibility.__.publishSonatypeCentral \
-        + morphir.lib.__.publishSonatypeCentral \
-        + morphir.interop.__.publishSonatypeCentral \
-        + morphir.contrib.__.publishSonatypeCentral \
-        + morphir.tests.__.publishSonatypeCentral
+    local module_prefixes=(
+        morphir.main
+        morphir.jvm
+        morphir.js
+        morphir.naming.__
+        morphir.model.__
+        morphir.runtime.__
+        morphir.tools.__
+        morphir.extensibility.__
+        morphir.lib.__
+        morphir.interop.__
+        morphir.contrib.__
+        morphir.tests.__
+    )
+
+    local publish_selectors=""
+    local artifact_selectors=""
+    local prefix
+    for prefix in "${module_prefixes[@]}"; do
+        if [[ -n "$publish_selectors" ]]; then
+            publish_selectors+=" + "
+            artifact_selectors+=" + "
+        fi
+        publish_selectors+="${prefix}.publishSonatypeCentral"
+        artifact_selectors+="${prefix}.publishArtifacts"
+    done
+
+    if [[ "${DRY_RUN:-}" == "true" ]]; then
+        log_warn "DRY_RUN mode - skipping actual publish"
+        log_info "Would run: ./mill -i $artifact_selectors"
+        log_info "Then:      ./mill -i --jobs 1 $publish_selectors"
+        return 0
+    fi
+
+    # Stage 1: build every module's publishable artifacts with Mill's normal
+    # parallelism. No remote publication happens here, so concurrency is safe,
+    # and the results are cached in `out/` for the next invocation.
+    log_info "Building publish artifacts (parallel)..."
+    # shellcheck disable=SC2086 # selectors are word-split on purpose; none contain spaces
+    ./mill -i $artifact_selectors
+
+    # Stage 2: run the actual publications one at a time (--jobs 1).
+    #
+    # Concurrent publishSonatypeCentral tasks race SLF4J initialization inside
+    # Mill's maven worker: the losing thread gets an org.slf4j.helpers
+    # .SubstituteLogger, which WorkerImpl.withQuietLogging cannot cast to a
+    # Logback Logger, and the task dies with a ClassCastException after other
+    # modules have already published (issue #957, seen on Mill
+    # 1.2.0-RC1-46-16168f). Serializing the publish tasks keeps the first
+    # worker call single-threaded, so SLF4J initialization completes before
+    # any other task asks for a logger. Artifacts are already built above, so
+    # this stage is network-bound and the lost parallelism is cheap.
+    #
+    # Retry/recovery for SNAPSHOT versions: every upload is timestamped and
+    # per-module maven-metadata points consumers at the newest one. If this
+    # stage still fails partway, re-running the whole publish job is safe —
+    # all modules republish under fresh timestamps and any earlier partial
+    # set becomes inert.
+    log_info "Publishing to Sonatype Central (serialized, --jobs 1)..."
+    # shellcheck disable=SC2086
+    ./mill -i --jobs 1 $publish_selectors
 }
 
 # Main


### PR DESCRIPTION
## Summary

Fixes #957.

The `develop` snapshot publish job failed with:

```text
java.lang.ClassCastException: class org.slf4j.helpers.SubstituteLogger cannot be cast to class ch.qos.logback.classic.Logger
  mill.javalib.maven.worker.impl.WorkerImpl.withQuietLogging(WorkerImpl.scala:52)
```

## Root cause

`WorkerImpl.withQuietLogging` in Mill's maven worker does `LoggerFactory.getLogger(name).asInstanceOf[ch.qos.logback.classic.Logger]`. When the `+`-separated `publishSonatypeCentral` selectors run concurrently in one Mill invocation, several tasks enter the worker while SLF4J is still initializing. SLF4J hands the losing threads an `org.slf4j.helpers.SubstituteLogger` during that initialization window, and the cast throws. Because other publish tasks have already completed by then, the failure leaves a partially published snapshot set. The cast is unchanged on Mill `main` (`libs/javalib/maven-worker/src/mill/javalib/maven/worker/impl/WorkerImpl.scala`), so a Mill upgrade does not currently fix it.

## Change

`.config/mise/tasks/publish/sonatype` now publishes in two stages:

1. **Parallel prebuild** — `./mill -i <modules>.publishArtifacts` builds every module's publishable artifacts with Mill's normal parallelism. No remote publication happens here, and results are cached in `out/`.
2. **Serialized publish** — `./mill -i --jobs 1 <modules>.publishSonatypeCentral` runs the actual publications one at a time. The worker's first SLF4J lookup completes single-threaded, so no task can observe a `SubstituteLogger`. With artifacts prebuilt, this stage is network-bound and the lost parallelism costs little.

The module list is unchanged and now lives in one array used by both stages, so the two invocations cannot drift apart. The existing invariant comment about coverage of `MorphirPublishModule` is preserved.

## Retry/recovery for partial snapshot sets

Documented in the script: snapshot uploads are timestamped, and per-module `maven-metadata` points consumers at the newest upload. If a publish still fails partway, re-running the whole publish job is safe — every module republishes under fresh timestamps and the earlier partial set becomes inert.

## Verification

- `bash -n` and `shellcheck` pass (only pre-existing SC2155 warnings elsewhere in the script remain).
- `DRY_RUN` output confirms both stages assemble the exact same module set as before.
- `./mill --jobs 1 resolve` confirms the `publishArtifacts` selectors resolve and that `--jobs 1` is accepted by the pinned Mill (`1.2.0-RC1-46-16168f`).

The definitive check is the next `develop` snapshot publish run, since the race only manifests against the real worker under concurrency. The reproduction (concurrent `+`-separated publish selectors on Mill 1.2.0-RC1-46-16168f) is documented in the script comment and in #957.