### PR TITLE
fix(deps): hold morphir-elm at 2.99.0 to dodge a fatal EBADF crash

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,13 +1,22 @@
 {
   "automerge": true,
   "rebaseWhen": "conflicted",
-  "labels": ["type: dependencies"],
+  "labels": [
+    "type: dependencies"
+  ],
   "packageRules": [
     {
       "matchManagers": [
         "sbt"
       ],
       "enabled": false
+    },
+    {
+      "matchPackageNames": [
+        "morphir-elm"
+      ],
+      "allowedVersions": "!=2.100.0",
+      "description": "morphir-elm 2.100.0 crashes with a fatal EBADF fd-close-on-GC after successful generation (bead morphir-qki); later releases are welcome"
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,8 +196,10 @@ jobs:
             out/morphir-elm/
           key: ${{ runner.os }}-mill-morphir-projects-${{ hashFiles('.mill-version', 'mill-plugins/morphir/toolchain/src/**', 'mill-plugins/morphir/javascript/src/**', 'mill-plugins/morphir/elm-tooling/src/**', 'mill-plugins/morphir/elm/test-tools/morphir-elm/package-lock.json') }}-${{ github.sha }}
       - name: Run capability
+        # -j 1 serializes the morphirIR tasks: parallel morphir-elm 2.100.0 node
+        # processes crash with EBADF fd-close-on-GC on this runner (bead morphir-qki).
         run: |
-          ./mill -i -k "examples.morphir-elm-projects.__.morphirIR" \
+          ./mill -i -k -j 1 "examples.morphir-elm-projects.__.morphirIR" \
             + "morphir-elm.sdks.__.morphirIR"
 
   runtime-generated-fixtures:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,10 +196,8 @@ jobs:
             out/morphir-elm/
           key: ${{ runner.os }}-mill-morphir-projects-${{ hashFiles('.mill-version', 'mill-plugins/morphir/toolchain/src/**', 'mill-plugins/morphir/javascript/src/**', 'mill-plugins/morphir/elm-tooling/src/**', 'mill-plugins/morphir/elm/test-tools/morphir-elm/package-lock.json') }}-${{ github.sha }}
       - name: Run capability
-        # -j 1 serializes the morphirIR tasks: parallel morphir-elm 2.100.0 node
-        # processes crash with EBADF fd-close-on-GC on this runner (bead morphir-qki).
         run: |
-          ./mill -i -k -j 1 "examples.morphir-elm-projects.__.morphirIR" \
+          ./mill -i -k "examples.morphir-elm-projects.__.morphirIR" \
             + "morphir-elm.sdks.__.morphirIR"
 
   runtime-generated-fixtures:

--- a/mill-build/test/MorphirElmToolTests.scala
+++ b/mill-build/test/MorphirElmToolTests.scala
@@ -11,10 +11,10 @@ def assertEquals[A](actual: A, expected: A): Unit =
   val lock          = ujson.read(os.read(toolDirectory / "package-lock.json"))
   val lockedPackage = lock("packages")("node_modules/morphir-elm")
 
-  assertEquals(MorphirElmTool.Version, "2.100.0")
+  assertEquals(MorphirElmTool.Version, "2.99.0")
   assertEquals(
     os.read(toolDirectory / "package.json").trim,
-    """{"name":"morphir-scala-morphir-elm-tool","private":true,"dependencies":{"morphir-elm":"2.100.0"}}"""
+    """{"name":"morphir-scala-morphir-elm-tool","private":true,"dependencies":{"morphir-elm":"2.99.0"}}"""
   )
   assertEquals(manifest("name").str, "morphir-scala-morphir-elm-tool")
   assert(manifest("private").bool)
@@ -23,11 +23,11 @@ def assertEquals[A](actual: A, expected: A): Unit =
   assertEquals(lock("lockfileVersion").num.toInt, 3)
   assertEquals(lock("packages")("")("dependencies")("morphir-elm").str, MorphirElmTool.Version)
   assertEquals(lockedPackage("version").str, MorphirElmTool.Version)
-  assertEquals(MorphirElmTool.Resolved, "https://registry.npmjs.org/morphir-elm/-/morphir-elm-2.100.0.tgz")
-  assertEquals(MorphirElmTool.Sha1, "b83b6ddfe3eb068f1e25160a8f2ea371a517fd2c")
+  assertEquals(MorphirElmTool.Resolved, "https://registry.npmjs.org/morphir-elm/-/morphir-elm-2.99.0.tgz")
+  assertEquals(MorphirElmTool.Sha1, "064c70fc7df67d2cb554e6242cd09005225817d7")
   assertEquals(
     MorphirElmTool.Integrity,
-    "sha512-0JFVV1CnxppfC90NrOqSlXS7LVqqTQCLCMpTvBTu95EHQoJwQgUkWbK3N2QwOnCI9fqt8jJJsqQ5fonU3PWpAQ=="
+    "sha512-Ped2tjlJVr4mN/AmKo+TcjYgdV2DKJPB0hOVSktvPG50HLOl90/ik+mP6AvW6B0W9WeFm0ubsjVy0/9wbQPMug=="
   )
   assertEquals(lockedPackage("resolved").str, MorphirElmTool.Resolved)
   assertEquals(lockedPackage("integrity").str, MorphirElmTool.Integrity)

--- a/mill-plugins/morphir/elm/src/org/finos/morphir/mill/elm/morphir/MorphirElmTool.scala
+++ b/mill-plugins/morphir/elm/src/org/finos/morphir/mill/elm/morphir/MorphirElmTool.scala
@@ -1,9 +1,9 @@
 package org.finos.morphir.mill.elm.morphir
 
 object MorphirElmTool {
-  val Version   = "2.100.0"
-  val Resolved  = "https://registry.npmjs.org/morphir-elm/-/morphir-elm-2.100.0.tgz"
-  val Sha1      = "b83b6ddfe3eb068f1e25160a8f2ea371a517fd2c"
+  val Version   = "2.99.0"
+  val Resolved  = "https://registry.npmjs.org/morphir-elm/-/morphir-elm-2.99.0.tgz"
+  val Sha1      = "064c70fc7df67d2cb554e6242cd09005225817d7"
   val Integrity =
-    "sha512-0JFVV1CnxppfC90NrOqSlXS7LVqqTQCLCMpTvBTu95EHQoJwQgUkWbK3N2QwOnCI9fqt8jJJsqQ5fonU3PWpAQ=="
+    "sha512-Ped2tjlJVr4mN/AmKo+TcjYgdV2DKJPB0hOVSktvPG50HLOl90/ik+mP6AvW6B0W9WeFm0ubsjVy0/9wbQPMug=="
 }

--- a/mill-plugins/morphir/elm/test-tools/morphir-elm/package-lock.json
+++ b/mill-plugins/morphir/elm/test-tools/morphir-elm/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "morphir-scala-morphir-elm-tool",
       "dependencies": {
-        "morphir-elm": "2.100.0"
+        "morphir-elm": "2.99.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3568,9 +3568,9 @@
       }
     },
     "node_modules/morphir-elm": {
-      "version": "2.100.0",
-      "resolved": "https://registry.npmjs.org/morphir-elm/-/morphir-elm-2.100.0.tgz",
-      "integrity": "sha512-0JFVV1CnxppfC90NrOqSlXS7LVqqTQCLCMpTvBTu95EHQoJwQgUkWbK3N2QwOnCI9fqt8jJJsqQ5fonU3PWpAQ==",
+      "version": "2.99.0",
+      "resolved": "https://registry.npmjs.org/morphir-elm/-/morphir-elm-2.99.0.tgz",
+      "integrity": "sha512-Ped2tjlJVr4mN/AmKo+TcjYgdV2DKJPB0hOVSktvPG50HLOl90/ik+mP6AvW6B0W9WeFm0ubsjVy0/9wbQPMug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.1",

--- a/mill-plugins/morphir/elm/test-tools/morphir-elm/package.json
+++ b/mill-plugins/morphir/elm/test-tools/morphir-elm/package.json
@@ -1,1 +1,1 @@
-{"name":"morphir-scala-morphir-elm-tool","private":true,"dependencies":{"morphir-elm":"2.100.0"}}
+{"name":"morphir-scala-morphir-elm-tool","private":true,"dependencies":{"morphir-elm":"2.99.0"}}

--- a/mill-plugins/morphir/elm/test/src/org/finos/morphir/mill/elm/morphir/MorphirElmToolTests.scala
+++ b/mill-plugins/morphir/elm/test/src/org/finos/morphir/mill/elm/morphir/MorphirElmToolTests.scala
@@ -49,7 +49,7 @@ object MorphirElmToolTests extends TestSuite {
         """
       )
       assert(errors.isEmpty)
-      assert(MorphirElmTool.Version == "2.100.0")
+      assert(MorphirElmTool.Version == "2.99.0")
     }
 
     test("pinned production tool lock is strict before any process") {

--- a/mill-plugins/morphir/integration/resources/published-consumer/tool/package-lock.json
+++ b/mill-plugins/morphir/integration/resources/published-consumer/tool/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "morphir-scala-morphir-elm-tool",
       "dependencies": {
-        "morphir-elm": "2.100.0"
+        "morphir-elm": "2.99.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3568,9 +3568,9 @@
       }
     },
     "node_modules/morphir-elm": {
-      "version": "2.100.0",
-      "resolved": "https://registry.npmjs.org/morphir-elm/-/morphir-elm-2.100.0.tgz",
-      "integrity": "sha512-0JFVV1CnxppfC90NrOqSlXS7LVqqTQCLCMpTvBTu95EHQoJwQgUkWbK3N2QwOnCI9fqt8jJJsqQ5fonU3PWpAQ==",
+      "version": "2.99.0",
+      "resolved": "https://registry.npmjs.org/morphir-elm/-/morphir-elm-2.99.0.tgz",
+      "integrity": "sha512-Ped2tjlJVr4mN/AmKo+TcjYgdV2DKJPB0hOVSktvPG50HLOl90/ik+mP6AvW6B0W9WeFm0ubsjVy0/9wbQPMug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.1",

--- a/mill-plugins/morphir/integration/resources/published-consumer/tool/package.json
+++ b/mill-plugins/morphir/integration/resources/published-consumer/tool/package.json
@@ -1,1 +1,1 @@
-{"name":"morphir-scala-morphir-elm-tool","private":true,"dependencies":{"morphir-elm":"2.100.0"}}
+{"name":"morphir-scala-morphir-elm-tool","private":true,"dependencies":{"morphir-elm":"2.99.0"}}


### PR DESCRIPTION
morphir-elm 2.100.0's CLI crashes with an uncaught `EBADF: Closing file descriptor N on garbage collection failed` under node 24 *after* successful generation, exiting 1 and failing the morphir-elm-projects job. Five consecutive occurrences across PR #962 and this PR's first attempt; serializing the tasks (`-j 1`) did not help, proving the crash is per-process, not contention — that commit is reverted here.

This holds morphir-elm at 2.99.0 (tool pin, lockfile, plugin checksums) and adds a renovate `allowedVersions: !=2.100.0` rule so the hold survives automerge while any fixed later release still arrives. Verified locally: the previously-failing morphirIR task generates green on 2.99.0, and the mill-plugin unit suites pass (667/667).

Tracked as bead morphir-qki; the durable fix is upstream in morphir-elm's CLI file-descriptor handling. Unblocks #962 and every PR behind it.