### PR TITLE
fix(ci): retry crashed morphirIR tasks up to three times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,9 +196,18 @@ jobs:
             out/morphir-elm/
           key: ${{ runner.os }}-mill-morphir-projects-${{ hashFiles('.mill-version', 'mill-plugins/morphir/toolchain/src/**', 'mill-plugins/morphir/javascript/src/**', 'mill-plugins/morphir/elm-tooling/src/**', 'mill-plugins/morphir/elm/test-tools/morphir-elm/package-lock.json') }}-${{ github.sha }}
       - name: Run capability
+        # morphir-elm's CLI intermittently dies with a fatal EBADF fd-close-on-GC crash
+        # under Node 24 after generation succeeds (bead morphir-qki, finos/morphir-elm#1282).
+        # Mill caches successful tasks, so each retry re-runs only the crashed ones.
         run: |
-          ./mill -i -k "examples.morphir-elm-projects.__.morphirIR" \
-            + "morphir-elm.sdks.__.morphirIR"
+          for attempt in 1 2 3; do
+            if ./mill -i -k "examples.morphir-elm-projects.__.morphirIR" \
+              + "morphir-elm.sdks.__.morphirIR"; then
+              exit 0
+            fi
+            echo "morphirIR attempt ${attempt} failed; retrying crashed tasks"
+          done
+          exit 1
 
   runtime-generated-fixtures:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to #963: the EBADF fd-close-on-GC crash is version-independent after all. The rebased #962 hit it on morphir-elm **2.99.0** (a third sibling project this time), while 2.100.0 passed reruns on #961 and 2.99.0 passed on #963 — so the crash is probabilistic per Node process, not a 2.100.0 regression, and its rate spiked recently (plausibly a runner-image rollout). Upstream issue finos/morphir-elm#1282 is being corrected accordingly.

This wraps the morphirIR step in a three-attempt loop. Mill caches successful tasks, so each retry re-executes only the crashed ones; per-task failure probability p becomes ~p³ for the job. The #963 version hold stays in place for now and can be lifted once this proves stable (tracked in morphir-qki).