### PR TITLE
fix(ci): neutralize the EBADF fd-close-on-GC crash with a node preload shim

### DIFF
--- a/.github/scripts/ebadf-close-shim.cjs
+++ b/.github/scripts/ebadf-close-shim.cjs
@@ -1,0 +1,13 @@
+// morphir-elm's CLI double-closes a file descriptor; under Node 24 the second close
+// surfaces during garbage collection as a fatal uncaught EBADF exception AFTER the
+// CLI's work has completed successfully, killing the process with exit code 1.
+// This preload (via NODE_OPTIONS=--require) swallows exactly that error shape and
+// nothing else, so completed work is not reported as failure. Tracked as bead
+// morphir-qki and upstream as finos/morphir-elm#1282; delete when upstream fixes
+// its fd handling.
+process.on("uncaughtException", (err) => {
+  if (err && err.code === "EBADF" && err.syscall === "close") {
+    return;
+  }
+  throw err;
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,11 @@ jobs:
       - name: Run capability
         # morphir-elm's CLI intermittently dies with a fatal EBADF fd-close-on-GC crash
         # under Node 24 after generation succeeds (bead morphir-qki, finos/morphir-elm#1282).
+        # The preload shim swallows exactly that error shape; the trigger is run-scoped
+        # (a bad runner host fails all in-job retries), so retries alone do not cover it.
         # Mill caches successful tasks, so each retry re-runs only the crashed ones.
+        env:
+          NODE_OPTIONS: --require ${{ github.workspace }}/.github/scripts/ebadf-close-shim.cjs
         run: |
           for attempt in 1 2 3; do
             if ./mill -i -k "examples.morphir-elm-projects.__.morphirIR" \

--- a/mill-plugins/morphir/elm-tooling/src/org/finos/morphir/mill/elm/ElmProcessEnvironment.scala
+++ b/mill-plugins/morphir/elm-tooling/src/org/finos/morphir/mill/elm/ElmProcessEnvironment.scala
@@ -13,6 +13,9 @@ object ElmProcessEnvironment {
     "SSL_CERT_FILE",
     "SSL_CERT_DIR",
     "NODE_EXTRA_CA_CERTS",
+    // Lets CI inject a --require preload that neutralizes morphir-elm's fatal EBADF
+    // fd-close-on-GC crash (finos/morphir-elm#1282); remove when upstream fixes it.
+    "NODE_OPTIONS",
     "SYSTEMROOT",
     "SystemRoot",
     "WINDIR",


### PR DESCRIPTION
Third and mechanism-level mitigation for the morphir-elm CLI crash (bead morphir-qki, finos/morphir-elm#1282). New evidence from the latest #962 run: the same task crashed on all three in-job retry attempts (6 EBADF hits in one job) while other runs of identical code pass everything — the trigger is run-scoped (runner-host variance), so #964's within-job retries cannot cover a bad host.

This adds a tiny CommonJS preload, injected via `NODE_OPTIONS=--require` for the morphir-elm-projects step only, that swallows exactly `code === 'EBADF' && syscall === 'close'` uncaught exceptions — the crash fires during garbage collection after the CLI's work has already completed successfully — and rethrows everything else. Version- and host-independent because it neutralizes the crash mechanism rather than dodging its trigger. The retry loop stays as a second net. Delete the shim when upstream fixes its fd handling.

Unblocks #962.