### PR TITLE
feat(buildkit): succeed and attempt stage constructors

### DIFF
--- a/morphir/buildkit/core/src/morphir/buildkit/Stage.scala
+++ b/morphir/buildkit/core/src/morphir/buildkit/Stage.scala
@@ -115,6 +115,32 @@ object Stage:
   def pure[A, B](f: A => B): Stage[A, B, Nothing, Any] =
     Run(a => f(a))
 
+  /**
+   * Lift an effectful function that declares no error — the ergonomic constructor for the common case, after
+   * `ZIO.succeed`'s role as the infallible-effect constructor. `E` is fixed to `Nothing` by the name rather than
+   * spelled at every call site; `S` still wants help where no expected type flows in (`Stage.succeed[Int, Int, Any]` or
+   * an ascribed lambda result), for the same underconstrained-row reason [[apply]] documents.
+   *
+   * "Succeed" is a claim, not a proof: Scala offers no negative evidence over effect rows, so an `Abort` smuggled
+   * inside `S` cannot be rejected here statically. The executors contain one at runtime instead, converting it to a
+   * panic carrying [[UndeclaredAbortException]] — the event stream stays balanced and `runReport` folds it as data.
+   * Code that can genuinely fail belongs in [[attempt]] (throws) or [[apply]] (a declared error type).
+   */
+  def succeed[A, B, S](f: A => B < S): Stage[A, B, Nothing, S] =
+    Run(f)
+
+  /**
+   * Lift a plain side-effecting function whose non-fatal throws become the declared error — after `ZIO.attempt`, fixing
+   * the error channel to `Throwable` so exception-throwing code fails typed instead of panicking. Fatal throwables
+   * (`VirtualMachineError`, `InterruptedException`, ...) are not caught, matching `kyo.Abort.catching`.
+   *
+   * The parameter is a plain function, as in ZIO: a Kyo-effectful computation that also throws is unusual enough to
+   * spell out with [[succeed]] or [[apply]] plus `Abort.catching` directly, and a `B < S` parameter here would let an
+   * underconstrained `S` collapse to `Nothing` at plain-lambda call sites.
+   */
+  def attempt[A, B](f: A => B): Stage[A, B, Throwable, Any] =
+    Run(a => Abort.catching[Throwable](f(a)))
+
   /** A stage that never aborts: its declared error is `Nothing`, so it composes into any pipeline's error row. */
   type Infallible[-I, +O, S] = Stage[I, O, Nothing, S]
 end Stage

--- a/morphir/buildkit/core/test/src/morphir/buildkit/PipelineTests.scala
+++ b/morphir/buildkit/core/test/src/morphir/buildkit/PipelineTests.scala
@@ -115,7 +115,7 @@ class PipelineTests extends Test[Any]:
     }
     "a stage can read its provenance" in {
       val observing =
-        Stage[Int, String, Nothing, Any](i => Pipeline.provenance.map(path => path.map(_.label).mkString(",")))
+        Stage.succeed[Int, String, Any](i => Pipeline.provenance.map(path => path.map(_.label).mkString(",")))
           .named("observer")
       val plan        = sealOrFail(Pipeline.stage(observing))
       val (_, result) = runPure(Emit.run(plan.execute(0))).eval

--- a/morphir/buildkit/core/test/src/morphir/buildkit/StageTests.scala
+++ b/morphir/buildkit/core/test/src/morphir/buildkit/StageTests.scala
@@ -40,9 +40,25 @@ class StageTests extends Test[Any]:
       val out                                        = runPure(program).eval
       assert(out == "5")
     }
-    "apply lifts an effectful function" in {
+    "attempt turns a non-fatal throw into a typed Abort[Throwable]" in {
+      val boom = Stage.attempt((i: Int) => if i > 0 then throw new RuntimeException(s"boom-$i") else i)
+      Abort.run[Throwable](boom.run(3)).eval match
+        case Result.Failure(t) => assert(t.getMessage == "boom-3")
+        case _                 => assert(false)
+    }
+    "attempt succeeds when nothing throws" in {
+      val safe = Stage.attempt((i: Int) => i * 2)
+      assert(Abort.run[Throwable](safe.run(4)).eval == Result.Success(8))
+    }
+    "succeed composes into a declared-error pipeline" in {
+      val doubled = Stage.succeed[Int, Int, Any](i => i * 2)
+      val shown   = Stage.pure((i: Int) => i.toString)
+      val chained = doubled.andThen(shown)
+      assert(runPure(chained.run(21)).eval == "42")
+    }
+    "succeed lifts an effectful function" in {
       val effStage: Stage[Int, Int, Nothing, Any] =
-        Stage[Int, Int, Nothing, Any]((i: Int) => (i * 2): Int < Any)
+        Stage.succeed((i: Int) => (i * 2): Int < Any)
       val program = effStage.run(21)
       val out     = runPure(program).eval
       assert(out == 42)

--- a/morphir/buildkit/core/test/src/morphir/buildkitaccess/VisibilityTests.scala
+++ b/morphir/buildkit/core/test/src/morphir/buildkitaccess/VisibilityTests.scala
@@ -11,7 +11,7 @@ import morphir.buildkit.*
 class VisibilityTests extends Test[Any]:
 
   private def observer =
-    Stage[Int, String, Nothing, Any](i => Pipeline.provenance.map(path => path.map(_.label).mkString(",")))
+    Stage.succeed[Int, String, Any](i => Pipeline.provenance.map(path => path.map(_.label).mkString(",")))
       .named("observer")
 
   /**


### PR DESCRIPTION
Follow-up to #968's ergonomics cost: removing `fromKyo` left the common cases spelling four explicit type parameters. Following ZIO's constructor pairing, the fallibility decision moves into the name:

- **`Stage.succeed`** — effectful, `E = Nothing` fixed by the name. Safe to offer because #968's runtime containment guards the smuggled-`Abort` case (`UndeclaredAbortException`); the scaladoc states the claim-vs-proof distinction and the `S`-inference caveat honestly.
- **`Stage.attempt`** — plain side-effecting function, non-fatal throws captured into typed `Abort[Throwable]` via kyo's `Abort.catching`, so exception-throwing code fails typed instead of panicking. Takes a plain function deliberately, as in ZIO — a `B < S` parameter lets an underconstrained `S` collapse to `Nothing` at plain-lambda call sites (probe-verified during implementation).
- `Stage.apply` remains the spelling for declared domain errors; `pure` unchanged.

Three new tests (attempt captures/succeeds, succeed composition); ascription-heavy call sites migrated back to the ergonomic forms; 208 green on jvm and full suites green on js, native, wasm.