### PR TITLE
feat(buildkit): succeed/attempt constructors and undeclared Abort containment

### DIFF
--- a/morphir/buildkit/core/src/morphir/buildkit/Pipeline.scala
+++ b/morphir/buildkit/core/src/morphir/buildkit/Pipeline.scala
@@ -381,19 +381,34 @@ final class SealedPipeline[-I, +O, E, S] private[buildkit] (
    *     [[morphir.buildkit.Stage#run]] already surfaced it; a panic that reaches this boundary re-raises as a `Panic`
    *     the same way it always did.
    *
+   * '''An `Abort` a stage hid inside its own `S` rather than its declared `E` is contained, not just observed.'''
+   * `Stage.apply`'s own scaladoc explains why this cannot be forbidden statically: a caller can always pick `E :=
+   * Nothing` and fold the real error into `S` instead, and Scala has no negative evidence to reject that. What used to
+   * happen then was worse than a merely-untyped escape: `Abort.tapError[E]` only claims a failure its own
+   * `ConcreteTag[E]` accepts, so a hidden failure sailed straight past it, leaving `closeOpenNodes` and
+   * `RunFinished(false)` un-run — a `NodeStarted` with no matching `NodeFinished`/`RunFinished`, and this method
+   * escaping instead of returning to its caller with a value. The single interception below is now
+   * [[SealedPipeline.executeIntercepted]], which claims '''every''' `Abort` reaching it (Kyo dispatches every
+   * `Abort[X]` through one erased tag, so a handler summoned at `ConcreteTag[Any]` sees a hidden failure exactly as it
+   * would the declared one) and only then decides, against this plan's own `ConcreteTag[E]`, whether to re-raise it as
+   * the declared `Abort[E]` (byte-identical to what `Abort.tapError[E]` used to do for a value it accepted) or convert
+   * it to a panic — [[morphir.buildkit.UndeclaredAbortException]] — carrying the original value. Either way
+   * `closeOpenNodes`/`RunFinished(false)` run first, so the event stream stays balanced; a hidden abort now surfaces as
+   * a contained panic rather than an unhandled row effect.
+   *
    * '''Known gap: a fatal `Throwable` still leaves its `NodeStarted` unclosed.''' `Effect.catching`, used by
    * `bracketed`'s own per-node panic handling, filters on `scala.util.control.NonFatal`, so `InterruptedException`,
    * `VirtualMachineError`, `LinkageError`, and `ControlThrowable` are not caught there, and they are not typed
-   * `Abort[E]` failures either, so `Abort.tapError` does not observe them. See bead morphir-zdy.2 for the fuller
-   * history of this row's evolution.
+   * `Abort[E]` failures either, so [[SealedPipeline.executeIntercepted]] does not observe them. See bead morphir-zdy.2
+   * for the fuller history of this row's evolution.
    */
   def execute(input: I)(using ConcreteTag[E], Frame): O < (Abort[E] & S & Emit[PipelineEvent]) =
     Var.run(SealedPipeline.OpenNodes(Chunk.empty)) {
       for
         _   <- Emit.value(PipelineEvent.RunStarted)
-        out <- Abort.tapError[E] { (_: Result.Error[E]) =>
-          SealedPipeline.closeOpenNodes.andThen(Emit.value(PipelineEvent.RunFinished(false)))
-        }(SealedPipeline.executeChain(sealedChain, Chunk.empty, input))
+        out <- SealedPipeline.executeIntercepted[E, O, S](
+          SealedPipeline.executeChain(sealedChain, Chunk.empty, input)
+        )
         _ <- Emit.value(PipelineEvent.RunFinished(true))
       yield out
     }
@@ -404,12 +419,17 @@ final class SealedPipeline[-I, +O, E, S] private[buildkit] (
    * result row — this is where the typed interception happens, which is why `ConcreteTag[E]` (what `Abort.run` needs to
    * recognize an `E` at runtime) surfaces once, here.
    *
-   * '''Per node.''' The node body runs under `Abort.run[E]`, wrapped in `kyo.kernel.Effect.catching` so a raw non-fatal
-   * throw during the body's own eager evaluation is folded in too (see [[SealedPipeline.attempt]]). The three-way
-   * `Result` folds to: `Success` → `Succeeded(Provenance.Executed)`, `Failure(e)` → `Failed(Result.Failure(e))`,
-   * `Panic(t)` → `Failed(Result.Panic(t))`. A fatal `Throwable` still tears the run — the same gap [[execute]]
-   * documents, unchanged here. An `Abort` carried inside `S` rather than the declared `E` is likewise not intercepted
-   * here and tears the run, visible in the return row's own `S`.
+   * '''Per node.''' The node body runs under [[SealedPipeline.attempt]], wrapped in `kyo.kernel.Effect.catching` so a
+   * raw non-fatal throw during the body's own eager evaluation is folded in too. The three-way `Result` folds to:
+   * `Success` → `Succeeded(Provenance.Executed)`, `Failure(e)` → `Failed(Result.Failure(e))`, `Panic(t)` →
+   * `Failed(Result.Panic(t))`. A fatal `Throwable` still tears the run — the same gap [[execute]] documents, unchanged
+   * here. An `Abort` a stage hid inside its own `S` rather than its declared `E` is '''contained, not tearing the
+   * run''': `attempt` claims every `Abort` reaching it (`ConcreteTag[Any]` accepts anything, and Kyo dispatches every
+   * `Abort[X]` through one erased tag, so a hidden failure is offered to the same handler as a declared one) and
+   * converts one this plan's own `ConcreteTag[E]` does not accept into `Result.Panic(UndeclaredAbortException(..))`
+   * instead of leaving it to escape through the return row's own `S` — the gap this paragraph used to describe as
+   * unintercepted. `reportStage` then folds that `Result.Panic` exactly like any other panic:
+   * `Failed(Result.Panic(..))`.
    *
    * '''Downstream of a failure.''' Every later node in the same chain reports `Blocked(blockedBy, rootCauses)`, where
    * `blockedBy` names its ''immediate'' predecessor(s) and `rootCauses` names the node(s) that actually failed,
@@ -531,6 +551,47 @@ object SealedPipeline:
       Kyo.foreachDiscard(openIds.reverse) { id =>
         Emit.value(PipelineEvent.NodeFinished(id, NodeStatus.Failed))
       }
+    }
+
+  /**
+   * [[SealedPipeline#execute]]'s own single interception boundary for `Abort`, replacing what used to be a direct
+   * `Abort.tapError[E]` wrapping the whole chain. `Abort.run[Any]` — not `Abort.run[E]` — is what makes this claim
+   * every `Abort` in `body`'s row rather than only the declared `E`: Kyo dispatches every `Abort[X]` through one erased
+   * tag (`kyo.Abort`'s own `erasedTag`), so a handler is offered any raised failure regardless of which `Abort[X]`
+   * produced it, and `ConcreteTag[Any].accepts` always answers `true`, so this handler never lets one pass by. That
+   * closes the gap a hidden `Abort` used to open: one folded into a stage's declared `S` instead of its declared `E`
+   * (`Stage.apply` cannot forbid that statically) used to sail straight past `Abort.tapError[E]`, whose own
+   * `ConcreteTag[E]` rejected it, leaving `closeOpenNodes`/`RunFinished(false)` un-run and the failure escaping this
+   * method's own row instead of being returned to the caller through the declared `Abort[E]`.
+   *
+   * The single `Var[OpenNodes]` this shares with every node bracket (see [[SealedPipeline.executeElem]] and this
+   * class's own doc on why a `Var`, not a `Local`, survives a hard halt) is what makes one boundary enough even for a
+   * hidden abort nested several levels deep — inside a `fanOut` child, say: every bracket still open when the failure
+   * reaches here, at any depth, is in that `Var`, and `closeOpenNodes` closes all of them, innermost first, in one
+   * pass.
+   *
+   * A `Result.Failure(e)` whose value this plan's own `ConcreteTag[E]` still accepts is the declared channel: it is
+   * re-raised through `Abort.fail[E]`, byte-identical to what `Abort.tapError[E]` used to do for the only failures it
+   * could see. `ConcreteTag[E].unapply` does the narrowing itself — an internal, already-tag-checked cast on kyo's own
+   * side — so no cast is written here. One `ConcreteTag[E]` rejects is undeclared: it is converted to
+   * `Abort.panic(UndeclaredAbortException(e))` instead, a contained panic in place of a silent escape. A `Result.Panic`
+   * is repropagated unchanged, matching what `Abort.tapError`'s own `onError` already did for a panic that reached it.
+   */
+  private def executeIntercepted[E, A, S](
+      body: => A < (Abort[E] & S & Emit[PipelineEvent] & Var[OpenNodes])
+  )(using tag: ConcreteTag[E], frame: Frame): A < (Abort[E] & S & Emit[PipelineEvent] & Var[OpenNodes]) =
+    Abort.run[Any](body).map {
+      case Result.Success(a) => a
+      case Result.Panic(ex)  =>
+        closeOpenNodes.andThen(Emit.value(PipelineEvent.RunFinished(false))).andThen(Abort.panic[E](ex))
+      case Result.Failure(e) =>
+        e match
+          case tag(typed) =>
+            closeOpenNodes.andThen(Emit.value(PipelineEvent.RunFinished(false))).andThen(Abort.fail[E](typed))
+          case _ =>
+            closeOpenNodes.andThen(Emit.value(PipelineEvent.RunFinished(false))).andThen(
+              Abort.panic[E](UndeclaredAbortException(e))
+            )
     }
 
   /**
@@ -776,15 +837,32 @@ object SealedPipeline:
   /**
    * Run one node's own body and fold every way it can end into a `Result`.
    *
-   * `Abort.run[E]` intercepts the typed channel and already renders a panic raised through it as `Result.Panic`. The
-   * `Effect.catching` wrapper covers what `Abort.run` alone cannot: `body` is forced ''while constructing'' the
-   * computation (a `Stage.Run`'s own function is applied eagerly), so a raw non-fatal throw from that application would
-   * otherwise escape the handler entirely and tear the run. Both paths land on the same `Result.Panic`, and the caller
-   * folds one shape. Fatal throwables remain uncaught — `Effect.catching` filters on `scala.util.control.NonFatal`, the
-   * gap [[SealedPipeline#execute]] documents.
+   * `Abort.run[Any]` — not `Abort.run[E]` — intercepts the channel: Kyo dispatches every `Abort[X]` through one erased
+   * tag (see `kyo.Abort`'s own `erasedTag`), so a handler is offered any failure reached, regardless of which
+   * `Abort[X]` in the row raised it, and only its own `ConcreteTag` decides whether to claim it —
+   * `ConcreteTag[Any].accepts` always answers `true`, so this handler claims everything, including a failure a stage
+   * hid inside its declared `S` rather than its declared `E` (`Stage.apply` cannot forbid that statically; see
+   * [[morphir.buildkit.UndeclaredAbortException]]). The result is folded once, right here, against the caller's own
+   * `ConcreteTag[E]`: a value it still accepts is the declared channel, re-raised as `Result.Failure[E]` exactly as
+   * `Abort.run[E]` used to render it directly; one it rejects came from a hidden `Abort` and becomes
+   * `Result.Panic(UndeclaredAbortException(..))` instead of escaping through `S` unhandled — the gap
+   * [[SealedPipeline#runReport]]'s own scaladoc used to document. `ConcreteTag[E].unapply` does the narrowing itself
+   * (an internal, already-tag-checked cast on kyo's side), so no cast is needed here. The `Effect.catching` wrapper
+   * covers what `Abort.run` alone cannot: `body` is forced ''while constructing'' the computation (a `Stage.Run`'s own
+   * function is applied eagerly), so a raw non-fatal throw from that application would otherwise escape the handler
+   * entirely and tear the run. Both paths land on the same `Result.Panic`, and the caller folds one shape. Fatal
+   * throwables remain uncaught — `Effect.catching` filters on `scala.util.control.NonFatal`, the gap
+   * [[SealedPipeline#execute]] documents.
    */
-  private def attempt[A, E, S](body: => A < (Abort[E] & S))(using ConcreteTag[E], Frame): Result[E, A] < S =
-    Effect.catching(Abort.run[E](body))((ex: Throwable) => Result.Panic(ex): Result[E, A])
+  private def attempt[A, E, S](body: => A < (Abort[E] & S))(using tag: ConcreteTag[E], frame: Frame): Result[E, A] < S =
+    Effect.catching(Abort.run[Any](body))((ex: Throwable) => Result.Panic(ex): Result[Any, A]).map {
+      case Result.Success(a) => Result.Success(a)
+      case Result.Panic(ex)  => Result.Panic(ex)
+      case Result.Failure(e) =>
+        e match
+          case tag(typed) => Result.Failure(typed)
+          case _          => Result.Panic(UndeclaredAbortException(e))
+    }
 
   /**
    * Assert that a [[morphir.buildkit.FanOutKeyError]] conforms to a `reportFanOutKeyed` call's own top-level `E` — true

--- a/morphir/buildkit/core/src/morphir/buildkit/Stage.scala
+++ b/morphir/buildkit/core/src/morphir/buildkit/Stage.scala
@@ -98,6 +98,11 @@ object Stage:
    * A bare `Stage(...)` call with no expected type flowing in leaves `S` underconstrained, and inference defaults it to
    * `Nothing` rather than `Any` — a valid but unusable row. Ascribe the stage's type (`Stage[I, O, E, S]`) when
    * composing one standalone, rather than inline inside a pipeline where the expected type already pins `S`.
+   *
+   * This is the only lift for effectful functions: a `fromKyo`-style constructor that fixed the declared error to
+   * `Nothing` while accepting an arbitrary row let `Abort[E]` hide inside `S`, bypassing the executor's error cleanup
+   * and unbalancing the event stream. Declare the error type here instead; an infallible effectful function is simply
+   * `E = Nothing`.
    */
   def apply[I, O, E, S](f: I => O < (Abort[E] & S)): Stage[I, O, E, S] =
     Run(f)
@@ -109,10 +114,6 @@ object Stage:
   /** Lift a pure function into a stage with no effects. */
   def pure[A, B](f: A => B): Stage[A, B, Nothing, Any] =
     Run(a => f(a))
-
-  /** Lift an effect-tracked function into a stage with no declared error. */
-  def fromKyo[A, B, S](f: A => B < S): Stage[A, B, Nothing, S] =
-    Run(f)
 
   /** A stage that never aborts: its declared error is `Nothing`, so it composes into any pipeline's error row. */
   type Infallible[-I, +O, S] = Stage[I, O, Nothing, S]

--- a/morphir/buildkit/core/src/morphir/buildkit/Stage.scala
+++ b/morphir/buildkit/core/src/morphir/buildkit/Stage.scala
@@ -115,6 +115,32 @@ object Stage:
   def pure[A, B](f: A => B): Stage[A, B, Nothing, Any] =
     Run(a => f(a))
 
+  /**
+   * Lift an effectful function that declares no error — the ergonomic constructor for the common case, after
+   * `ZIO.succeed`'s role as the infallible-effect constructor. `E` is fixed to `Nothing` by the name rather than
+   * spelled at every call site; `S` still wants help where no expected type flows in (`Stage.succeed[Int, Int, Any]` or
+   * an ascribed lambda result), for the same underconstrained-row reason [[apply]] documents.
+   *
+   * "Succeed" is a claim, not a proof: Scala offers no negative evidence over effect rows, so an `Abort` smuggled
+   * inside `S` cannot be rejected here statically. The executors contain one at runtime instead, converting it to a
+   * panic carrying [[UndeclaredAbortException]] — the event stream stays balanced and `runReport` folds it as data.
+   * Code that can genuinely fail belongs in [[attempt]] (throws) or [[apply]] (a declared error type).
+   */
+  def succeed[A, B, S](f: A => B < S): Stage[A, B, Nothing, S] =
+    Run(f)
+
+  /**
+   * Lift a plain side-effecting function whose non-fatal throws become the declared error — after `ZIO.attempt`, fixing
+   * the error channel to `Throwable` so exception-throwing code fails typed instead of panicking. Fatal throwables
+   * (`VirtualMachineError`, `InterruptedException`, ...) are not caught, matching `kyo.Abort.catching`.
+   *
+   * The parameter is a plain function, as in ZIO: a Kyo-effectful computation that also throws is unusual enough to
+   * spell out with [[succeed]] or [[apply]] plus `Abort.catching` directly, and a `B < S` parameter here would let an
+   * underconstrained `S` collapse to `Nothing` at plain-lambda call sites.
+   */
+  def attempt[A, B](f: A => B): Stage[A, B, Throwable, Any] =
+    Run(a => Abort.catching[Throwable](f(a)))
+
   /** A stage that never aborts: its declared error is `Nothing`, so it composes into any pipeline's error row. */
   type Infallible[-I, +O, S] = Stage[I, O, Nothing, S]
 end Stage

--- a/morphir/buildkit/core/src/morphir/buildkit/UndeclaredAbortException.scala
+++ b/morphir/buildkit/core/src/morphir/buildkit/UndeclaredAbortException.scala
@@ -1,0 +1,23 @@
+package morphir.buildkit
+
+import morphir.MorphirException
+
+/**
+ * A stage hid an `Abort` inside its declared `S` effect row instead of its declared `E` — something
+ * [[morphir.buildkit.Stage.apply]]'s own scaladoc warns cannot be forbidden statically (Scala has no negative evidence
+ * for "this row does not carry `Abort[X]`"), since a caller can always pick `E := Nothing` and fold the real error into
+ * `S` instead. The executor's own choke points ([[SealedPipeline#execute]], [[SealedPipeline#runReport]]) catch that at
+ * runtime instead: every `Abort` failure that reaches them, declared or not, is observed — Kyo dispatches every
+ * `Abort[X]` through one erased tag, so a handler summoned at `ConcreteTag[Any]` is offered a hidden failure exactly as
+ * it would the declared one — and one whose value the pipeline's own declared `E` does not accept is converted to this
+ * panic rather than left to escape silently through `S`, unbalancing the event stream (a `NodeStarted` with no matching
+ * `NodeFinished`/`RunFinished`) the way it used to before `Stage.fromKyo` was removed.
+ *
+ * `error` is the original value the hidden `Abort` was raised with, preserved here (not just in the message string) for
+ * a caller that wants to inspect it programmatically — [[NodeOutcome.Failed]] carries the whole [[kyo.Result.Panic]],
+ * so this exception is reachable from a report the same way any other panic is.
+ */
+final class UndeclaredAbortException(val error: Any)
+    extends MorphirException(
+      s"a stage hid Abort(...) inside its declared effect row instead of its declared error channel: $error"
+    )

--- a/morphir/buildkit/core/src/morphir/buildkit/UndeclaredAbortException.scala
+++ b/morphir/buildkit/core/src/morphir/buildkit/UndeclaredAbortException.scala
@@ -16,8 +16,18 @@ import morphir.MorphirException
  * `error` is the original value the hidden `Abort` was raised with, preserved here (not just in the message string) for
  * a caller that wants to inspect it programmatically — [[NodeOutcome.Failed]] carries the whole [[kyo.Result.Panic]],
  * so this exception is reachable from a report the same way any other panic is.
+ *
+ * The message must never throw: `executeIntercepted` builds this exception while assembling the cleanup continuation,
+ * before `closeOpenNodes` / `RunFinished(false)` have run, so a throwing `error.toString` would escape and leave the
+ * event stream unbalanced again. Rendering therefore swallows any `Throwable` from `String.valueOf` / `toString`.
  */
 final class UndeclaredAbortException(val error: Any)
-    extends MorphirException(
-      s"a stage hid Abort(...) inside its declared effect row instead of its declared error channel: $error"
-    )
+    extends MorphirException(UndeclaredAbortException.message(error))
+
+object UndeclaredAbortException:
+  private def message(error: Any): String =
+    val rendered =
+      try String.valueOf(error)
+      catch
+        case t: Throwable => s"<error toString failed: ${t.getClass.getName}>"
+    s"a stage hid Abort(...) inside its declared effect row instead of its declared error channel: $rendered"

--- a/morphir/buildkit/core/src/morphir/buildkit/UndeclaredAbortException.scala
+++ b/morphir/buildkit/core/src/morphir/buildkit/UndeclaredAbortException.scala
@@ -17,17 +17,20 @@ import morphir.MorphirException
  * a caller that wants to inspect it programmatically — [[NodeOutcome.Failed]] carries the whole [[kyo.Result.Panic]],
  * so this exception is reachable from a report the same way any other panic is.
  *
- * The message must never throw: `executeIntercepted` builds this exception while assembling the cleanup continuation,
- * before `closeOpenNodes` / `RunFinished(false)` have run, so a throwing `error.toString` would escape and leave the
- * event stream unbalanced again. Rendering therefore swallows any `Throwable` from `String.valueOf` / `toString`.
+ * The core message is always present. Detail from `error` is appended when rendering succeeds; when `String.valueOf` /
+ * `toString` throws, that failure note is appended instead — never substituting away the core — because
+ * `executeIntercepted` builds this exception while assembling the cleanup continuation, before `closeOpenNodes` /
+ * `RunFinished(false)` have run, and a throw there would leave the event stream unbalanced again.
  */
 final class UndeclaredAbortException(val error: Any)
     extends MorphirException(UndeclaredAbortException.message(error))
 
 object UndeclaredAbortException:
+  private val coreMessage =
+    "a stage hid Abort(...) inside its declared effect row instead of its declared error channel"
+
   private def message(error: Any): String =
-    val rendered =
-      try String.valueOf(error)
-      catch
-        case t: Throwable => s"<error toString failed: ${t.getClass.getName}>"
-    s"a stage hid Abort(...) inside its declared effect row instead of its declared error channel: $rendered"
+    try s"$coreMessage: ${String.valueOf(error)}"
+    catch
+      case t: Throwable =>
+        s"$coreMessage: <error toString failed: ${t.getClass.getName}>"

--- a/morphir/buildkit/core/test/src/morphir/buildkit/PipelineTests.scala
+++ b/morphir/buildkit/core/test/src/morphir/buildkit/PipelineTests.scala
@@ -571,6 +571,31 @@ class PipelineTests extends Test[Any]:
       assert(started.sorted(using Ordering.by(_.render)) == finished.sorted(using Ordering.by(_.render)))
       assert(started.map(_.render).contains("fo") && started.map(_.render).exists(_.startsWith("fo/0/")))
     }
+    // `UndeclaredAbortException`'s message is built while `executeIntercepted` assembles the cleanup continuation —
+    // before `closeOpenNodes` / `RunFinished(false)` have run. A throwing `error.toString` used to escape there and
+    // unbalance the stream again; rendering must swallow that so containment still holds.
+    "a hidden Abort whose error toString throws still closes its own NodeStarted/NodeFinished and balances RunFinished(false)" in {
+      final class ExplosiveToString:
+        override def toString: String = throw new RuntimeException("toString boom")
+      val payload = new ExplosiveToString
+      val hidden: Stage[Int, Int, Nothing, Abort[ExplosiveToString]] =
+        Stage[Int, Int, Nothing, Abort[ExplosiveToString]]((_: Int) => Abort.fail(payload)).named("hidden")
+      val plan              = sealOrFail(Pipeline.stage(hidden))
+      val (events, outcome) = Emit.run(Abort.run[Any](plan.execute(1))).eval
+      outcome match
+        case Result.Panic(ex: UndeclaredAbortException) =>
+          assert(ex.error.asInstanceOf[AnyRef] eq payload)
+          assert(ex.getMessage.contains("toString failed"))
+        case other => assert(false, s"expected a panic carrying UndeclaredAbortException, got $other")
+      assert(
+        render(events) == Chunk(
+          "run:started",
+          "start:hidden",
+          "finish:hidden:Failed",
+          "run:finished:false"
+        )
+      )
+    }
   }
 
   "typed pipelines" - {

--- a/morphir/buildkit/core/test/src/morphir/buildkit/PipelineTests.scala
+++ b/morphir/buildkit/core/test/src/morphir/buildkit/PipelineTests.scala
@@ -577,7 +577,7 @@ class PipelineTests extends Test[Any]:
     "a hidden Abort whose error toString throws still closes its own NodeStarted/NodeFinished and balances RunFinished(false)" in {
       final class ExplosiveToString:
         override def toString: String = throw new RuntimeException("toString boom")
-      val payload = new ExplosiveToString
+      val payload                                                    = new ExplosiveToString
       val hidden: Stage[Int, Int, Nothing, Abort[ExplosiveToString]] =
         Stage[Int, Int, Nothing, Abort[ExplosiveToString]]((_: Int) => Abort.fail(payload)).named("hidden")
       val plan              = sealOrFail(Pipeline.stage(hidden))

--- a/morphir/buildkit/core/test/src/morphir/buildkit/PipelineTests.scala
+++ b/morphir/buildkit/core/test/src/morphir/buildkit/PipelineTests.scala
@@ -115,7 +115,7 @@ class PipelineTests extends Test[Any]:
     }
     "a stage can read its provenance" in {
       val observing =
-        Stage[Int, String, Nothing, Any](i => Pipeline.provenance.map(path => path.map(_.label).mkString(",")))
+        Stage.succeed[Int, String, Any](i => Pipeline.provenance.map(path => path.map(_.label).mkString(",")))
           .named("observer")
       val plan        = sealOrFail(Pipeline.stage(observing))
       val (_, result) = runPure(Emit.run(plan.execute(0))).eval

--- a/morphir/buildkit/core/test/src/morphir/buildkit/PipelineTests.scala
+++ b/morphir/buildkit/core/test/src/morphir/buildkit/PipelineTests.scala
@@ -585,6 +585,9 @@ class PipelineTests extends Test[Any]:
       outcome match
         case Result.Panic(ex: UndeclaredAbortException) =>
           assert(ex.error.asInstanceOf[AnyRef] eq payload)
+          assert(ex.getMessage.startsWith(
+            "a stage hid Abort(...) inside its declared effect row instead of its declared error channel"
+          ))
           assert(ex.getMessage.contains("toString failed"))
         case other => assert(false, s"expected a panic carrying UndeclaredAbortException, got $other")
       assert(

--- a/morphir/buildkit/core/test/src/morphir/buildkit/PipelineTests.scala
+++ b/morphir/buildkit/core/test/src/morphir/buildkit/PipelineTests.scala
@@ -114,9 +114,9 @@ class PipelineTests extends Test[Any]:
       )
     }
     "a stage can read its provenance" in {
-      val observing = Stage
-        .fromKyo[Int, String, Any](i => Pipeline.provenance.map(path => path.map(_.label).mkString(",")))
-        .named("observer")
+      val observing =
+        Stage[Int, String, Nothing, Any](i => Pipeline.provenance.map(path => path.map(_.label).mkString(",")))
+          .named("observer")
       val plan        = sealOrFail(Pipeline.stage(observing))
       val (_, result) = runPure(Emit.run(plan.execute(0))).eval
       assert(result == "observer")
@@ -533,6 +533,43 @@ class PipelineTests extends Test[Any]:
       val started  = events.collect { case PipelineEvent.NodeStarted(id, _) => id }
       val finished = events.collect { case PipelineEvent.NodeFinished(id, _) => id }
       assert(started.sorted(using Ordering.by(_.render)) == finished.sorted(using Ordering.by(_.render)))
+    }
+    // `Stage.apply`'s own scaladoc explains why this can't be forbidden statically: a caller can always pick
+    // `E := Nothing` and fold a real error into `S` instead. Before this fix, that let an `Abort` skip
+    // `execute`'s single `Abort.tapError[E]` boundary entirely — its own `ConcreteTag[E]` never accepted a value
+    // whose declared type wasn't part of the pipeline's own `E`, so it fell through unclosed and unbalanced. Now the
+    // boundary claims every `Abort` regardless of which one raised it (see `SealedPipeline.executeIntercepted`) and
+    // converts one the declared `E` doesn't accept into a contained panic instead.
+    "a stage that hides Abort[String] inside its declared S instead of its declared E still closes its own NodeStarted/NodeFinished and balances RunFinished(false), converting to a panic rather than escaping unhandled" in {
+      val hidden: Stage[Int, Int, Nothing, Abort[String]] =
+        Stage[Int, Int, Nothing, Abort[String]]((_: Int) => Abort.fail("boom")).named("hidden")
+      val plan              = sealOrFail(Pipeline.stage(hidden))
+      val (events, outcome) = Emit.run(Abort.run[Any](plan.execute(1))).eval
+      outcome match
+        case Result.Panic(ex: UndeclaredAbortException) => assert(ex.error == "boom")
+        case other => assert(false, s"expected a panic carrying UndeclaredAbortException, got $other")
+      assert(
+        render(events) == Chunk(
+          "run:started",
+          "start:hidden",
+          "finish:hidden:Failed",
+          "run:finished:false"
+        )
+      )
+    }
+    "a hidden Abort inside a fanOut child balances both the child's own NodeStarted/NodeFinished and the fan-out node's own bracket" in {
+      def sources = Stage.pure((n: Int) => Chunk.from(0 until n)).named("sources")
+      val hidden: Stage[Int, Int, Nothing, Abort[String]] =
+        Stage[Int, Int, Nothing, Abort[String]]((_: Int) => Abort.fail("boom")).named("hidden")
+      val plan              = sealOrFail(Pipeline.stage(sources).fanOut("fo", Pipeline.stage(hidden)))
+      val (events, outcome) = Emit.run(Abort.run[Any](plan.execute(2))).eval
+      outcome match
+        case Result.Panic(ex: UndeclaredAbortException) => assert(ex.error == "boom")
+        case other => assert(false, s"expected a panic carrying UndeclaredAbortException, got $other")
+      val started  = events.collect { case PipelineEvent.NodeStarted(id, _) => id }
+      val finished = events.collect { case PipelineEvent.NodeFinished(id, _) => id }
+      assert(started.sorted(using Ordering.by(_.render)) == finished.sorted(using Ordering.by(_.render)))
+      assert(started.map(_.render).contains("fo") && started.map(_.render).exists(_.startsWith("fo/0/")))
     }
   }
 

--- a/morphir/buildkit/core/test/src/morphir/buildkit/RunReportTests.scala
+++ b/morphir/buildkit/core/test/src/morphir/buildkit/RunReportTests.scala
@@ -111,7 +111,7 @@ class RunReportTests extends Test[Any]:
     "a hidden Abort whose error toString throws still folds into Failed(Panic), not a torn run" in {
       final class ExplosiveToString:
         override def toString: String = throw new RuntimeException("toString boom")
-      val payload = new ExplosiveToString
+      val payload                                                       = new ExplosiveToString
       val explosive: Stage[Int, Int, Nothing, Abort[ExplosiveToString]] =
         Stage[Int, Int, Nothing, Abort[ExplosiveToString]]((_: Int) => Abort.fail(payload)).named("hidden")
       val plan =

--- a/morphir/buildkit/core/test/src/morphir/buildkit/RunReportTests.scala
+++ b/morphir/buildkit/core/test/src/morphir/buildkit/RunReportTests.scala
@@ -28,6 +28,14 @@ class RunReportTests extends Test[Any]:
   private val explode: Stage[Int, Int, Nothing, Any] = Stage((_: Int) => (throw new RuntimeException("kaboom")): Int)
   private val stringify: Stage[Int, String, Nothing, Any] = Stage((i: Int) => i.toString)
 
+  /**
+   * Declares `E = Nothing` but folds its real failure into `S` instead — the shape `Stage.apply`'s own scaladoc warns
+   * cannot be forbidden statically. Used to exercise `SealedPipeline.attempt`'s own containment of an `Abort` hidden
+   * this way, in place of the escape it used to leave through the report row's own `S`.
+   */
+  private val hidden: Stage[Int, Int, Nothing, Abort[String]] =
+    Stage[Int, Int, Nothing, Abort[String]]((_: Int) => Abort.fail("boom")).named("hidden")
+
   /** `a` succeeds, `b` aborts with a typed error, `c` never runs. */
   private def failingChain =
     Pipeline.stage(nodeId"a", inc).andThen(nodeId"b", boom).andThen(nodeId"c", double)
@@ -77,6 +85,26 @@ class RunReportTests extends Test[Any]:
       assert(report.outcome(nodeId"c") ==
         Present(NodeOutcome.Blocked(Causes.unsafe(Chunk(nodeId"boom")), Causes.unsafe(Chunk(nodeId"boom")))))
       assert(report.result.isEmpty)
+      assert(render(events).last == "run:finished:false")
+    }
+
+    "a stage that hides Abort[String] inside its declared S instead of its declared E folds into Failed(Panic), not a torn run" in {
+      val plan = sealOrFail(Pipeline.stage(nodeId"a", inc).andThen(nodeId"hidden", hidden).andThen(nodeId"c", double))
+      // `runReport`'s own row still declares the hidden `Abort[String]` (it's part of the pipeline's own flattened
+      // `S`, unioned in from `hidden`'s), even though `attempt` — see `SealedPipeline.attempt`'s own doc — already
+      // fully contains it before this point, so nothing ever actually raises through it here; the outer
+      // `Abort.run[Any]` only discharges that unused static capability, and always finds a `Result.Success`.
+      val (events, outer) = Emit.run(Abort.run[Any](plan.runReport(1))).eval
+      outer match
+        case Result.Success(report) =>
+          report.outcome(nodeId"hidden") match
+            case Present(NodeOutcome.Failed(Result.Panic(ex: UndeclaredAbortException))) =>
+              assert(ex.error == "boom")
+            case other => assert(false, s"expected Failed(Panic(UndeclaredAbortException)), got $other")
+          assert(report.outcome(nodeId"c") ==
+            Present(NodeOutcome.Blocked(Causes.unsafe(Chunk(nodeId"hidden")), Causes.unsafe(Chunk(nodeId"hidden")))))
+          assert(report.result.isEmpty)
+        case other => assert(false, s"expected the outer Abort[Any] boundary to be unused, got $other")
       assert(render(events).last == "run:finished:false")
     }
 

--- a/morphir/buildkit/core/test/src/morphir/buildkit/RunReportTests.scala
+++ b/morphir/buildkit/core/test/src/morphir/buildkit/RunReportTests.scala
@@ -108,6 +108,29 @@ class RunReportTests extends Test[Any]:
       assert(render(events).last == "run:finished:false")
     }
 
+    "a hidden Abort whose error toString throws still folds into Failed(Panic), not a torn run" in {
+      final class ExplosiveToString:
+        override def toString: String = throw new RuntimeException("toString boom")
+      val payload = new ExplosiveToString
+      val explosive: Stage[Int, Int, Nothing, Abort[ExplosiveToString]] =
+        Stage[Int, Int, Nothing, Abort[ExplosiveToString]]((_: Int) => Abort.fail(payload)).named("hidden")
+      val plan =
+        sealOrFail(Pipeline.stage(nodeId"a", inc).andThen(nodeId"hidden", explosive).andThen(nodeId"c", double))
+      val (events, outer) = Emit.run(Abort.run[Any](plan.runReport(1))).eval
+      outer match
+        case Result.Success(report) =>
+          report.outcome(nodeId"hidden") match
+            case Present(NodeOutcome.Failed(Result.Panic(ex: UndeclaredAbortException))) =>
+              assert(ex.error.asInstanceOf[AnyRef] eq payload)
+              assert(ex.getMessage.contains("toString failed"))
+            case other => assert(false, s"expected Failed(Panic(UndeclaredAbortException)), got $other")
+          assert(report.outcome(nodeId"c") ==
+            Present(NodeOutcome.Blocked(Causes.unsafe(Chunk(nodeId"hidden")), Causes.unsafe(Chunk(nodeId"hidden")))))
+          assert(report.result.isEmpty)
+        case other => assert(false, s"expected the outer Abort[Any] boundary to be unused, got $other")
+      assert(render(events).last == "run:finished:false")
+    }
+
     "Pipeline.halt inside a stage body yields Failed in the report" in {
       val halting: Stage[Int, Int, RunBoom, Any] = Stage((_: Int) => Pipeline.halt(RunBoom("halted")))
       val plan        = sealOrFail(Pipeline.stage(nodeId"a", inc).andThen(nodeId"h", halting))

--- a/morphir/buildkit/core/test/src/morphir/buildkit/RunReportTests.scala
+++ b/morphir/buildkit/core/test/src/morphir/buildkit/RunReportTests.scala
@@ -122,6 +122,9 @@ class RunReportTests extends Test[Any]:
           report.outcome(nodeId"hidden") match
             case Present(NodeOutcome.Failed(Result.Panic(ex: UndeclaredAbortException))) =>
               assert(ex.error.asInstanceOf[AnyRef] eq payload)
+              assert(ex.getMessage.startsWith(
+                "a stage hid Abort(...) inside its declared effect row instead of its declared error channel"
+              ))
               assert(ex.getMessage.contains("toString failed"))
             case other => assert(false, s"expected Failed(Panic(UndeclaredAbortException)), got $other")
           assert(report.outcome(nodeId"c") ==

--- a/morphir/buildkit/core/test/src/morphir/buildkit/StageTests.scala
+++ b/morphir/buildkit/core/test/src/morphir/buildkit/StageTests.scala
@@ -40,9 +40,25 @@ class StageTests extends Test[Any]:
       val out                                        = runPure(program).eval
       assert(out == "5")
     }
-    "apply lifts an effectful function" in {
+    "attempt turns a non-fatal throw into a typed Abort[Throwable]" in {
+      val boom = Stage.attempt((i: Int) => if i > 0 then throw new RuntimeException(s"boom-$i") else i)
+      Abort.run[Throwable](boom.run(3)).eval match
+        case Result.Failure(t) => assert(t.getMessage == "boom-3")
+        case _                 => assert(false)
+    }
+    "attempt succeeds when nothing throws" in {
+      val safe = Stage.attempt((i: Int) => i * 2)
+      assert(Abort.run[Throwable](safe.run(4)).eval == Result.Success(8))
+    }
+    "succeed composes into a declared-error pipeline" in {
+      val doubled = Stage.succeed[Int, Int, Any](i => i * 2)
+      val shown   = Stage.pure((i: Int) => i.toString)
+      val chained = doubled.andThen(shown)
+      assert(runPure(chained.run(21)).eval == "42")
+    }
+    "succeed lifts an effectful function" in {
       val effStage: Stage[Int, Int, Nothing, Any] =
-        Stage[Int, Int, Nothing, Any]((i: Int) => (i * 2): Int < Any)
+        Stage.succeed((i: Int) => (i * 2): Int < Any)
       val program = effStage.run(21)
       val out     = runPure(program).eval
       assert(out == 42)

--- a/morphir/buildkit/core/test/src/morphir/buildkit/StageTests.scala
+++ b/morphir/buildkit/core/test/src/morphir/buildkit/StageTests.scala
@@ -40,9 +40,9 @@ class StageTests extends Test[Any]:
       val out                                        = runPure(program).eval
       assert(out == "5")
     }
-    "fromKyo lifts an effectful function" in {
+    "apply lifts an effectful function" in {
       val effStage: Stage[Int, Int, Nothing, Any] =
-        Stage.fromKyo((i: Int) => (i * 2): Int < Any)
+        Stage[Int, Int, Nothing, Any]((i: Int) => (i * 2): Int < Any)
       val program = effStage.run(21)
       val out     = runPure(program).eval
       assert(out == 42)

--- a/morphir/buildkit/core/test/src/morphir/buildkitaccess/VisibilityTests.scala
+++ b/morphir/buildkit/core/test/src/morphir/buildkitaccess/VisibilityTests.scala
@@ -10,9 +10,9 @@ import morphir.buildkit.*
  */
 class VisibilityTests extends Test[Any]:
 
-  private def observer = Stage
-    .fromKyo[Int, String, Any](i => Pipeline.provenance.map(path => path.map(_.label).mkString(",")))
-    .named("observer")
+  private def observer =
+    Stage[Int, String, Nothing, Any](i => Pipeline.provenance.map(path => path.map(_.label).mkString(",")))
+      .named("observer")
 
   /**
    * Strip a proven-empty `Abort[Nothing]`: `observer` is a pure fixture, so `execute`'s own `E` infers as `Nothing`.

--- a/morphir/buildkit/core/test/src/morphir/buildkitaccess/VisibilityTests.scala
+++ b/morphir/buildkit/core/test/src/morphir/buildkitaccess/VisibilityTests.scala
@@ -11,7 +11,7 @@ import morphir.buildkit.*
 class VisibilityTests extends Test[Any]:
 
   private def observer =
-    Stage[Int, String, Nothing, Any](i => Pipeline.provenance.map(path => path.map(_.label).mkString(",")))
+    Stage.succeed[Int, String, Any](i => Pipeline.provenance.map(path => path.map(_.label).mkString(",")))
       .named("observer")
 
   /**


### PR DESCRIPTION
## Summary
- Promote `develop` into `main` so the post-squash `squire branch refresh` can move `develop` back to the `main` tip.
- Lands `#968`: remove `Stage.fromKyo` and contain Abort effects hidden in a stage's effect row as `UndeclaredAbortException` instead of an unbalanced event stream / escaped `runReport`.
- Lands `#969`: add `Stage.succeed` / `Stage.attempt` constructors so the fallibility decision lives in the name after the `fromKyo` removal.

## Context
`develop` advanced after [#966](https://github.com/finos/morphir-scala/pull/966) with these two commits. `main` also has commits not yet on `develop` (including [#970](https://github.com/finos/morphir-scala/pull/970)). After this PR squash-merges, run:

```bash
.claude/skills/squire/squire branch refresh --dry-run
.claude/skills/squire/squire branch refresh
```

## Test plan
- [ ] Confirm CI is green on this promote PR
- [ ] After squash-merge, verify the merge commit is on `origin/main`
- [ ] Run `squire branch refresh --dry-run` and confirm it validates against this PR's head SHA
- [ ] Run `squire branch refresh` and confirm `origin/develop` equals `origin/main`