### PR TITLE
build(publish): Mill-resolved Sonatype set and Morphir plugin SNAPSHOTs

### DIFF
--- a/.claude/skills/squire/SquireTests.scala
+++ b/.claude/skills/squire/SquireTests.scala
@@ -138,6 +138,61 @@ object SquireCiPolicy:
       "workflow must contain exactly one Sonatype publish invocation"
     )
 
+  def assertSonatypePublishPolicy(script: String): Unit =
+    expect(
+      !script.contains("module_prefixes"),
+      "sonatype publish must not hardcode a module_prefixes list"
+    )
+    expect(
+      script.contains("resolve '__.publishSonatypeCentral'"),
+      "sonatype publish must resolve publishSonatypeCentral from the Mill build"
+    )
+    expect(
+      script.contains("--jobs 1"),
+      "sonatype publish must serialize publishSonatypeCentral with --jobs 1"
+    )
+    expect(
+      script.contains("mill-libs-scalalib"),
+      "sonatype publish must record that Mill 1.x mill-libs-scalalib is on Maven Central"
+    )
+    expect(
+      !script.contains("mill-scalalib which isn't on Maven Central"),
+      "retired mill-scalalib Central exclusion must stay gone"
+    )
+    expect(
+      !script.contains("except the mill-morphir"),
+      "Mill Morphir plugins must not be excluded from Sonatype publication by comment policy"
+    )
+
+  def assertPublishTargetInventory(targets: Set[String]): Unit =
+    val requiredPluginPrefixes = List(
+      "mill-plugins.morphir.toolchain.",
+      "mill-plugins.morphir.javascript.",
+      "mill-plugins.morphir.elm-tooling.",
+      "mill-plugins.morphir.core.",
+      "mill-plugins.morphir.elm."
+    )
+    requiredPluginPrefixes.foreach { prefix =>
+      expect(
+        targets.exists(target => target.startsWith(prefix) && target.endsWith(".publishSonatypeCentral")),
+        s"publish inventory must include $prefix*.publishSonatypeCentral"
+      )
+    }
+    expect(
+      !targets.exists(_.contains(".integration.")),
+      "publish inventory must exclude mill-plugins.morphir.integration"
+    )
+    expect(
+      targets.contains("morphir.jvm.publishSonatypeCentral") &&
+        targets.contains("morphir.naming.jvm.publishSonatypeCentral"),
+      "publish inventory must still cover morphir.jvm and morphir.naming.jvm"
+    )
+    expect(targets.nonEmpty, "publish inventory must not be empty")
+    expect(
+      targets.forall(_.endsWith(".publishSonatypeCentral")),
+      "publish inventory may only contain publishSonatypeCentral targets"
+    )
+
   def assertSnapshotPolicy(workflow: String): Unit =
     val publish  = publishBlock(workflow)
     val snapshot = indentedBlock(publish, "- name: Configure snapshot version", 6)
@@ -1122,6 +1177,10 @@ class SquireCiPolicySpec extends Test[Any]:
     skillDirectory.resolve("../../../.config/mise/tasks/test/jvm-platform").normalize,
     StandardCharsets.UTF_8
   )
+  private val sonatypePublishTask = Files.readString(
+    skillDirectory.resolve("../../../.config/mise/tasks/publish/sonatype").normalize,
+    StandardCharsets.UTF_8
+  )
   private val jvmTargetSelectors = List(
     "morphir.__.jvm.__.compile",
     "morphir.jvm.__.compile",
@@ -1157,6 +1216,25 @@ class SquireCiPolicySpec extends Test[Any]:
       resolveJvmTarget(selector).map(selector -> _)
     }.map(_.toList.toMap)
 
+  private def resolvePublishTargets: Set[String] < (Async & Abort[SquireError]) =
+    LiveProcessRunner.run(
+      ProcessRequest(
+        Chunk((repositoryRoot / "mill").toString, "--ticker", "false", "resolve", "__.publishSonatypeCentral"),
+        Present(repositoryRoot)
+      )
+    ).flatMap {
+      case ProcessResult(_, 0, stdout, _) =>
+        stdout.linesIterator.filter(_.endsWith(".publishSonatypeCentral")).filterNot(_.contains(' ')).toSet
+      case result =>
+        Abort.fail(
+          SquireError.Failure(
+            "ci-policy",
+            s"could not resolve __.publishSonatypeCentral (exit ${result.exitCode})",
+            Present(result.stderr.trim)
+          )
+        )
+    }
+
   "hosted CI policy" - {
     "targets the exact supported pull-request and push branches" in {
       assertBranchPolicy(workflow)
@@ -1166,6 +1244,24 @@ class SquireCiPolicySpec extends Test[Any]:
     "waits for aggregate CI and owns one guarded release path" in {
       assertPublishPolicy(workflow)
       assert(true)
+    }
+
+    "derives the Sonatype publish set from Mill resolve, including the Mill Morphir plugin family" in {
+      assertSonatypePublishPolicy(sonatypePublishTask)
+      val hardCodedList = sonatypePublishTask + "\n    local module_prefixes=(\n        morphir.jvm\n    )\n"
+      val withoutResolve = replaceOnce(
+        sonatypePublishTask,
+        "resolve '__.publishSonatypeCentral'",
+        "resolve 'morphir.__.compile'"
+      )
+      assert(rejects(assertSonatypePublishPolicy, hardCodedList))
+      assert(rejects(assertSonatypePublishPolicy, withoutResolve))
+
+      for targets <- resolvePublishTargets
+      yield
+        assertPublishTargetInventory(targets)
+        val withoutPlugin = targets.filterNot(_.startsWith("mill-plugins.morphir.toolchain."))
+        assert(scala.util.Try(assertPublishTargetInventory(withoutPlugin)).isFailure)
     }
 
     "scopes the exact snapshot configuration to main and develop" in {

--- a/.claude/skills/squire/references/mill-morphir.md
+++ b/.claude/skills/squire/references/mill-morphir.md
@@ -34,6 +34,9 @@ The suite:
 - generates Scala, then compiles and runs it;
 - proves the consumer cannot see repository source modules or metabuild classes.
 
+CI Sonatype publication for the five plugins uses the same `MorphirMillPublishModule` surface
+(`__.publishSonatypeCentral`). Local SNAPSHOT acceptance stays authoritative; Central snapshots do not replace it.
+
 ## Diagnostics
 
 Run `/squire doctor`. Its project check reports:

--- a/.config/mise/tasks/publish/sonatype
+++ b/.config/mise/tasks/publish/sonatype
@@ -198,59 +198,73 @@ test_gpg_key() {
     fi
 }
 
+# Discover every module that declares Sonatype publication in the Mill build.
+#
+# MorphirPublishModule / MorphirMillPublishModule already expose
+# publishSonatypeCentral. Resolving that task is the publish set — there is no
+# parallel hand-maintained module list. A module that should not be released
+# must drop the publish trait (or never gain one); the integration plugin is
+# test-only and correctly has neither.
+#
+# Mill Morphir plugins are included: they compile against
+# com.lihaoyi::mill-libs-scalalib, which is on Maven Central for Mill 1.x. The
+# older "mill-scalalib is not on Central" exclusion predates that and is retired.
+resolve_publish_targets() {
+    local resolve_output
+    if ! resolve_output=$(./mill --ticker false resolve '__.publishSonatypeCentral'); then
+        log_error "Failed to resolve __.publishSonatypeCentral from the Mill build"
+        return 1
+    fi
+
+    local -a targets=()
+    local line
+    while IFS= read -r line; do
+        case "$line" in
+            *.publishSonatypeCentral)
+                # Mill resolve can echo progress on other lines; keep only task selectors.
+                if [[ "$line" != *" "* ]]; then
+                    targets+=("$line")
+                fi
+                ;;
+        esac
+    done <<< "$resolve_output"
+
+    if [[ ${#targets[@]} -eq 0 ]]; then
+        log_error "Mill resolved no publishSonatypeCentral targets"
+        return 1
+    fi
+
+    printf '%s\n' "${targets[@]}" | sort -u
+}
+
 # Run the publish
 run_publish() {
     log_info "Starting Sonatype Central publish..."
 
-    # Publish covers all morphir modules except the mill-morphir-elm plugin.
-    # The plugin depends on mill-scalalib which isn't on Maven Central.
-    #
-    # INVARIANT: this list must cover every module extending MorphirPublishModule,
-    # minus that plugin. Check with:
-    #
-    #     ./mill resolve 'morphir.__.publishSonatypeCentral'
-    #
-    # A module that carries the trait but is missing here is not published, and
-    # nothing reports it. If a module should not be released, drop the trait
-    # rather than leaving it out of this list — the trait is what declares the
-    # intent, so the two must agree.
-    #
-    # `morphir.naming.__` is not optional: `morphir.jvm`/`morphir.js` declare a
-    # moduleDep on it, so the published `morphir` POM names `morphir-naming_3`.
-    # Omitting it publishes a POM pointing at an artifact that is not on
-    # Sonatype, which breaks resolution for every consumer of `morphir` — not
-    # just for consumers of the new modules.
-    local module_prefixes=(
-        morphir.main
-        morphir.jvm
-        morphir.js
-        morphir.naming.__
-        morphir.model.__
-        morphir.runtime.__
-        morphir.tools.__
-        morphir.extensibility.__
-        morphir.lib.__
-        morphir.interop.__
-        morphir.contrib.__
-        morphir.tests.__
-        morphir.buildkit.__
-        morphir.prelude.__
-    )
+    local -a publish_targets=()
+    local target
+    while IFS= read -r target; do
+        [[ -n "$target" ]] && publish_targets+=("$target")
+    done < <(resolve_publish_targets)
 
     local publish_selectors=""
     local artifact_selectors=""
-    local prefix
-    for prefix in "${module_prefixes[@]}"; do
+    for target in "${publish_targets[@]}"; do
+        local module="${target%.publishSonatypeCentral}"
         if [[ -n "$publish_selectors" ]]; then
             publish_selectors+=" + "
             artifact_selectors+=" + "
         fi
-        publish_selectors+="${prefix}.publishSonatypeCentral"
-        artifact_selectors+="${prefix}.publishArtifacts"
+        publish_selectors+="${module}.publishSonatypeCentral"
+        artifact_selectors+="${module}.publishArtifacts"
     done
+
+    log_info "Publishing ${#publish_targets[@]} modules discovered from the Mill build"
 
     if [[ "${DRY_RUN:-}" == "true" ]]; then
         log_warn "DRY_RUN mode - skipping actual publish"
+        log_info "Resolved publishSonatypeCentral targets:"
+        printf '  %s\n' "${publish_targets[@]}"
         log_info "Would run: ./mill -i $artifact_selectors"
         log_info "Then:      ./mill -i --jobs 1 $publish_selectors"
         return 0

--- a/kb/bundles/morphir/morphir-scala/continuous-integration.md
+++ b/kb/bundles/morphir/morphir-scala/continuous-integration.md
@@ -20,7 +20,7 @@ branches.
 | `test-jvm` | JVM tests, including the Cucumber/JUnit5 `langkit.itest` suite |
 | `test-js` | ScalaJS tests, including the WebAssembly link variants |
 | `test-native` | Scala Native tests |
-| `publish` | Sonatype publication — branch snapshots on `main` and `develop`; VCS milestones and releases on `0.4.x` and tags |
+| `publish` | Sonatype publication — branch snapshots on `main` and `develop`; VCS milestones and releases on `0.4.x` and tags. The publish set is whatever Mill resolves for `__.publishSonatypeCentral`, including the Mill Morphir plugin family (`org.finos.morphir.mill`); the test-only `integration` module is not a publish module and is not uploaded. |
 | `ci` | Aggregate gate — depends on lint, knowledge-base and all three test jobs |
 
 CI runs on pull requests into `main`, `0.4.x`, and `develop`; pushes to those same branches; published releases; and

--- a/kb/bundles/morphir/morphir-scala/decisions/0012-keep-source-metabuild-for-mill-morphir-plugins.md
+++ b/kb/bundles/morphir/morphir-scala/decisions/0012-keep-source-metabuild-for-mill-morphir-plugins.md
@@ -1,0 +1,64 @@
+---
+type: Decision Record
+title: Keep compiling Mill Morphir plugins into the metabuild
+description: "Normal builds continue to compile mill-plugins/morphir sources into the metabuild; pinned Central artifacts are deferred until bootstrap experience is measured."
+state: Accepted
+decided: 2026-08-14
+tags: [mill, plugins, bootstrap, publishing]
+status: stable
+---
+
+# 0012 — Keep compiling Mill Morphir plugins into the metabuild
+
+Normal builds continue to compile the current `mill-plugins/morphir/` sources into the metabuild. They do **not**
+switch to resolving a pinned `org.finos.morphir.mill` artifact from Maven Central for day-to-day development.
+
+The five plugins still publish to Sonatype (SNAPSHOT from `develop`, releases from `main`) under
+`MorphirMillPublishModule`. Publication and metabuild consumption are separate choices.
+
+## Why
+
+The [Mill Morphir plugin architecture](/design/mill-morphir-plugin-architecture.md) already gates a pinned-artifact
+flip on measured maintenance and bootstrap experience after the first Mill 1.x plugin release. Enabling Sonatype
+publication does not, by itself, supply that measurement:
+
+- Clean checkouts already compile plugin sources into the metabuild with no bootstrap command
+  (`mill-build/build.mill` appends those source roots). That path is known to work and needs no network.
+- The authoritative dogfood boundary remains the local-SNAPSHOT fresh-consumer suite
+  (`mill-plugins.morphir.integration.test`). Switching the metabuild to Central must not weaken that path.
+- Central SNAPSHOT coordinates are mutable and, per Sonatype policy, may be cleaned up after about 90 days. Pinning
+  normal builds to them would couple every contributor bootstrap to snapshot retention and network reachability.
+- There is not yet measured evidence that a pinned release/milestone artifact reduces maintenance cost enough to
+  justify the extra bootstrap failure modes (version skew between metabuild and source tree, forced upgrade cadence,
+  offline clones).
+
+So the first Mill 1.x publication lands the consumer-facing coordinates without changing how this repository builds
+itself.
+
+## Alternatives considered
+
+1. **Flip immediately to a pinned Central SNAPSHOT in the metabuild.** Rejected: SNAPSHOT mutability and retention
+   make it a poor pin for every clean checkout, and there is no bootstrap-experience evidence yet.
+2. **Flip immediately to a pinned non-SNAPSHOT release/milestone.** Rejected for now: no release has been cut that
+   includes the plugin family, and forcing a release solely to change the metabuild would invert the dependency
+   between publication and measured need.
+3. **Keep source metabuild (chosen).** Preserves zero-bootstrap clean checkouts and leaves publication free to
+   serve external Mill consumers and the local-SNAPSHOT acceptance path.
+
+## Consequences
+
+- `mill-build` keeps compiling `mill-plugins/morphir/{toolchain,javascript,elm-tooling,core,elm}/src`.
+- External consumers may depend on published `org.finos.morphir.mill:mill-morphir-*_mill1_3` coordinates once CI
+  publishes them; this repository does not dogfood those coordinates in the metabuild yet.
+- The local-SNAPSHOT integration suite remains the gate that proves the published boundary.
+
+## Revisit when
+
+Revisit (and supersede this record) only when **all** of the following are true:
+
+1. At least one non-SNAPSHOT plugin release or milestone has been published and used by an external consumer, **or**
+   a sustained period of `develop` SNAPSHOT publication has produced concrete bootstrap/maintenance data.
+2. Measured evidence shows that a pinned artifact improves contributor or CI bootstrap enough to outweigh version
+   skew and network/offline costs.
+3. The flip can be implemented without weakening `mill-plugins.morphir.integration.test` (local-SNAPSHOT acceptance
+   stays authoritative).

--- a/kb/bundles/morphir/morphir-scala/decisions/index.md
+++ b/kb/bundles/morphir/morphir-scala/decisions/index.md
@@ -30,3 +30,7 @@ past-tense and answers *why is it shaped this way*. See
 * [Expressions are Expr, values are Val — diverging from Morphir's Elm-inherited vocabulary](/decisions/0009-expressions-are-expr-values-are-val.md) - The code model's expression type is renamed from Value to Expr, so that the word value is free for what an expression evaluates to.
 * [The old runtime becomes runtime.classic; its package rename is deferred](/decisions/0010-the-old-runtime-becomes-runtime-classic.md) - The existing ZIO runtime moved to morphir/runtime/classic intact, so the new runtime can take the good module path without a flag-day cutover.
 * [Runtime closures retain parameter patterns](/decisions/0011-runtime-closures-retain-parameter-patterns.md) - Val.Closure stores each remaining parameter as a code-model Pattern, preserving destructuring lambdas in the serializable runtime value.
+
+## Build and tooling
+
+* [Keep compiling Mill Morphir plugins into the metabuild](/decisions/0012-keep-source-metabuild-for-mill-morphir-plugins.md) - Normal builds continue to compile mill-plugins/morphir sources into the metabuild; pinned Central artifacts are deferred until bootstrap experience is measured.

--- a/kb/bundles/morphir/morphir-scala/design/mill-morphir-plugin-architecture.md
+++ b/kb/bundles/morphir/morphir-scala/design/mill-morphir-plugin-architecture.md
@@ -170,6 +170,9 @@ artifact-based acceptance path.
 
 After the first Mill 1.x plugin release, the project may switch normal builds to a pinned artifact. That choice does
 not weaken the local-SNAPSHOT acceptance path and should be made from measured maintenance and bootstrap experience.
+The decision for now is recorded in
+[0012 — Keep compiling Mill Morphir plugins into the metabuild](/decisions/0012-keep-source-metabuild-for-mill-morphir-plugins.md):
+publication is enabled; the metabuild stays source-compiled until the revisit conditions there are met.
 
 Mill uses the same basic pattern: its tests publish current modules into local test repositories and inject those
 repositories into isolated consumer runs. It also separates fast and packaged integration launchers.

--- a/kb/bundles/morphir/morphir-scala/log.md
+++ b/kb/bundles/morphir/morphir-scala/log.md
@@ -2,10 +2,13 @@
 
 ## 2026-08-14
 
+* **Creation**: Added [Keep compiling Mill Morphir plugins into the metabuild](/decisions/0012-keep-source-metabuild-for-mill-morphir-plugins.md).
 * **Update**: Sonatype publication now derives its module set from Mill
   (`__.publishSonatypeCentral`) rather than a hand-maintained script list, and publishes the Mill Morphir plugin
-  family (`org.finos.morphir.mill`) alongside the library modules. The retired exclusion for `mill-scalalib` no longer
-  applies under Mill 1.x (`mill-libs-scalalib` is on Maven Central). See
+  family (`org.finos.morphir.mill`) alongside the library modules. Pre-publish verification: `mill-libs-scalalib_3`
+  for the pinned Mill version is on Maven Central; plugin `publishArtifacts` succeed; generated POMs declare
+  `mill-libs-scalalib` as `provided`; `integration` is absent from the resolve inventory. Live Central SNAPSHOT
+  resolution is confirmed by the next `develop` publish job after merge. See
   [Continuous Integration](/continuous-integration.md).
 
 ## 2026-08-13

--- a/kb/bundles/morphir/morphir-scala/log.md
+++ b/kb/bundles/morphir/morphir-scala/log.md
@@ -1,5 +1,13 @@
 # Log
 
+## 2026-08-14
+
+* **Update**: Sonatype publication now derives its module set from Mill
+  (`__.publishSonatypeCentral`) rather than a hand-maintained script list, and publishes the Mill Morphir plugin
+  family (`org.finos.morphir.mill`) alongside the library modules. The retired exclusion for `mill-scalalib` no longer
+  applies under Mill 1.x (`mill-libs-scalalib` is on Maven Central). See
+  [Continuous Integration](/continuous-integration.md).
+
 ## 2026-08-13
 
 * **Update**: CI now publishes branch snapshots from `main` and `develop` after the aggregate gate, as described in

--- a/mill-plugins/morphir/AGENTS.md
+++ b/mill-plugins/morphir/AGENTS.md
@@ -6,5 +6,6 @@
 - Keep Kyo out of every plugin dependency graph. Use the pinned `sourcecode` dependency for user-facing call-site data.
 - Keep host-language `compile` authoritative. Morphir adapters expose typed tasks and append generated sources.
 - Cross-build every published plugin for all supported Mill 1.x versions with the `_mill1` platform suffix and Scala 3.
+- Sonatype publication covers the five plugins via `MorphirMillPublishModule` (`__.publishSonatypeCentral`); `integration` stays test-only and unpublished. The old `mill-scalalib`-not-on-Central exclusion is retired — plugins compile against `mill-libs-scalalib`, which is on Maven Central for Mill 1.x.
 
 See [the approved plugin architecture](../../kb/bundles/morphir/morphir-scala/design/mill-morphir-plugin-architecture.md) for rationale.


### PR DESCRIPTION
## Summary
- Retire the hand-maintained `module_prefixes` list; `publish:sonatype` resolves `__.publishSonatypeCentral` from the Mill build.
- Publish the Mill Morphir plugin family (`org.finos.morphir.mill`, `_mill1` coordinates) on the same SNAPSHOT path as library modules from `develop`/`main`.
- Record Decision Record 0012: keep compiling plugin sources into the metabuild; defer pinning Central artifacts until bootstrap experience is measured.
- Squire CI policy asserts the resolve-based publish set and that the five plugins are included (integration stays unpublished).

## Verification (post-merge)
After this lands on `develop` and the `publish` job succeeds, confirm Central snapshot coordinates resolve, e.g.:

```text
org.finos.morphir.mill:mill-morphir-toolchain_mill1_3:<develop-SNAPSHOT>
```

Pre-publish checks already done: `mill-libs-scalalib_3` on Maven Central, plugin `publishArtifacts` succeed, POM declares mill-libs as `provided`, integration absent from resolve inventory.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, `publish` job on `develop` uploads plugin SNAPSHOTs
- [ ] Resolve at least one plugin artifact from `https://central.sonatype.com/repository/maven-snapshots`
- [ ] Confirm `mill-plugins.morphir.integration` was not published