### PR TITLE
test(publish): stop generating GPG keys in mill-morphir-unit

### DIFF
--- a/mill-plugins/morphir/core/src/org/finos/morphir/mill/publish/PgpSecret.scala
+++ b/mill-plugins/morphir/core/src/org/finos/morphir/mill/publish/PgpSecret.scala
@@ -14,6 +14,8 @@ import scala.util.control.NonFatal
  */
 object PgpSecret {
 
+  private val GpgTimeoutMs = 15_000L
+
   /**
    * Convert raw key material into the base64 string Mill expects for `MILL_PGP_SECRET_BASE64`.
    *
@@ -77,7 +79,8 @@ object PgpSecret {
           stdin = decoded,
           stdout = os.Pipe,
           stderr = os.Pipe,
-          check = false
+          check = false,
+          timeout = GpgTimeoutMs
         )
       if imported.exitCode != 0 then
         throw PgpError.ImportFailed(imported.exitCode, imported.err.text())
@@ -92,7 +95,7 @@ object PgpSecret {
           "loopback",
           "--list-secret-keys"
         )
-        .call(env = env, stdout = os.Pipe, stderr = os.Pipe, check = false)
+        .call(env = env, stdout = os.Pipe, stderr = os.Pipe, check = false, timeout = GpgTimeoutMs)
       if listed.out.text().toLowerCase.contains("expired") then throw PgpError.KeyExpired
 
       log("GPG key imported successfully for validation")
@@ -101,7 +104,7 @@ object PgpSecret {
       case NonFatal(e) => throw PgpError.ValidationFailed(e.getMessage)
     } finally {
       os.proc("gpgconf", "--homedir", tempHome.toString, "--kill", "gpg-agent")
-        .call(env = env, check = false, stdout = os.Pipe, stderr = os.Pipe)
+        .call(env = env, check = false, stdout = os.Pipe, stderr = os.Pipe, timeout = GpgTimeoutMs)
       os.remove.all(tempHome)
     }
   }

--- a/mill-plugins/morphir/core/test/src/org/finos/morphir/mill/publish/EphemeralPgp.scala
+++ b/mill-plugins/morphir/core/test/src/org/finos/morphir/mill/publish/EphemeralPgp.scala
@@ -1,119 +1,16 @@
 package org.finos.morphir.mill.publish
 
-/** Throwaway GPG material for mill-morphir-core tests. Not used in publication. */
+/** Test-only GPG probes. Not used in publication. */
 object EphemeralPgp {
+
+  private val GpgTimeoutMs = 15_000L
 
   def gpgAvailable: Boolean =
     try
-      os.proc("gpg", "--version").call(check = false, stdout = os.Pipe, stderr = os.Pipe).exitCode == 0
+      os.proc("gpg", "--version")
+        .call(check = false, stdout = os.Pipe, stderr = os.Pipe, timeout = GpgTimeoutMs)
+        .exitCode == 0
     catch {
       case _: Throwable => false
     }
-
-  /**
-   * Generate an armored secret key in a throwaway `GNUPGHOME`. Prefers Ed25519; falls back to RSA 2048 if the local
-   * GnuPG cannot emit that curve.
-   */
-  def generateArmoredSecret(passphrase: String): String = {
-    val home = PgpSecret.shortGpgHome("mg-")
-    val env  = sys.env.toMap
-      .updated("GNUPGHOME", home.toString)
-      - "GPG_AGENT_INFO"
-      - "GPG_TTY"
-    try {
-      os.write.over(home / "gpg-agent.conf", "allow-loopback-pinentry\ndisable-scdaemon\n")
-      os.write.over(home / "gpg.conf", "pinentry-mode loopback\n")
-      launchAgent(env, home)
-      val eddsa = generate(env, home, eddsaBatch(passphrase))
-      if eddsa.exitCode != 0 then {
-        val rsa = generate(env, home, rsaBatch(passphrase))
-        if rsa.exitCode != 0 then
-          throw new RuntimeException(
-            s"gpg --generate-key failed (eddsa: ${eddsa.err.text()}; rsa: ${rsa.err.text()})"
-          )
-      }
-      val exported = os
-        .proc(
-          "gpg",
-          "--homedir",
-          home.toString,
-          "--batch",
-          "--yes",
-          "--pinentry-mode",
-          "loopback",
-          "--passphrase",
-          passphrase,
-          "--export-secret-keys",
-          "--armor"
-        )
-        .call(env = env, check = false, stdout = os.Pipe, stderr = os.Pipe)
-      val armor = exported.out.text()
-      if exported.exitCode != 0 || !armor.contains("BEGIN PGP PRIVATE KEY") then
-        throw new RuntimeException(s"gpg --export-secret-keys failed: ${exported.err.text()}\n$armor")
-      armor
-    } finally {
-      os.proc("gpgconf", "--homedir", home.toString, "--kill", "gpg-agent")
-        .call(env = env, check = false, stdout = os.Pipe, stderr = os.Pipe)
-      os.remove.all(home)
-    }
-  }
-
-  private def launchAgent(env: Map[String, String], home: os.Path): Unit = {
-    val daemon = os
-      .proc(
-        "gpg-agent",
-        "--homedir",
-        home.toString,
-        "--daemon",
-        "--allow-loopback-pinentry"
-      )
-      .call(env = env, check = false, stdout = os.Pipe, stderr = os.Pipe)
-    val ping = os
-      .proc("gpg-connect-agent", "--homedir", home.toString, "/bye")
-      .call(env = env, check = false, stdout = os.Pipe, stderr = os.Pipe)
-    if ping.exitCode != 0 then
-      throw new RuntimeException(
-        s"gpg-agent is not reachable (daemon exit ${daemon.exitCode}: ${daemon.err.text()}; ping: ${ping.err.text()})"
-      )
-  }
-
-  private def generate(env: Map[String, String], home: os.Path, body: String): os.CommandResult = {
-    val batch = home / "batch"
-    os.write.over(batch, body)
-    os.proc(
-      "gpg",
-      "--homedir",
-      home.toString,
-      "--batch",
-      "--pinentry-mode",
-      "loopback",
-      "--generate-key",
-      batch.toString
-    )
-      .call(env = env, check = false, stdout = os.Pipe, stderr = os.Pipe)
-  }
-
-  private def eddsaBatch(passphrase: String): String =
-    s"""%echo generating ephemeral morphir ci test key
-Key-Type: EDDSA
-Key-Curve: Ed25519
-Key-Usage: sign
-Name-Real: Morphir CI Test
-Name-Email: morphir-ci-test@example.invalid
-Expire-Date: 1d
-Passphrase: $passphrase
-%commit
-"""
-
-  private def rsaBatch(passphrase: String): String =
-    s"""%echo generating ephemeral morphir ci test key
-Key-Type: RSA
-Key-Length: 2048
-Key-Usage: sign
-Name-Real: Morphir CI Test
-Name-Email: morphir-ci-test@example.invalid
-Expire-Date: 1d
-Passphrase: $passphrase
-%commit
-"""
 }

--- a/mill-plugins/morphir/core/test/src/org/finos/morphir/mill/publish/MillPublishEnvTests.scala
+++ b/mill-plugins/morphir/core/test/src/org/finos/morphir/mill/publish/MillPublishEnvTests.scala
@@ -18,6 +18,10 @@ object MillPublishEnvTests extends TestSuite {
   private val armoredBase64 =
     Base64.getEncoder.encodeToString(armoredKey.getBytes(StandardCharsets.UTF_8))
 
+  /** Unprotected RSA fixture Mill's own publish tests use. Avoids `gpg --generate-key`, which can hang on GHA. */
+  private val millTestKeyBase64 =
+    "LS0tLS1CRUdJTiBQR1AgUFJJVkFURSBLRVkgQkxPQ0stLS0tLQoKeFZnRWFHekhpeFlKS3dZQkJBSGFSdzhCQVFkQWxQamhsaGo5MUtZUnhDQXFtaUZNMjR1UEVDL0kxemR0CnlWS2dRR1lENHZZQUFQOW9jK0ZFQzQ2dkt6b0tNWVE3M1Jvemh4UDE3WWhUZnZwRFBwYk1CZHNZQ2c2RQp6VEpwYnk1bmFYUm9kV0l1WVhKMGRYSmhlaTUwWlhOMFVISnZhbVZqZENCaWIzUWdQR0Z6UUdGeWRIVnkKWVhvdWJtVjBQc0tNQkJBV0NnQWRCUUpvYk1lTEJBc0pCd2dERlFnS0JCWUFBZ0VDR1FFQ0d3TUNIZ0VBCklRa1FBMkRDK3lxemF1RVdJUVRnUmJWQ05LcVpxRTFkdDB3RFlNTDdLck5xNFR1L0FQNHRDYzZpYWNUdQpZVEJBa2Q3UDZOM1E1VTZjbGdnSElVQ2lRL3lIbmFvVHZ3RUExbU92M2MydEVORGtrdnF5Ujl2YVhWNHEKZlBEckNDRmRTUTR0anpMY3hnVEhYUVJvYk1lTEVnb3JCZ0VFQVpkVkFRVUJBUWRBUHpzMjV5RERLSC80Cm1KNmtMU1dLSExITXJEWUZMWGVHOTNWRTluSVY0Q0FEQVFnSEFBRC9aQ1hVMDhqMkZTU2VYQWdZaFZzNwp2akVDQjQweTA2TjdaM0pqaitCSko3Z08xc0o0QkJnV0NBQUpCUUpvYk1lTEFoc01BQ0VKRUFOZ3d2c3EKczJyaEZpRUU0RVcxUWpTcW1haE5YYmRNQTJEQyt5cXphdUgrY2dEL1QxRUVkVDl1WnR6L255bGk1OHR0CjYxaWNLcndyU3kzSTBBRDNYWWErcm40QS9qWEZlZXNsNVBZZWtpU0ZzNVZGNUczRVNpWmY0amJxZXlOWQpLd09ENVIwSwo9WDhSdQotLS0tLUVORCBQR1AgUFJJVkFURSBLRVkgQkxPQ0stLS0tLQo="
+
   val tests = Tests {
     test("toMillBase64 encodes armored plaintext") {
       val encoded = PgpSecret.toMillBase64(armoredKey)
@@ -165,22 +169,22 @@ object MillPublishEnvTests extends TestSuite {
       }
     }
 
-    test("validate accepts a generated ephemeral key") {
+    test("validate accepts a converted mill test key") {
       if !EphemeralPgp.gpgAvailable then {
-        println("skipping ephemeral PgpSecret.validate: gpg not on PATH")
+        println("skipping PgpSecret.validate: gpg not on PATH")
       } else {
-        val passphrase = "morphir-ci-test-pass"
-        val armored    = EphemeralPgp.generateArmoredSecret(passphrase)
-        val millEnv    = MillSonatypeEnv.fromEnvOrThrow(
+        val armored = new String(Base64.getDecoder.decode(millTestKeyBase64), StandardCharsets.UTF_8)
+        val millEnv = MillSonatypeEnv.fromEnvOrThrow(
           Map(
             "GPG_PRIVATE_KEY"   -> armored,
-            "GPG_PASSPHRASE"    -> passphrase,
+            "GPG_PASSPHRASE"    -> "unused",
             "SONATYPE_USERNAME" -> "dry-user",
             "SONATYPE_PASSWORD" -> "dry-pass"
           )
         )
         PgpSecret.validate(millEnv.pgpSecretBase64)
         assert(millEnv.pgpSecretBase64 == PgpSecret.toMillBase64(armored))
+        assert(!millEnv.pgpSecretBase64.contains("BEGIN PGP"))
       }
     }
   }


### PR DESCRIPTION
## Summary
- `mill-morphir-unit` on the #973 squash (`19a49bba`) hung for 30 minutes in `MillPublishEnvTests.validate accepts a generated ephemeral key` (`gpg --generate-key` never returned), so `publish` never ran.
- Drop live key generation. Convert Mill's unprotected test key through `GPG_*` and import it with `PgpSecret.validate` instead.
- Bound remaining `gpg` / `gpgconf` calls at 15s so a wedged agent cannot take the job timeout.

## Test plan
- [x] `./mill -i --ticker false mill-plugins.morphir.core.1_2_0-RC1-46-16168f.test`
- [ ] `mill-morphir-unit` on this PR finishes in a few minutes
- [ ] After merge, the `develop` `publish` job reaches Central