### PR TITLE
ci: disable the mill ticker on hosted workflow invocations

### DIFF
--- a/.claude/skills/squire/SquireTests.scala
+++ b/.claude/skills/squire/SquireTests.scala
@@ -151,11 +151,15 @@ object SquireCiPolicy:
     )
 
   def assertCiMillTicker(workflow: String): Unit =
-    val invocations = workflow.linesIterator
-      .map(_.trim)
-      .filter(line => line.startsWith("./mill") || line.startsWith("if ./mill"))
-      .toList
-    expect(invocations.nonEmpty, "CI workflow must invoke mill")
+    assertMillInvocationsDisableTicker(Seq(workflow))
+
+  def assertMillInvocationsDisableTicker(texts: Seq[String]): Unit =
+    val invocations = texts.iterator.flatMap { text =>
+      text.linesIterator
+        .map(_.trim)
+        .filter(line => line.startsWith("./mill") || line.startsWith("if ./mill"))
+    }.toList
+    expect(invocations.nonEmpty, "CI mill invocations must exist")
     invocations.foreach { line =>
       expect(
         line.contains("--ticker false"),
@@ -324,7 +328,7 @@ object SquireCiPolicy:
     val runJvm  = indentedBlock(testJvm, "- name: Run JVM tests", 6)
     expect(scalar(runJvm, "run") == "mise run test:jvm-platform", "generic JVM CI must use test:jvm-platform")
     expect(
-      task.linesIterator.map(_.trim).contains("./mill -i Alias/run testJVMPlatform"),
+      task.linesIterator.map(_.trim).contains("./mill --ticker false -i Alias/run testJVMPlatform"),
       "test:jvm-platform must invoke Alias/run testJVMPlatform"
     )
     val expectedMembers = List(
@@ -1237,6 +1241,10 @@ class SquireCiPolicySpec extends Test[Any]:
     skillDirectory.resolve("../../../.config/mise/tasks/test/jvm-platform").normalize,
     StandardCharsets.UTF_8
   )
+  private val lintTask = Files.readString(
+    skillDirectory.resolve("../../../.config/mise/tasks/lint").normalize,
+    StandardCharsets.UTF_8
+  )
   private val sonatypePublishTask = Files.readString(
     skillDirectory.resolve("../../../ci/MorphirCi.mill").normalize,
     StandardCharsets.UTF_8
@@ -1310,14 +1318,26 @@ class SquireCiPolicySpec extends Test[Any]:
       assert(true)
     }
 
-    "disables the mill ticker on every workflow mill invocation" in {
-      assertCiMillTicker(workflow)
+    "disables the mill ticker on hosted workflow and mise mill invocations" in {
+      assertMillInvocationsDisableTicker(Seq(workflow, lintTask, jvmPlatformTask))
       val tickerEnabled = replaceOnce(
         workflow,
         "./mill --ticker false -i ci.publish",
         "./mill -i ci.publish"
       )
+      val lintTickerEnabled = replaceOnce(
+        lintTask,
+        "./mill --ticker false ",
+        "./mill "
+      )
+      val jvmTickerEnabled = replaceOnce(
+        jvmPlatformTask,
+        "./mill --ticker false -i ",
+        "./mill -i "
+      )
       assert(rejects(assertCiMillTicker, tickerEnabled))
+      assert(scala.util.Try(assertMillInvocationsDisableTicker(Seq(workflow, lintTickerEnabled, jvmPlatformTask))).isFailure)
+      assert(scala.util.Try(assertMillInvocationsDisableTicker(Seq(workflow, lintTask, jvmTickerEnabled))).isFailure)
     }
 
     "derives the Sonatype publish set from Mill resolve, including the Mill Morphir plugin family" in {
@@ -1418,8 +1438,8 @@ class SquireCiPolicySpec extends Test[Any]:
       )
       val taskMutation = replaceOnce(
         jvmPlatformTask,
-        "./mill -i Alias/run testJVMPlatform",
-        "./mill -i Alias/run testJVM"
+        "./mill --ticker false -i Alias/run testJVMPlatform",
+        "./mill --ticker false -i Alias/run testJVM"
       )
       val aliasMutations = List(
         missingPublishAliasMutation,

--- a/.claude/skills/squire/SquireTests.scala
+++ b/.claude/skills/squire/SquireTests.scala
@@ -130,11 +130,11 @@ object SquireCiPolicy:
     )
     val release = indentedBlock(publish, "- name: Release", 6)
     expect(
-      count(release, "./mill -i ci.publish") == 1,
+      count(release, "./mill --ticker false -i ci.publish") == 1,
       "Release step must contain the Sonatype publish invocation"
     )
     expect(
-      count(workflow, "./mill -i ci.publish") == 1,
+      count(workflow, "./mill --ticker false -i ci.publish") == 1,
       "workflow must contain exactly one Sonatype publish invocation"
     )
     expect(
@@ -149,6 +149,19 @@ object SquireCiPolicy:
       !release.contains("BEGIN PGP PRIVATE KEY"),
       "Release step must not duplicate PgpSecret conversion in bash"
     )
+
+  def assertCiMillTicker(workflow: String): Unit =
+    val invocations = workflow.linesIterator
+      .map(_.trim)
+      .filter(line => line.startsWith("./mill") || line.startsWith("if ./mill"))
+      .toList
+    expect(invocations.nonEmpty, "CI workflow must invoke mill")
+    invocations.foreach { line =>
+      expect(
+        line.contains("--ticker false"),
+        s"CI mill invocation must disable the ticker: $line"
+      )
+    }
 
   def assertSonatypePublishPolicy(script: String): Unit =
     expect(
@@ -1297,6 +1310,16 @@ class SquireCiPolicySpec extends Test[Any]:
       assert(true)
     }
 
+    "disables the mill ticker on every workflow mill invocation" in {
+      assertCiMillTicker(workflow)
+      val tickerEnabled = replaceOnce(
+        workflow,
+        "./mill --ticker false -i ci.publish",
+        "./mill -i ci.publish"
+      )
+      assert(rejects(assertCiMillTicker, tickerEnabled))
+    }
+
     "derives the Sonatype publish set from Mill resolve, including the Mill Morphir plugin family" in {
       assertSonatypePublishPolicy(sonatypePublishTask)
       assertSonatypePublishConfig(ciPackageYaml)
@@ -1493,8 +1516,8 @@ class SquireCiPolicySpec extends Test[Any]:
           "path: out/"
         ),
         "runtime-generated-fixtures:",
-        "run: ./mill -i morphir.runtime.classic.jvm.test.generatedRuntimeFixtures",
-        "run: |\n          echo out/morphir/runtime/classic/jvm/test/\n          ./mill -i morphir.runtime.classic.jvm.test.generatedRuntimeFixtures"
+        "run: ./mill --ticker false -i morphir.runtime.classic.jvm.test.generatedRuntimeFixtures",
+        "run: |\n          echo out/morphir/runtime/classic/jvm/test/\n          ./mill --ticker false -i morphir.runtime.classic.jvm.test.generatedRuntimeFixtures"
       )
       val runtimeTestsOutputOutsideStep = replaceInJob(
         replaceInJob(
@@ -1504,8 +1527,8 @@ class SquireCiPolicySpec extends Test[Any]:
           "path: out/"
         ),
         "runtime-tests:",
-        "./mill -i morphir.runtime.classic.jvm.test.verifyRuntimeTestDiscovery",
-        "echo out/morphir/runtime/classic/jvm/test/\n          ./mill -i morphir.runtime.classic.jvm.test.verifyRuntimeTestDiscovery"
+        "./mill --ticker false -i morphir.runtime.classic.jvm.test.verifyRuntimeTestDiscovery",
+        "echo out/morphir/runtime/classic/jvm/test/\n          ./mill --ticker false -i morphir.runtime.classic.jvm.test.verifyRuntimeTestDiscovery"
       )
       val unnamedCacheAction = replaceInJob(
         workflow,
@@ -1697,19 +1720,19 @@ class SquireCiPolicySpec extends Test[Any]:
         "\nenv:\n  DUPLICATE: \"MORPHIR_PUBLISH_MODE=snapshot\"\n"
       val duplicatePublishPath = replaceOnce(
         workflow,
-        "          ./mill -i ci.publish",
-        "          ./mill -i ci.publish\n          ./mill -i ci.publish"
+        "          ./mill --ticker false -i ci.publish",
+        "          ./mill --ticker false -i ci.publish\n          ./mill --ticker false -i ci.publish"
       )
       val unguardedPublishPath = replaceOnce(
         workflow,
-        "          ./mill -i ci.publish",
+        "          ./mill --ticker false -i ci.publish",
         "          echo release command moved"
       ) +
         "\n  unguarded-publish:\n" +
         "    runs-on: ubuntu-latest\n" +
         "    steps:\n" +
         "      - name: Bypass Release\n" +
-        "        run: ./mill -i ci.publish\n"
+        "        run: ./mill --ticker false -i ci.publish\n"
 
       val mutations = List(
         (assertBranchPolicy, pushWithExtraBranch),

--- a/.config/mise/tasks/lint
+++ b/.config/mise/tasks/lint
@@ -16,6 +16,6 @@ echo "  Linting Scala files..."
 # which needs a cold JVM to trigger — so --no-server, which starts a fresh runner
 # every time, was the one form guaranteed to deadlock, while a warm daemon
 # usually escaped. With that fixed the glob completes in seconds either way.
-./mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll 'morphir.__.sources'
+./mill --ticker false mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll 'morphir.__.sources'
 
 echo "Lint completed successfully"

--- a/.config/mise/tasks/test/jvm-platform
+++ b/.config/mise/tasks/test/jvm-platform
@@ -3,4 +3,4 @@
 
 set -euo pipefail
 
-./mill -i Alias/run testJVMPlatform
+./mill --ticker false -i Alias/run testJVMPlatform

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
             !out/mill-plugins/morphir/**/testOnly.dest/**
           key: ${{ runner.os }}-mill-morphir-unit-${{ hashFiles('.mill-version', 'mill-plugins/morphir/toolchain/src/**', 'mill-plugins/morphir/javascript/src/**', 'mill-plugins/morphir/elm-tooling/src/**', 'mill-plugins/morphir/elm/test-tools/morphir-elm/package-lock.json') }}-${{ github.sha }}
       - name: Run capability
-        run: ./mill -i -k 'mill-plugins.morphir.{toolchain,javascript,elm-tooling,core,elm}.__.test'
+        run: ./mill --ticker false -i -k 'mill-plugins.morphir.{toolchain,javascript,elm-tooling,core,elm}.__.test'
 
   mill-morphir-integration:
     runs-on: ubuntu-latest
@@ -160,7 +160,7 @@ jobs:
             !out/mill-plugins/morphir/**/testOnly.dest/**
           key: ${{ runner.os }}-mill-morphir-unit-${{ hashFiles('.mill-version', 'mill-plugins/morphir/toolchain/src/**', 'mill-plugins/morphir/javascript/src/**', 'mill-plugins/morphir/elm-tooling/src/**', 'mill-plugins/morphir/elm/test-tools/morphir-elm/package-lock.json') }}-${{ github.sha }}
       - name: Run capability
-        run: ./mill -i mill-plugins.morphir.integration.test
+        run: ./mill --ticker false -i mill-plugins.morphir.integration.test
 
   morphir-elm-projects:
     runs-on: ubuntu-latest
@@ -205,7 +205,7 @@ jobs:
           NODE_OPTIONS: --require ${{ github.workspace }}/.github/scripts/ebadf-close-shim.cjs
         run: |
           for attempt in 1 2 3; do
-            if ./mill -i -k "examples.morphir-elm-projects.__.morphirIR" \
+            if ./mill --ticker false -i -k "examples.morphir-elm-projects.__.morphirIR" \
               + "morphir-elm.sdks.__.morphirIR"; then
               exit 0
             fi
@@ -247,7 +247,7 @@ jobs:
           path: out/morphir/runtime/classic/jvm/test/
           key: ${{ runner.os }}-mill-runtime-generated-${{ hashFiles('.mill-version', 'mill-plugins/morphir/toolchain/src/**', 'mill-plugins/morphir/javascript/src/**', 'mill-plugins/morphir/elm-tooling/src/**', 'mill-plugins/morphir/elm/test-tools/morphir-elm/package-lock.json') }}-${{ github.sha }}
       - name: Run capability
-        run: ./mill -i morphir.runtime.classic.jvm.test.generatedRuntimeFixtures
+        run: ./mill --ticker false -i morphir.runtime.classic.jvm.test.generatedRuntimeFixtures
 
   runtime-tests:
     runs-on: ubuntu-latest
@@ -284,8 +284,8 @@ jobs:
           key: ${{ runner.os }}-mill-runtime-generated-${{ hashFiles('.mill-version', 'mill-plugins/morphir/toolchain/src/**', 'mill-plugins/morphir/javascript/src/**', 'mill-plugins/morphir/elm-tooling/src/**', 'mill-plugins/morphir/elm/test-tools/morphir-elm/package-lock.json') }}-${{ github.sha }}
       - name: Run capability
         run: |
-          ./mill -i morphir.runtime.classic.jvm.test.verifyRuntimeTestDiscovery
-          ./mill -i morphir.runtime.classic.jvm.test
+          ./mill --ticker false -i morphir.runtime.classic.jvm.test.verifyRuntimeTestDiscovery
+          ./mill --ticker false -i morphir.runtime.classic.jvm.test
 
   test-js:
     runs-on: ubuntu-latest
@@ -319,7 +319,7 @@ jobs:
         # `-j 4` matches that task; see the comment there for why the Scala.js
         # link phase needs a parallelism cap against the daemon's `-Xmx4g`.
         run: |
-          ./mill -i -k -j 4 "morphir.__.js.__.compile" + "morphir.__.js.publishArtifacts" + "morphir.__.js.__.test" + "morphir.__.wasm.__.test" + "morphir.__.wasm.fullLinkJS"
+          ./mill --ticker false -i -k -j 4 "morphir.__.js.__.compile" + "morphir.__.js.publishArtifacts" + "morphir.__.js.__.test" + "morphir.__.wasm.__.test" + "morphir.__.wasm.fullLinkJS"
 
       - name: Cache JS build output
         # when in master repo: all commits to main branch and all additional tags
@@ -369,7 +369,7 @@ jobs:
         # Kept in step with .config/mise/tasks/test/native — `-j 4` caps the
         # concurrent `nativeLink` tasks against the daemon's `-Xmx4g`.
         run: |
-          ./mill -i -k -j 4 "morphir.__.native.__.compile" + "morphir.__.native.publishArtifacts" + "morphir.__.native.__.test"
+          ./mill --ticker false -i -k -j 4 "morphir.__.native.__.compile" + "morphir.__.native.publishArtifacts" + "morphir.__.native.__.test"
 
   test-jvm:
     runs-on: ubuntu-latest
@@ -482,7 +482,7 @@ jobs:
           # shellcheck disable=SC1090
           source "$envfile"
           set +a
-          ./mill -i ci.publish
+          ./mill --ticker false -i ci.publish
 
   ci:
     if: ${{ always() }}

--- a/.github/workflows/github-dependency-graph.yml
+++ b/.github/workflows/github-dependency-graph.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Submit dependency graph
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./mill io.eleven19.mill.github.dependency.graph.Graph/submit
+        run: ./mill --ticker false io.eleven19.mill.github.dependency.graph.Graph/submit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,7 +343,7 @@ The project uses GitHub Actions for CI:
 - `test-jvm` - JVM tests, including `langkit.itest`
 - `test-js` - ScalaJS tests, including the wasm link variants
 - `test-native` - Scala Native tests
-- `publish` - SNAPSHOTs from `main` and `develop`; milestones/releases from `0.4.x` and tags, via `./mill -i ci.publish`
+- `publish` - SNAPSHOTs from `main` and `develop`; milestones/releases from `0.4.x` and tags, via `./mill --ticker false -i ci.publish`
 
 CI runs on pull requests targeting and pushes to `main`, `0.4.x`, and `develop`, plus releases and manual triggers.
 

--- a/kb/bundles/morphir/morphir-scala/continuous-integration.md
+++ b/kb/bundles/morphir/morphir-scala/continuous-integration.md
@@ -24,10 +24,11 @@ branches.
 | `ci` | Aggregate gate — depends on lint, knowledge-base and all three test jobs |
 
 CI runs on pull requests into `main`, `0.4.x`, and `develop`; pushes to those same branches; published releases; and
-manual dispatch. Older runs of the same pull request are cancelled automatically.
+manual dispatch. Older runs of the same pull request are cancelled automatically. Workflow mill invocations pass
+`--ticker false` so the GitHub log is a linear task trace rather than a replayed progress ticker.
 
 The Release step runs `ci.sonatype.writeMillEnv` first, with Morphir `GPG_*` and `SONATYPE_*` names in that mill.
-It sources the written file and then starts `./mill -i ci.publish`. Mill snapshots `Task.env` at process start, so
+It sources the written file and then starts `./mill --ticker false -i ci.publish`. Mill snapshots `Task.env` at process start, so
 conversion has to happen in an earlier mill. Live Central upload is the first `develop` publish job after merge.
 
 ## Branch snapshots

--- a/kb/bundles/morphir/morphir-scala/continuous-integration.md
+++ b/kb/bundles/morphir/morphir-scala/continuous-integration.md
@@ -24,8 +24,9 @@ branches.
 | `ci` | Aggregate gate — depends on lint, knowledge-base and all three test jobs |
 
 CI runs on pull requests into `main`, `0.4.x`, and `develop`; pushes to those same branches; published releases; and
-manual dispatch. Older runs of the same pull request are cancelled automatically. Workflow mill invocations pass
-`--ticker false` so the GitHub log is a linear task trace rather than a replayed progress ticker.
+manual dispatch. Older runs of the same pull request are cancelled automatically. Hosted mill invocations pass
+`--ticker false`. That includes the workflow and the mise tasks CI runs (`lint`, `test:jvm-platform`). The GitHub
+log is then a linear task trace rather than a replayed progress ticker.
 
 The Release step runs `ci.sonatype.writeMillEnv` first, with Morphir `GPG_*` and `SONATYPE_*` names in that mill.
 It sources the written file and then starts `./mill --ticker false -i ci.publish`. Mill snapshots `Task.env` at process start, so

--- a/kb/bundles/morphir/morphir-scala/log.md
+++ b/kb/bundles/morphir/morphir-scala/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-14
 
+* **Update**: Hosted CI mill invocations pass `--ticker false`. See [Continuous Integration](/continuous-integration.md).
 * **Update**: The publish job now invokes Mill `ci.publish` (destination fan-out over `ci.sonatype.*`) rather than `mise run publish:sonatype`. The Release step converts Morphir `GPG_*` names through `ci.sonatype.writeMillEnv` before that mill. Live Central upload is the first `develop` publish job after merge. See [Continuous Integration](/continuous-integration.md).
 * **Creation**: Added [Keep compiling Mill Morphir plugins into the metabuild](/decisions/0012-keep-source-metabuild-for-mill-morphir-plugins.md).
 * **Update**: Sonatype publication now derives its module set from Mill


### PR DESCRIPTION
## Summary
- Pass `--ticker false` on hosted mill: workflow `./mill` lines, and the mise tasks CI actually runs (`lint`, `test:jvm-platform`).
- Lock that in Squire hosted CI policy so a mill command without `--ticker false` in those files fails `squire-policy`.

## Test plan
- [x] `SquireCiPolicySpec` hosted CI policy, including workflow and mise ticker assertions (16 passed)
- [x] `kb check --no-provenance` (0 errors)
- [ ] PR `squire-policy` and mill job logs without ticker replay