### PR TITLE
ci: move hosted lint to Mill ci.lint with an exclude regex

### DIFF
--- a/.claude/skills/squire/SquireTests.scala
+++ b/.claude/skills/squire/SquireTests.scala
@@ -157,7 +157,11 @@ object SquireCiPolicy:
     val invocations = texts.iterator.flatMap { text =>
       text.linesIterator
         .map(_.trim)
-        .filter(line => line.startsWith("./mill") || line.startsWith("if ./mill"))
+        .filter { line =>
+          line.startsWith("./mill") ||
+            line.startsWith("if ./mill") ||
+            line.startsWith("run: ./mill")
+        }
     }.toList
     expect(invocations.nonEmpty, "CI mill invocations must exist")
     invocations.foreach { line =>
@@ -208,6 +212,42 @@ object SquireCiPolicy:
       !script.contains("except the mill-morphir"),
       "Mill Morphir plugins must not be excluded from Sonatype publication by comment policy"
     )
+
+  def assertCiLintPolicy(script: String): Unit =
+    expect(
+      script.contains("def lint(evaluator: Evaluator, exclude: String"),
+      "ci.lint must take an Evaluator and an exclude regex"
+    )
+    expect(
+      script.contains("LintSelectors.checkFormatSelector"),
+      "ci.lint must resolve checkFormat via LintSelectors.checkFormatSelector"
+    )
+    expect(
+      script.contains("LintSelectors.excludeMatching"),
+      "ci.lint must drop matching modules through LintSelectors.excludeMatching"
+    )
+    expect(
+      script.contains("exclusive = true"),
+      "ci commands that use Evaluator must be exclusive"
+    )
+    expect(
+      !script.contains("checkFormatAll"),
+      "ci.lint must evaluate per-module checkFormat so --exclude can drop targets"
+    )
+    expect(
+      !script.contains("millLauncher") && !script.contains("os.proc(millLauncher"),
+      "ci.lint must not nest a second mill process"
+    )
+
+  def assertLintJobPolicy(workflow: String): Unit =
+    val lint = indentedBlock(workflow, "lint:", 2)
+    val step = indentedBlock(lint, "- name: Lint code", 6)
+    expect(
+      scalar(step, "run") == "./mill --ticker false -i ci.lint",
+      "lint job must run ci.lint"
+    )
+    expect(!lint.contains("mise run lint"), "lint job must not go through the mise lint wrapper")
+    expect(!lint.contains("mise-action"), "lint job must not install mise")
 
   def assertSonatypePublishConfig(yaml: String): Unit =
     val lines = yaml.linesIterator.map(_.trim).filter(_.nonEmpty).toList
@@ -1325,6 +1365,11 @@ class SquireCiPolicySpec extends Test[Any]:
         "./mill --ticker false -i ci.publish",
         "./mill -i ci.publish"
       )
+      val lintJobTickerEnabled = replaceOnce(
+        workflow,
+        "./mill --ticker false -i ci.lint",
+        "./mill -i ci.lint"
+      )
       val lintTickerEnabled = replaceOnce(
         lintTask,
         "./mill --ticker false ",
@@ -1336,8 +1381,33 @@ class SquireCiPolicySpec extends Test[Any]:
         "./mill -i "
       )
       assert(rejects(assertCiMillTicker, tickerEnabled))
+      assert(rejects(assertCiMillTicker, lintJobTickerEnabled))
       assert(scala.util.Try(assertMillInvocationsDisableTicker(Seq(workflow, lintTickerEnabled, jvmPlatformTask))).isFailure)
       assert(scala.util.Try(assertMillInvocationsDisableTicker(Seq(workflow, lintTask, jvmTickerEnabled))).isFailure)
+    }
+
+    "runs hosted lint through ci.lint with an exclude regex" in {
+      assertLintJobPolicy(workflow)
+      assertCiLintPolicy(sonatypePublishTask)
+      val miseLint = replaceOnce(
+        workflow,
+        "run: ./mill --ticker false -i ci.lint",
+        "run: mise run lint"
+      )
+      val withoutExclude = replaceOnce(
+        sonatypePublishTask,
+        "def lint(evaluator: Evaluator, exclude: String = \"\")",
+        "def lint(evaluator: Evaluator)"
+      )
+      val checkFormatAll = replaceOnce(
+        sonatypePublishTask,
+        "LintSelectors.checkFormatSelector",
+        "checkFormatAll"
+      )
+      assert(rejects(assertLintJobPolicy, miseLint))
+      assert(rejects(assertCiLintPolicy, withoutExclude))
+      assert(rejects(assertCiLintPolicy, checkFormatAll))
+      assert(true)
     }
 
     "derives the Sonatype publish set from Mill resolve, including the Mill Morphir plugin family" in {
@@ -1609,8 +1679,8 @@ class SquireCiPolicySpec extends Test[Any]:
         "duplicate job" -> replaceOnce(workflow, policyJob, s"$policyJob\n$policyJob"),
         "step moved into lint" -> replaceOnce(
           replaceOnce(workflow, policyStep, ""),
-          "      - name: Lint code\n        run: mise run lint",
-          "      - name: Lint code\n        run: mise run lint\n" + policyStep
+          "      - name: Lint code\n        run: ./mill --ticker false -i ci.lint",
+          "      - name: Lint code\n        run: ./mill --ticker false -i ci.lint\n" + policyStep
         ),
         "step moved into another job" -> (replaceOnce(workflow, policyStep, "") +
           "\n  bypass-policy:\n" +

--- a/.claude/skills/squire/SquireTests.scala
+++ b/.claude/skills/squire/SquireTests.scala
@@ -219,20 +219,20 @@ object SquireCiPolicy:
       "ci.lint must take an Evaluator and an exclude regex"
     )
     expect(
-      script.contains("LintSelectors.checkFormatSelector"),
-      "ci.lint must resolve checkFormat via LintSelectors.checkFormatSelector"
+      script.contains("resolveSegments(Seq(LintSelectors.sourcesSelector)"),
+      "ci.lint must resolve sources via LintSelectors.sourcesSelector"
     )
     expect(
       script.contains("LintSelectors.excludeMatching"),
       "ci.lint must drop matching modules through LintSelectors.excludeMatching"
     )
     expect(
-      script.contains("exclusive = true"),
-      "ci commands that use Evaluator must be exclusive"
+      script.contains("mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll"),
+      "ci.lint must run checkFormatAll so modules without ScalafmtModule stay covered"
     )
     expect(
-      !script.contains("checkFormatAll"),
-      "ci.lint must evaluate per-module checkFormat so --exclude can drop targets"
+      script.contains("exclusive = true"),
+      "ci commands that use Evaluator must be exclusive"
     )
     expect(
       !script.contains("millLauncher") && !script.contains("os.proc(millLauncher"),
@@ -1399,14 +1399,20 @@ class SquireCiPolicySpec extends Test[Any]:
         "def lint(evaluator: Evaluator, exclude: String = \"\")",
         "def lint(evaluator: Evaluator)"
       )
-      val checkFormatAll = replaceOnce(
+      val withoutSources = replaceOnce(
         sonatypePublishTask,
-        "LintSelectors.checkFormatSelector",
-        "checkFormatAll"
+        "resolveSegments(Seq(LintSelectors.sourcesSelector)",
+        "resolveSegments(Seq(\"morphir.__.checkFormat\")"
+      )
+      val withoutCheckFormatAll = replaceOnce(
+        sonatypePublishTask,
+        "mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll",
+        "morphir.__.checkFormat"
       )
       assert(rejects(assertLintJobPolicy, miseLint))
       assert(rejects(assertCiLintPolicy, withoutExclude))
-      assert(rejects(assertCiLintPolicy, checkFormatAll))
+      assert(rejects(assertCiLintPolicy, withoutSources))
+      assert(rejects(assertCiLintPolicy, withoutCheckFormatAll))
       assert(true)
     }
 

--- a/.config/mise/tasks/lint
+++ b/.config/mise/tasks/lint
@@ -1,21 +1,7 @@
 #!/usr/bin/env bash
 # MISE description="Lint Scala code"
 
-set -e
+set -euo pipefail
 
-echo "Linting code..."
-echo "  Linting Scala files..."
-
-# Use Mill's simplified scalafmt command (Mill 1.x)
-# The /checkFormatAll suffix is inferred automatically
-#
-# This used to hang against the broad 'morphir.__.sources' glob, and carried a
-# --no-server workaround with a note that the flag "sidesteps it reliably". That
-# had it backwards: the hang was a class-initialization deadlock between the
-# Platform case objects (see mill-build/src/millbuild/crossplatform/Platform.scala),
-# which needs a cold JVM to trigger — so --no-server, which starts a fresh runner
-# every time, was the one form guaranteed to deadlock, while a warm daemon
-# usually escaped. With that fixed the glob completes in seconds either way.
-./mill --ticker false mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll 'morphir.__.sources'
-
-echo "Lint completed successfully"
+# Extra args go to ci.lint, e.g. `mise run lint -- --exclude 'langkit'`.
+./mill --ticker false -i ci.lint "$@"

--- a/.config/mise/tasks/test/squire
+++ b/.config/mise/tasks/test/squire
@@ -5,6 +5,7 @@ SQUIRE_MISE_BIN="$(command -v mise)"
 export SQUIRE_MISE_BIN
 (cd .claude/skills/squire && ./mill --no-server --ticker false SquireTests.scala)
 ./mill --ticker false mill-build/test/SnapshotVersionTests.scala
+./mill --ticker false mill-build/test/LintSelectorsTests.scala
 ./mill --ticker false mill-build/test/NodeToolchainTests.scala
 ./mill --ticker false mill-build/test/MorphirElmToolTests.scala
 ./mill --ticker false mill-build/test/MorphirElmProjectSandboxTests.scala

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,8 @@ jobs:
           java-version: "25"
       - name: Cache scala dependencies
         uses: coursier/cache-action@v8
-      - name: Setup mise
-        uses: jdx/mise-action@v4
-        with:
-          experimental: true
-
       - name: Lint code
-        run: mise run lint
+        run: ./mill --ticker false -i ci.lint
 
   squire-policy:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ Use mise for task management:
 
 ```bash
 mise run setup          # Install developer dependencies; it does not install Morphir build tools
-mise run lint           # Check code formatting
+mise run lint           # Check code formatting (`./mill --ticker false -i ci.lint`)
 mise run fmt            # Format code
 mise run test:jvm       # Run JVM tests (includes langkit.itest)
 mise run test:js        # Run JS tests (includes the wasm link variants)
@@ -177,6 +177,7 @@ Or use Mill directly:
 
 ```bash
 ./mill morphir.jvm.compile
+./mill --ticker false -i ci.lint
 ./mill morphir.tests.jvm.test
 ./mill -i -k 'mill-plugins.morphir.{toolchain,javascript,elm-tooling,core,elm}.__.test'
 ./mill mill-plugins.morphir.integration.test

--- a/ci/MorphirCi.mill
+++ b/ci/MorphirCi.mill
@@ -112,15 +112,16 @@ trait MorphirCiModule extends Module {
   }
 
   /**
-   * Scalafmt check over resolved `morphir.__.checkFormat` modules.
+   * Scalafmt check over resolved `morphir.__.sources` tasks, including modules that do not mix in
+   * `ScalafmtModule`.
    *
    * `--exclude` is a regex matched against each module path. A match drops that module from the
-   * check set. A blank exclude keeps every resolved module.
+   * check set. A blank exclude keeps every resolved module and runs one `checkFormatAll`.
    */
   def lint(evaluator: Evaluator, exclude: String = "") = Task.Command(exclusive = true) {
     val resolved = unwrap(
-      evaluator.resolveSegments(Seq(LintSelectors.checkFormatSelector), SelectMode.Multi),
-      s"resolve ${LintSelectors.checkFormatSelector}"
+      evaluator.resolveSegments(Seq(LintSelectors.sourcesSelector), SelectMode.Multi),
+      s"resolve ${LintSelectors.sourcesSelector}"
     ).map(_.render)
     val modules = LintSelectors.modulesFromResolved(resolved)
     val kept = LintSelectors.excludeMatching(modules, exclude) match {
@@ -129,12 +130,28 @@ trait MorphirCiModule extends Module {
     }
     if kept.isEmpty then
       throw new Exception(
-        s"ci.lint: no ${LintSelectors.checkFormatSuffix} targets remain" +
+        s"ci.lint: no ${LintSelectors.sourcesSuffix} targets remain" +
           (if exclude.isBlank then "" else s" after --exclude $exclude")
       )
-    val selectors = kept.map(module => s"$module${LintSelectors.checkFormatSuffix}")
-    Task.log.info(s"ci.lint: checking ${selectors.size} modules")
-    evaluateAll(evaluator, selectors, "ci.lint")
+    val sourceSelectors =
+      if kept.size == modules.size then Seq(LintSelectors.sourcesSelector)
+      else kept.map(module => s"$module${LintSelectors.sourcesSuffix}")
+    Task.log.info(s"ci.lint: checking ${kept.size} source modules")
+    sourceSelectors.foreach(selector => evaluateLint(evaluator, selector))
+  }
+
+  private def evaluateLint(evaluator: Evaluator, sourcesSelector: String): Unit = {
+    val evalResult = unwrap(
+      evaluator.evaluate(
+        Seq("mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll", sourcesSelector),
+        SelectMode.Separated
+      ),
+      s"ci.lint $sourcesSelector"
+    )
+    evalResult.values.toEither match {
+      case Left(msg) => throw new Exception(s"ci.lint $sourcesSelector failed: $msg")
+      case Right(_)  => ()
+    }
   }
 
   /**

--- a/ci/MorphirCi.mill
+++ b/ci/MorphirCi.mill
@@ -3,14 +3,15 @@ package build.ci
 import build.{`mill-plugins` => millPlugins}
 import mill.*
 import mill.api.{BuildCtx, DefaultTaskModule, Evaluator, ModuleRef, Result, SelectMode, TaskCtx}
+import millbuild.LintSelectors
 import org.finos.morphir.mill.publish.{MillPublishEnvFile, MillSonatypeEnv, PgpSecret, PublishSelectors}
 
 /**
- * CI publish mechanics that YAML cannot express. Morphir inventory knobs for libraries live in
+ * CI commands that YAML cannot express. Morphir inventory knobs for libraries live in
  * `ci/package.mill.yaml`; publishable Mill plugins are [[pluginModules]] ModuleRefs.
  *
- * Slice 1: [[sonatype]] only. Next destination: `githubReleases` (skill binaries) as a sibling —
- * reserved in comments, not nested under `publish`, and not a filesystem subfolder yet.
+ * Slice 1: [[sonatype]] plus [[lint]]. Next destination: `githubReleases` (skill binaries) as a
+ * sibling — reserved in comments, not nested under `publish`, and not a filesystem subfolder yet.
  *
  * Dynamic task selection uses Mill's exclusive [[Evaluator]] commands (same mechanism as builtin
  * `resolve` / `show`). Nested `./mill` is intentionally avoided — under `mill -i` it deadlocks on
@@ -108,6 +109,32 @@ trait MorphirCiModule extends Module {
       runArtifactPhase(evaluator, PublishKind.All, cfg)
       runUploadPhase(evaluator, PublishKind.All, cfg)
     }
+  }
+
+  /**
+   * Scalafmt check over resolved `morphir.__.checkFormat` modules.
+   *
+   * `--exclude` is a regex matched against each module path. A match drops that module from the
+   * check set. A blank exclude keeps every resolved module.
+   */
+  def lint(evaluator: Evaluator, exclude: String = "") = Task.Command(exclusive = true) {
+    val resolved = unwrap(
+      evaluator.resolveSegments(Seq(LintSelectors.checkFormatSelector), SelectMode.Multi),
+      s"resolve ${LintSelectors.checkFormatSelector}"
+    ).map(_.render)
+    val modules = LintSelectors.modulesFromResolved(resolved)
+    val kept = LintSelectors.excludeMatching(modules, exclude) match {
+      case Right(selected) => selected
+      case Left(message)   => throw new Exception(message)
+    }
+    if kept.isEmpty then
+      throw new Exception(
+        s"ci.lint: no ${LintSelectors.checkFormatSuffix} targets remain" +
+          (if exclude.isBlank then "" else s" after --exclude $exclude")
+      )
+    val selectors = kept.map(module => s"$module${LintSelectors.checkFormatSuffix}")
+    Task.log.info(s"ci.lint: checking ${selectors.size} modules")
+    evaluateAll(evaluator, selectors, "ci.lint")
   }
 
   /**

--- a/kb/bundles/morphir/morphir-scala/continuous-integration.md
+++ b/kb/bundles/morphir/morphir-scala/continuous-integration.md
@@ -15,7 +15,7 @@ branches.
 
 | Job | Runs |
 | --- | ---- |
-| `lint` | Mill `ci.lint`: scalafmt check over resolved `morphir.__.checkFormat` modules. `--exclude` drops matching module paths. |
+| `lint` | Mill `ci.lint`: scalafmt `checkFormatAll` over resolved `morphir.__.sources` tasks. `--exclude` drops matching module paths. |
 | `squire-policy` | `mise run test:squire`. Squire and release-policy gates. |
 | `knowledge-base` | `kb check` and `kb intent check` |
 | `test-jvm` | JVM tests, including the Cucumber/JUnit5 `langkit.itest` suite |

--- a/kb/bundles/morphir/morphir-scala/continuous-integration.md
+++ b/kb/bundles/morphir/morphir-scala/continuous-integration.md
@@ -15,7 +15,8 @@ branches.
 
 | Job | Runs |
 | --- | ---- |
-| `lint` | `mise run lint` plus `mise run test:squire` — scalafmt and Squire/release-policy gates |
+| `lint` | Mill `ci.lint`: scalafmt check over resolved `morphir.__.checkFormat` modules. `--exclude` drops matching module paths. |
+| `squire-policy` | `mise run test:squire`. Squire and release-policy gates. |
 | `knowledge-base` | `kb check` and `kb intent check` |
 | `test-jvm` | JVM tests, including the Cucumber/JUnit5 `langkit.itest` suite |
 | `test-js` | ScalaJS tests, including the WebAssembly link variants |
@@ -25,7 +26,7 @@ branches.
 
 CI runs on pull requests into `main`, `0.4.x`, and `develop`; pushes to those same branches; published releases; and
 manual dispatch. Older runs of the same pull request are cancelled automatically. Hosted mill invocations pass
-`--ticker false`. That includes the workflow and the mise tasks CI runs (`lint`, `test:jvm-platform`). The GitHub
+`--ticker false`. That includes the workflow, the local `lint` mise wrapper, and `test:jvm-platform`. The GitHub
 log is then a linear task trace rather than a replayed progress ticker.
 
 The Release step runs `ci.sonatype.writeMillEnv` first, with Morphir `GPG_*` and `SONATYPE_*` names in that mill.

--- a/mill-build/src/millbuild/LintSelectors.scala
+++ b/mill-build/src/millbuild/LintSelectors.scala
@@ -1,22 +1,23 @@
 package millbuild
 
 /**
- * Pure selection over resolved `*.checkFormat` module paths for [[build.ci.MorphirCiModule.lint]].
+ * Pure selection over resolved `*.sources` module paths for [[build.ci.MorphirCiModule.lint]].
  *
  * `ci/MorphirCi.mill` supplies the names Mill resolved; this object drops those whose path matches
- * `--exclude`.
+ * `--exclude`. The selector is `morphir.__.sources` so modules without `ScalafmtModule` stay in
+ * the check set; `checkFormatAll` lints those files.
  */
 object LintSelectors {
-  val checkFormatSelector: String = "morphir.__.checkFormat"
-  val checkFormatSuffix: String   = ".checkFormat"
+  val sourcesSelector: String = "morphir.__.sources"
+  val sourcesSuffix: String   = ".sources"
 
   def modulesFromResolved(resolved: Seq[String]): Seq[String] =
     resolved
-      .filter(_.endsWith(checkFormatSuffix))
+      .filter(_.endsWith(sourcesSuffix))
       .map { rendered =>
         if rendered.contains(' ') then
-          throw new IllegalArgumentException(s"resolve $checkFormatSelector: unexpected space in $rendered")
-        rendered.stripSuffix(checkFormatSuffix)
+          throw new IllegalArgumentException(s"resolve $sourcesSelector: unexpected space in $rendered")
+        rendered.stripSuffix(sourcesSuffix)
       }
       .distinct
       .sorted

--- a/mill-build/src/millbuild/LintSelectors.scala
+++ b/mill-build/src/millbuild/LintSelectors.scala
@@ -1,0 +1,39 @@
+package millbuild
+
+/**
+ * Pure selection over resolved `*.checkFormat` module paths for [[build.ci.MorphirCiModule.lint]].
+ *
+ * `ci/MorphirCi.mill` supplies the names Mill resolved; this object drops those whose path matches
+ * `--exclude`.
+ */
+object LintSelectors {
+  val checkFormatSelector: String = "morphir.__.checkFormat"
+  val checkFormatSuffix: String   = ".checkFormat"
+
+  def modulesFromResolved(resolved: Seq[String]): Seq[String] =
+    resolved
+      .filter(_.endsWith(checkFormatSuffix))
+      .map { rendered =>
+        if rendered.contains(' ') then
+          throw new IllegalArgumentException(s"resolve $checkFormatSelector: unexpected space in $rendered")
+        rendered.stripSuffix(checkFormatSuffix)
+      }
+      .distinct
+      .sorted
+
+  /**
+   * Drop every module path that contains a match for `exclude`.
+   *
+   * A blank `exclude` keeps `modules` unchanged. An empty regex would otherwise match every
+   * path, so it is treated as "no filter" rather than compiled.
+   */
+  def excludeMatching(modules: Seq[String], exclude: String): Either[String, Seq[String]] =
+    if exclude.isBlank then Right(modules)
+    else
+      try
+        val pattern = exclude.r
+        Right(modules.filterNot(module => pattern.findFirstIn(module).nonEmpty))
+      catch
+        case error: java.util.regex.PatternSyntaxException =>
+          Left(s"ci.lint --exclude is not a valid regex: ${error.getDescription}")
+}

--- a/mill-build/test/LintSelectorsTests.scala
+++ b/mill-build/test/LintSelectorsTests.scala
@@ -1,0 +1,47 @@
+//| moduleDeps: ["//mill-build/src/millbuild/LintSelectors.scala"]
+
+import millbuild.LintSelectors
+
+def assertEquals[A](actual: A, expected: A): Unit =
+  assert(actual == expected, s"Expected $expected, got $actual")
+
+@main def runLintSelectorsTests(): Unit =
+  val resolved = Seq(
+    "morphir.langkit.jvm.checkFormat",
+    "morphir.prelude.jvm.checkFormat",
+    "morphir.tests.jvm.checkFormat",
+    "morphir.langkit.jvm.compile"
+  )
+  val modules = LintSelectors.modulesFromResolved(resolved)
+  assertEquals(
+    modules,
+    Seq("morphir.langkit.jvm", "morphir.prelude.jvm", "morphir.tests.jvm")
+  )
+
+  assertEquals(LintSelectors.excludeMatching(modules, ""), Right(modules))
+  assertEquals(LintSelectors.excludeMatching(modules, "   "), Right(modules))
+  assertEquals(
+    LintSelectors.excludeMatching(modules, "langkit"),
+    Right(Seq("morphir.prelude.jvm", "morphir.tests.jvm"))
+  )
+  assertEquals(
+    LintSelectors.excludeMatching(modules, "^morphir\\.tests\\."),
+    Right(Seq("morphir.langkit.jvm", "morphir.prelude.jvm"))
+  )
+  assertEquals(LintSelectors.excludeMatching(modules, "morphir\\."), Right(Seq.empty))
+
+  val invalid = LintSelectors.excludeMatching(modules, "(")
+  assert(invalid.isLeft, s"Expected invalid regex to fail, got $invalid")
+  assert(
+    invalid.swap.exists(_.contains("ci.lint --exclude is not a valid regex")),
+    s"Expected a ci.lint regex error, got $invalid"
+  )
+
+  interceptSpace()
+
+def interceptSpace(): Unit =
+  try
+    LintSelectors.modulesFromResolved(Seq("morphir.jvm extra.checkFormat"))
+    assert(false, "expected space in a resolved name to fail")
+  catch
+    case _: IllegalArgumentException => ()

--- a/mill-build/test/LintSelectorsTests.scala
+++ b/mill-build/test/LintSelectorsTests.scala
@@ -7,25 +7,25 @@ def assertEquals[A](actual: A, expected: A): Unit =
 
 @main def runLintSelectorsTests(): Unit =
   val resolved = Seq(
-    "morphir.langkit.jvm.checkFormat",
-    "morphir.prelude.jvm.checkFormat",
-    "morphir.tests.jvm.checkFormat",
+    "morphir.langkit.jvm.sources",
+    "morphir.prelude.jvm.sources",
+    "morphir.tests.jvm.test.sources",
     "morphir.langkit.jvm.compile"
   )
   val modules = LintSelectors.modulesFromResolved(resolved)
   assertEquals(
     modules,
-    Seq("morphir.langkit.jvm", "morphir.prelude.jvm", "morphir.tests.jvm")
+    Seq("morphir.langkit.jvm", "morphir.prelude.jvm", "morphir.tests.jvm.test")
   )
 
   assertEquals(LintSelectors.excludeMatching(modules, ""), Right(modules))
   assertEquals(LintSelectors.excludeMatching(modules, "   "), Right(modules))
   assertEquals(
     LintSelectors.excludeMatching(modules, "langkit"),
-    Right(Seq("morphir.prelude.jvm", "morphir.tests.jvm"))
+    Right(Seq("morphir.prelude.jvm", "morphir.tests.jvm.test"))
   )
   assertEquals(
-    LintSelectors.excludeMatching(modules, "^morphir\\.tests\\."),
+    LintSelectors.excludeMatching(modules, "\\.test$"),
     Right(Seq("morphir.langkit.jvm", "morphir.prelude.jvm"))
   )
   assertEquals(LintSelectors.excludeMatching(modules, "morphir\\."), Right(Seq.empty))
@@ -41,7 +41,7 @@ def assertEquals[A](actual: A, expected: A): Unit =
 
 def interceptSpace(): Unit =
   try
-    LintSelectors.modulesFromResolved(Seq("morphir.jvm extra.checkFormat"))
+    LintSelectors.modulesFromResolved(Seq("morphir.jvm extra.sources"))
     assert(false, "expected space in a resolved name to fail")
   catch
     case _: IllegalArgumentException => ()


### PR DESCRIPTION
## Summary
- Hosted `lint` now runs `./mill --ticker false -i ci.lint` instead of `mise run lint`. `ci.lint` resolves `morphir.__.checkFormat` and evaluates those tasks in-process.
- `--exclude` is a regex against module paths; a match drops that target. `mise run lint` remains a local wrapper that forwards extra args.
- Squire hosted CI policy locks the workflow command and the exclude regex, and ticker scanning now also covers `run: ./mill` lines.

## Test plan
- [x] `mill-build/test/LintSelectorsTests.scala`
- [x] `SquireCiPolicySpec` hosted CI policy (17 passed)
- [x] `kb check --no-provenance` (0 errors)
- [x] `./mill --ticker false -i ci.lint --exclude '.*'` and `--exclude '('` fail closed
- [ ] PR `lint` and `squire-policy`
