### PR TITLE
fix(publish): pass decoded PGP key bytes to gpg validate

### DIFF
--- a/mill-plugins/morphir/core/src/org/finos/morphir/mill/publish/PgpSecret.scala
+++ b/mill-plugins/morphir/core/src/org/finos/morphir/mill/publish/PgpSecret.scala
@@ -9,8 +9,9 @@ import scala.util.control.NonFatal
  * Normalize CI-supplied PGP material to Mill's `MILL_PGP_SECRET_BASE64` form and optionally validate it with a
  * temporary `gpg --import`.
  *
- * Accepts armored plaintext (`BEGIN PGP PRIVATE KEY`) or base64 of that armor — the same dual input Morphir CI
- * historically accepted in its publish scripts.
+ * Accepts armored plaintext (`BEGIN PGP PRIVATE KEY`), base64 of that armor, or base64 of a binary
+ * `gpg --export-secret-keys` packet — the dual input Morphir CI historically accepted in its publish scripts,
+ * plus the common binary-export encoding.
  */
 object PgpSecret {
 
@@ -30,8 +31,10 @@ object PgpSecret {
     } else {
       val cleaned = normalized.filterNot(_.isWhitespace)
       try {
-        val decoded = new String(Base64.getDecoder.decode(cleaned), StandardCharsets.UTF_8)
-        if decoded.contains("PGP") || decoded.contains("PRIVATE") || decoded.contains("BEGIN") then {
+        val decodedBytes = Base64.getDecoder.decode(cleaned)
+        // Inspect as Latin-1 so binary OpenPGP packets are not corrupted before marker checks.
+        val decodedText = new String(decodedBytes, StandardCharsets.ISO_8859_1)
+        if decodedText.contains("PGP") || decodedText.contains("PRIVATE") || decodedText.contains("BEGIN") then {
           log("Detected base64-encoded PGP key")
           cleaned
         } else {
@@ -49,11 +52,14 @@ object PgpSecret {
   /**
    * Import the Mill-form base64 secret into a throwaway `GNUPGHOME` and fail if GPG rejects it or reports the key as
    * expired.
+   *
+   * Decoded key bytes are passed to `gpg` directly — never via a UTF-8 `String` — so binary
+   * `gpg --export-secret-keys` material survives validation.
    */
   def validate(secretBase64: String, log: String => Unit = _ => ()): Unit = {
     log("Validating GPG key via temporary import")
-    val decoded =
-      try new String(Base64.getDecoder.decode(secretBase64), StandardCharsets.UTF_8)
+    val decodedBytes =
+      try Base64.getDecoder.decode(secretBase64)
       catch {
         case e: IllegalArgumentException =>
           throw PgpError.InvalidBase64(e.getMessage)
@@ -76,7 +82,7 @@ object PgpSecret {
         )
         .call(
           env = env,
-          stdin = decoded,
+          stdin = decodedBytes,
           stdout = os.Pipe,
           stderr = os.Pipe,
           check = false,

--- a/mill-plugins/morphir/core/test/src/org/finos/morphir/mill/publish/MillPublishEnvTests.scala
+++ b/mill-plugins/morphir/core/test/src/org/finos/morphir/mill/publish/MillPublishEnvTests.scala
@@ -187,5 +187,62 @@ object MillPublishEnvTests extends TestSuite {
         assert(!millEnv.pgpSecretBase64.contains("BEGIN PGP"))
       }
     }
+
+    test("validate accepts base64 of a binary secret-key export") {
+      if !EphemeralPgp.gpgAvailable then {
+        println("skipping PgpSecret.validate binary export: gpg not on PATH")
+      } else {
+        val armored  = new String(Base64.getDecoder.decode(millTestKeyBase64), StandardCharsets.UTF_8)
+        val tempHome = PgpSecret.shortGpgHome("mbt-")
+        val env      = sys.env.toMap.updated("GNUPGHOME", tempHome.toString) - "GPG_AGENT_INFO" - "GPG_TTY"
+        try {
+          val imported = os
+            .proc(
+              "gpg",
+              "--homedir",
+              tempHome.toString,
+              "--batch",
+              "--pinentry-mode",
+              "loopback",
+              "--import",
+              "--no-tty"
+            )
+            .call(
+              env = env,
+              stdin = armored,
+              stdout = os.Pipe,
+              stderr = os.Pipe,
+              check = false,
+              timeout = 15_000L
+            )
+          assert(imported.exitCode == 0)
+
+          val exported = os
+            .proc(
+              "gpg",
+              "--homedir",
+              tempHome.toString,
+              "--batch",
+              "--pinentry-mode",
+              "loopback",
+              "--export-secret-keys"
+            )
+            .call(env = env, stdout = os.Pipe, stderr = os.Pipe, check = false, timeout = 15_000L)
+          assert(exported.exitCode == 0)
+          val binaryBytes = exported.out.bytes
+          assert(binaryBytes.nonEmpty)
+          assert(!(new String(binaryBytes, StandardCharsets.UTF_8).contains("BEGIN PGP")))
+
+          val binaryBase64 = Base64.getEncoder.encodeToString(binaryBytes)
+          val millForm     = PgpSecret.toMillBase64(binaryBase64)
+          assert(millForm == binaryBase64.filterNot(_.isWhitespace))
+          PgpSecret.validate(millForm)
+        } finally {
+          os.proc("gpgconf", "--homedir", tempHome.toString, "--kill", "gpg-agent")
+            .call(env = env, check = false, stdout = os.Pipe, stderr = os.Pipe, timeout = 15_000L)
+          os.remove.all(tempHome)
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Addresses the Codex P1 on #977: `PgpSecret.validate` no longer UTF-8-decodes key material before `gpg --import`, so base64 of a binary `gpg --export-secret-keys` export survives `writeMillEnv` validation.
- `toMillBase64` inspects decoded bytes as Latin-1 for armor markers so binary packets are not corrupted during detection.
- Adds a unit test that exports a secret key as binary, base64-encodes it, and validates through the Mill env path.

## Test plan

- [x] `./mill mill-plugins.morphir.core.<ver>.test` (includes new binary-export validate test)
- [ ] CI green on this PR
- [ ] Merge to `develop`, then continue #977 promote


Made with [Cursor](https://cursor.com)