### PR TITLE
fix(ci): stop treating intelligence BuildInfo as PublishModule

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -226,12 +226,29 @@ trait MorphirCliBuildInfo extends MorphirVersionBuildInfo {
 
 /** BuildInfo wiring for `morphir.intelligence` — its own member set (adds JVM build info, no `platform` member
   * since this module isn't cross-platform) and package name, both hardcoded per [[MorphirExtensibilityBuildInfo]].
+  *
+  * Intentionally does **not** extend [[PublishModule]]. Intelligence is unpublished (#950); mixing in
+  * `PublishModule` typed `moduleDeps` as `Seq[PublishModule]` and broke Graph/generate once the SDK lost
+  * its publish trait while remaining a module dependency of this CLI.
   */
-trait MorphirIntelligenceBuildInfo extends BuildInfo with PublishModule with ScalaModule {
+trait MorphirIntelligenceBuildInfo extends BuildInfo with ScalaModule {
   def buildInfoPackageName = "org.finos.morphir.intelligence.buildinfo"
   override def buildInfoObjectName = "BuildInfo"
+
+  /** Same env-driven version selection as [[MorphirPublishModule.publishVersion]], without requiring PublishModule. */
+  def intelligenceVersionEnvironment = Task.Input {
+    Seq("MORPHIR_PUBLISH_MODE", "MORPHIR_PUBLISH_BRANCH")
+      .flatMap(name => Task.env.get(name).map(name -> _))
+      .toMap
+  }
+  def intelligenceVersion = Task {
+    SnapshotVersion
+      .select(VcsVersion.vcsState(), intelligenceVersionEnvironment())
+      .fold(message => throw new IllegalArgumentException(message), identity)
+  }
+
   def buildInfoMembers = Seq(
-    BuildInfo.Value("version", publishVersion()),
+    BuildInfo.Value("version", intelligenceVersion()),
     BuildInfo.Value("scalaVersion", scalaVersion()),
     BuildInfo.Value("buildJvmVersion", System.getProperty("java.version")),
     BuildInfo.Value("buildJvmVendor", System.getProperty("java.vendor"))

--- a/morphir/intelligence/package.mill.yaml
+++ b/morphir/intelligence/package.mill.yaml
@@ -1,4 +1,4 @@
-extends: [build.MorphirCommonModule, build.MorphirIntelligenceBuildInfo, build.MorphirScoverage, build.MorphirKyoCaseAppMvnDeps, build.MorphirKyoSchemaMvnDeps]
+extends: [build.MorphirCommonModule, build.MorphirIntelligenceBuildInfo, build.MorphirScoverage, build.MorphirKyoCaseAppMvnDeps, build.MorphirKyoSchemaMvnDeps, build.MorphirKyoSchemaJsonMvnDeps]
 mainClass: org.finos.morphir.intelligence.Main
 moduleDeps: [build.morphir.intelligence.sdk.jvm]
 


### PR DESCRIPTION
## Summary

- Fixes the `dependency-graph` failure on `main` ([run 31821927756](https://github.com/finos/morphir-scala/actions/runs/31821927756/job/94836978537)): `Graph/generate` crashed casting `morphir.intelligence.sdk.jvm` to `PublishModule`.
- Root cause: `MorphirIntelligenceBuildInfo` still mixed in `PublishModule` after #950 intentionally removed publish traits from intelligence/sdk. Mill therefore typed `moduleDeps` as `Seq[PublishModule]`.
- Fix: keep intelligence unpublished; resolve BuildInfo version through `SnapshotVersion` without `PublishModule`. Also add `MorphirKyoSchemaJsonMvnDeps` so `kyo.Json` in the CLI compiles once that cast no longer masks it.

## Test plan

- [x] `./mill io.eleven19.mill.github.dependency.graph.Graph/generate` succeeds
- [x] `./mill morphir.intelligence.showModuleDeps` lists `sdk.jvm`
- [x] `./mill morphir.intelligence.compile` / `.test` pass
- [x] `__.publishSonatypeCentral` still excludes intelligence
- [ ] CI green on this PR
- [ ] After merge to develop and promote/back-integration (or direct main path), dependency-graph job on main is green


Made with [Cursor](https://cursor.com)