### PR TITLE
fix(ci): make desktop packaging work on Windows, macOS and arm64 Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,12 +511,14 @@ jobs:
             MATRIX='{"include":[{"token":"mac-aarch64","runner":"macos-14"},{"token":"mac-amd64","runner":"macos-15-intel"},{"token":"linux-amd64","runner":"ubuntu-24.04"},{"token":"linux-aarch64","runner":"ubuntu-24.04-arm"},{"token":"win-amd64","runner":"windows-latest"}]}'
             PLATFORMS="mac-aarch64,mac-amd64,linux-amd64,linux-aarch64,win-amd64"
           else
-            # A pull request packages linux-amd64 and win-amd64. Windows is the platform least like
-            # the others — Git Bash rather than a POSIX shell, mill.bat rather than ./mill, NSIS
-            # rather than fpm — so it is the one most worth catching before a merge. The remaining
-            # three legs still wait for a push to a release branch.
-            MATRIX='{"include":[{"token":"linux-amd64","runner":"ubuntu-24.04"},{"token":"win-amd64","runner":"windows-latest"}]}'
-            PLATFORMS="linux-amd64,win-amd64"
+            # A pull request packages one leg per operating system: linux-amd64, win-amd64 and
+            # mac-aarch64. Each covers machinery the others do not — fpm and AppImage on Linux, Git
+            # Bash and mill.bat and NSIS on Windows, code signing and dmg on macOS — and all three
+            # of those areas have produced a real packaging failure. What a pull request defers is
+            # only the second architecture of an already-covered operating system, mac-amd64 and
+            # linux-aarch64, which a push to a release branch still exercises.
+            MATRIX='{"include":[{"token":"linux-amd64","runner":"ubuntu-24.04"},{"token":"win-amd64","runner":"windows-latest"},{"token":"mac-aarch64","runner":"macos-14"}]}'
+            PLATFORMS="linux-amd64,win-amd64,mac-aarch64"
           fi
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
           echo "platforms=$PLATFORMS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,10 +497,11 @@ jobs:
     # (and everything gated on it) would never run.
     if: github.repository == 'finos/morphir-scala' && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'release' || vars.MORPHIR_CI_PACKAGE_DESKTOP != 'false')
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 20
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       platforms: ${{ steps.matrix.outputs.platforms }}
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Compute the packaging matrix
         id: matrix
@@ -510,11 +511,46 @@ jobs:
             MATRIX='{"include":[{"token":"mac-aarch64","runner":"macos-14"},{"token":"mac-amd64","runner":"macos-15-intel"},{"token":"linux-amd64","runner":"ubuntu-24.04"},{"token":"linux-aarch64","runner":"ubuntu-24.04-arm"},{"token":"win-amd64","runner":"windows-latest"}]}'
             PLATFORMS="mac-aarch64,mac-amd64,linux-amd64,linux-aarch64,win-amd64"
           else
-            MATRIX='{"include":[{"token":"linux-amd64","runner":"ubuntu-24.04"}]}'
-            PLATFORMS="linux-amd64"
+            # A pull request packages linux-amd64 and win-amd64. Windows is the platform least like
+            # the others — Git Bash rather than a POSIX shell, mill.bat rather than ./mill, NSIS
+            # rather than fpm — so it is the one most worth catching before a merge. The remaining
+            # three legs still wait for a push to a release branch.
+            MATRIX='{"include":[{"token":"linux-amd64","runner":"ubuntu-24.04"},{"token":"win-amd64","runner":"windows-latest"}]}'
+            PLATFORMS="linux-amd64,win-amd64"
           fi
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
           echo "platforms=$PLATFORMS" >> "$GITHUB_OUTPUT"
+
+      # Resolved once, here, rather than on each packaging runner. Two reasons: every leg then
+      # stamps the identical version, where five independent resolves could disagree across a
+      # commit boundary; and Windows never has to run Mill for this, since the ./mill launcher
+      # supports only Linux and macOS and exits 1 anywhere else.
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: "25"
+          distribution: temurin
+
+      - name: Cache scala dependencies
+        uses: coursier/cache-action@v8
+
+      - name: Resolve the publish version
+        id: version
+        shell: bash
+        # `mill show` is not guaranteed to put the value alone on stdout, so take the last line and
+        # strip the JSON quotes; an empty result is a failure rather than a blank version carried
+        # into electron-builder, where it would surface as a confusing packaging error.
+        run: |
+          version="$(./mill --ticker false -i show ci.desktop.version | tail -n 1 | tr -d '"')"
+          if [[ -z "$version" ]]; then
+            echo "ci.desktop.version resolved to an empty string" >&2
+            exit 1
+          fi
+          echo "resolved desktop version: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
   desktop-package:
     # Desktop binaries ship on tags and published releases only regardless of the switch. Ordinary
@@ -545,22 +581,6 @@ jobs:
       - name: Cache scala dependencies
         uses: coursier/cache-action@v8
 
-      - name: Resolve publish version
-        shell: bash
-        # `mill show` is not guaranteed to put the value alone on stdout — a bootstrap or daemon line
-        # can precede it, and writing that straight into $GITHUB_ENV produces a second line with no
-        # `KEY=`, which the runner rejects with "Unable to process file command 'env' successfully".
-        # Take the last line, strip the JSON quotes, and refuse an empty result rather than carrying
-        # a blank version into electron-builder, where it would surface as a confusing packaging error.
-        run: |
-          version="$(./mill --ticker false -i show ci.desktop.version | tail -n 1 | tr -d '"')"
-          if [[ -z "$version" ]]; then
-            echo "ci.desktop.version resolved to an empty string" >&2
-            exit 1
-          fi
-          echo "resolved desktop version: $version"
-          echo "MORPHIR_DESKTOP_VERSION=$version" >> "$GITHUB_ENV"
-
       - name: Package
         shell: bash
         env:
@@ -570,7 +590,7 @@ jobs:
           APPLE_ID: ${{ secrets.ORG_MORPHIR_APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.ORG_MORPHIR_APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.ORG_MORPHIR_APPLE_TEAM_ID }}
-        run: ./morphir/desktop/scripts/package.sh "${{ matrix.token }}" "$MORPHIR_DESKTOP_VERSION"
+        run: ./morphir/desktop/scripts/package.sh "${{ matrix.token }}" "${{ needs.desktop-matrix.outputs.version }}"
 
       - name: Upload raw packaging output
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -764,6 +764,11 @@ jobs:
     if: github.repository == 'finos/morphir-scala' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.4.x' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/'))
     needs: [ci]
 
+    # Without this the job inherits GitHub's six-hour default. An `apt-get update` wedged against
+    # unreachable Ubuntu mirrors held this job — and the whole run, including its logs — open for
+    # over half an hour with no upload attempted; six hours is not a useful thing to wait for.
+    timeout-minutes: 60
+
     runs-on: ubuntu-latest
 
     # only run one publish job for the same sha at the same time
@@ -844,6 +849,7 @@ jobs:
   ci:
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [lint, squire-policy, knowledge-base, test-js, test-js-desktop, test-jvm, test-native, mill-morphir-unit, mill-morphir-integration, morphir-elm-projects, runtime-generated-fixtures, runtime-tests]
     steps:
       - name: Verify required CI jobs succeeded
@@ -866,6 +872,7 @@ jobs:
   packaging:
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [desktop-matrix, desktop-package, desktop-verify]
     steps:
       # Unlike `ci`, a skip can be legitimate here — MORPHIR_CI_PACKAGE_DESKTOP=false stands the whole

--- a/mill-plugins/morphir/core/src/org/finos/morphir/mill/publish/desktop/DesktopPlatform.scala
+++ b/mill-plugins/morphir/core/src/org/finos/morphir/mill/publish/desktop/DesktopPlatform.scala
@@ -24,8 +24,12 @@ enum DesktopPlatform(
   case MacAmd64   extends DesktopPlatform("mac-amd64", "mac", "x64", ArchiveKind.Zip, Seq("dmg"))
   case LinuxAmd64
       extends DesktopPlatform("linux-amd64", "linux", "x64", ArchiveKind.TarGz, Seq("AppImage", "deb"))
+  // No deb here, unlike linux-amd64. electron-builder builds a deb by shelling out to fpm, and the
+  // only fpm build it publishes is `fpm-1.9.3-2.3.1-linux-x86`, which cannot execute on an arm64
+  // runner. Declaring the target anyway would make `expected-assets-present` demand a file no
+  // packaging run can produce.
   case LinuxAarch64
-      extends DesktopPlatform("linux-aarch64", "linux", "arm64", ArchiveKind.TarGz, Seq("AppImage", "deb"))
+      extends DesktopPlatform("linux-aarch64", "linux", "arm64", ArchiveKind.TarGz, Seq("AppImage"))
   case WinAmd64 extends DesktopPlatform("win-amd64", "win", "x64", ArchiveKind.Zip, Seq("exe"))
 
   /** Maven artifactId, and the leading part of every asset name for this platform. */

--- a/mill-plugins/morphir/core/test/src/org/finos/morphir/mill/publish/desktop/DesktopPlatformTests.scala
+++ b/mill-plugins/morphir/core/test/src/org/finos/morphir/mill/publish/desktop/DesktopPlatformTests.scala
@@ -26,6 +26,9 @@ object DesktopPlatformTests extends TestSuite {
       assert(DesktopPlatform.MacAarch64.installerExts == Seq("dmg"))
       assert(DesktopPlatform.WinAmd64.installerExts == Seq("exe"))
       assert(DesktopPlatform.LinuxAmd64.installerExts == Seq("AppImage", "deb"))
+      // arm64 ships no deb: electron-builder builds one through fpm, and the only fpm build it
+      // publishes is linux-x86, which cannot execute on an arm64 runner.
+      assert(DesktopPlatform.LinuxAarch64.installerExts == Seq("AppImage"))
     }
 
     test("allExts lists the archive first, then installers") {

--- a/mill-plugins/morphir/core/test/src/org/finos/morphir/mill/publish/desktop/DesktopReleaseInventoryTests.scala
+++ b/mill-plugins/morphir/core/test/src/org/finos/morphir/mill/publish/desktop/DesktopReleaseInventoryTests.scala
@@ -52,8 +52,10 @@ object DesktopReleaseInventoryTests extends TestSuite {
     }
 
     test("a tar.gz is not mistaken for another gz-suffixed file") {
+      // linux-amd64 rather than linux-aarch64: only the x64 leg declares a deb, because
+      // electron-builder's fpm build cannot execute on arm64.
       val result = DesktopReleaseInventory.classify(
-        DesktopPlatform.LinuxAarch64,
+        DesktopPlatform.LinuxAmd64,
         Seq("app.tar.gz", "app.AppImage", "app.deb", "notes.txt.gz")
       )
       assert(result.map(_.archive) == Right("app.tar.gz"))

--- a/morphir/desktop/scripts/package.sh
+++ b/morphir/desktop/scripts/package.sh
@@ -10,13 +10,22 @@ VERSION="${2:?version required}"
 
 cd "$(dirname "$0")/../../.."
 
+# The `./mill` launcher is a POSIX shell script that supports only Linux and macOS — on anything
+# else it prints "This native mill launcher supports only Linux and macOS." and exits 1. Under Git
+# Bash on a Windows runner `uname -s` reports MINGW64_NT-…, so the Windows build has to go through
+# `mill.bat`, which the repository ships alongside it.
+MILL="./mill"
+case "$(uname -s)" in
+  MINGW* | MSYS* | CYGWIN*) MILL="./mill.bat" ;;
+esac
+
 # Release builds use fullLinkJS; scripts/assemble.sh uses fastLinkJS for the dev loop.
 #
 # The `+` is required. Two task selectors written side by side are not two tasks: Mill reads the
 # second as an argument to the first, links only the boot bundle, and exits 0. That failure is
 # invisible on a machine where the renderer was linked at some earlier point, and shows up on a
 # fresh checkout as a missing directory much later in the script.
-./mill morphir.desktop.boot.js.fullLinkJS + morphir.desktop.renderer.js.fullLinkJS
+"$MILL" morphir.desktop.boot.js.fullLinkJS + morphir.desktop.renderer.js.fullLinkJS
 
 APP="morphir/desktop/app"
 mkdir -p "$APP/dist"

--- a/morphir/desktop/scripts/package.sh
+++ b/morphir/desktop/scripts/package.sh
@@ -58,10 +58,25 @@ case "$TOKEN" in
   mac-aarch64)   BUILDER_ARGS=(--mac --arm64) ;;
   mac-amd64)     BUILDER_ARGS=(--mac --x64) ;;
   linux-amd64)   BUILDER_ARGS=(--linux --x64) ;;
-  linux-aarch64) BUILDER_ARGS=(--linux --arm64) ;;
+  # No deb on arm64: electron-builder shells out to fpm, and the only build it publishes is
+  # `fpm-1.9.3-2.3.1-linux-x86`, which cannot execute on an arm64 runner. tar.gz and AppImage are
+  # named explicitly here so this leg does not inherit the deb target from electron-builder.yml.
+  linux-aarch64) BUILDER_ARGS=(--linux tar.gz AppImage --arm64) ;;
   win-amd64)     BUILDER_ARGS=(--win --x64) ;;
   *) echo "unknown platform token: $TOKEN" >&2; exit 1 ;;
 esac
+
+# GitHub Actions sets an `env:` entry to the empty string when its secret does not exist, so the
+# signing variables arrive defined-but-empty rather than absent. electron-builder treats a defined
+# CSC_LINK as a certificate path, resolves the empty value to the working directory, and fails with
+# "<dir> not a file" — which is how both macOS legs died while Linux and Windows, which do not sign
+# by default, went through. Unsetting the empty ones restores the intended behaviour: sign when a
+# certificate is configured, build unsigned when one is not.
+for signing_var in CSC_LINK CSC_KEY_PASSWORD APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID; do
+  if [ -z "${!signing_var:-}" ]; then
+    unset "$signing_var" || true
+  fi
+done
 
 cd "$APP"
 npm ci


### PR DESCRIPTION
## Summary

The first full five-platform packaging run on `develop` (run 32082847404) packaged `linux-amd64` and failed the four legs that had never executed before. This fixes all four, and brings one leg per operating system forward into pull-request CI so the next such failure is found before a merge rather than after one.

| Leg | Why it failed | Fix |
| --- | --- | --- |
| `win-amd64` | `./mill` is a POSIX shell script that prints "This native mill launcher supports only Linux and macOS" and exits 1. Under Git Bash `uname -s` reports `MINGW64_NT-…`, so the Windows leg could never run it. | `package.sh` selects `mill.bat` under MINGW/MSYS/CYGWIN. The publish version is now resolved once in `desktop-matrix` and passed to each leg, so Windows does not run Mill for that step at all. |
| `mac-aarch64`, `mac-amd64` | Both died at code signing with `⨯ …/morphir/desktop/app not a file`. GitHub Actions sets an `env:` entry to the **empty string** when its secret does not exist, so `CSC_LINK` arrived defined-but-empty; electron-builder treated it as a certificate path, resolved it to the working directory, and failed. Linux and Windows never noticed because they do not sign by default. | `package.sh` unsets the signing variables when they are empty, restoring the intended behaviour: sign when a certificate is configured, build unsigned when one is not. |
| `linux-aarch64` | electron-builder builds a `.deb` by shelling out to fpm, and the only fpm build it publishes is `fpm-1.9.3-2.3.1-linux-x86`, which cannot execute on an arm64 runner. | `linux-aarch64` no longer declares or builds a deb. It still ships `tar.gz` and AppImage. |

## Also

- **Resolving the version once.** Previously each packaging runner resolved `ci.desktop.version` independently. Besides removing Mill from the Windows runner, this guarantees every platform stamps the same version rather than risking two legs disagreeing across a commit boundary.
- **`publish` had no `timeout-minutes`**, so it inherited GitHub's six-hour default. On run 32082847404 an `apt-get update` wedged against unreachable Ubuntu mirrors held that job — and the whole run, including its logs — open for over half an hour with no upload attempted. It now has 60 minutes; the `ci` and `packaging` aggregates have 10.
- **Pull requests now package one leg per operating system**: `linux-amd64`, `win-amd64` and `mac-aarch64`. Each covers machinery the others do not, and all three areas have now produced a real packaging failure. What a pull request defers is only the second architecture of an already-covered operating system.

## Testing

- `mill-plugins.morphir.core.__.test` green, including a new assertion that `linux-aarch64` declares no deb, so `expected-assets-present` cannot start demanding a file no runner can produce.
- `ci.lint` exits 0; the workflow parses and `actionlint` exits 0.
- The matrix JSON and the platform token list were checked to agree in both branches of `desktop-matrix` — `desktop-verify` scopes canonicalization by that token list, so a mismatch would verify a platform that was not built, or skip one that was.
- This pull request exercises three of the four fixes directly. `mac-amd64` and `linux-aarch64` remain unverified until it lands on `develop`.
