### PR TITLE
ci: raise the test-native timeout to 45 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,7 +410,12 @@ jobs:
   # failure should be legible on its own.
   test-native:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 45 rather than 30, for the same reason test-js carries 45. This job finishes in about fifteen
+    # minutes on a warm cache and exceeded thirty on a coursier cache miss, with no OutOfMemoryError
+    # in the log — lowering the link concurrency to `-j 2` cured the heap exhaustion and left
+    # wall-clock as the binding constraint. A timed-out job is reported as *cancelled*, which reads
+    # like an unrelated infrastructure failure rather than a job that needed more minutes.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

`test-native` was cancelled on the `develop` run after the desktop packaging merge, having run 30m14s against its `timeout-minutes: 30`. A timed-out job is reported as *cancelled*, which reads like unrelated infrastructure trouble rather than a job that needed more minutes.

Unlike the earlier native failure, there is **no `OutOfMemoryError` in this log**. Lowering the link concurrency to `-j 2` cured the heap exhaustion and left wall-clock as the binding constraint:

```
coursier cache miss, fell back on coursier-desktop-package-matrix-…
test-native (25): cancelled  02:23:15 -> 02:53:29
```

The job finishes in about fifteen minutes on a warm cache. A cache miss pushes it past thirty. `test-js` already carries 45 minutes for exactly this reason; this brings `test-native` in line.

## Consequence this unblocks

`ci` failing here skips the packaging fan-out, so `mac-amd64` and `linux-aarch64` — the two legs whose fixes landed in #988 untested — still have not run. This is what stands between them and a first green result.

## Alternatives considered

- Restoring `-j 4` would undo the fix for a real `OutOfMemoryError` inside the Scala Native link.
- Adding a build-output cache for the native job, as `test-js` has, would address the cold-run cost rather than the symptom. That is worth doing on its own, and is not this change.
