### PR TITLE
feat(langkit): add budgeted Markdown scanning

### DIFF
--- a/.claude/skills/squire/SquireTests.scala
+++ b/.claude/skills/squire/SquireTests.scala
@@ -416,10 +416,10 @@ object SquireCiPolicy:
     )
     val expectedMembers = List(
       "morphir.jvm.__.compile",
-      "morphir.{buildkit.core,contrib.knowledge,extensibility,intelligence.sdk,interop.borer,interop.zio.json,kit.kyo,langkit.core,langkit.elm.compiler.api,langkit.elm.core,langkit.trees,lib.interop,model,model.lowering,naming,prelude,testing.generators,testing.zio,tests,tools}.jvm.__.compile",
+      "morphir.{buildkit.core,contrib.knowledge,extensibility,intelligence.sdk,interop.borer,interop.zio.json,kit.kyo,langkit.core,langkit.elm.compiler.api,langkit.elm.core,langkit.markdown,langkit.trees,lib.interop,model,model.lowering,naming,prelude,testing.generators,testing.zio,tests,tools}.jvm.__.compile",
       "morphir.jvm.publishArtifacts",
       "morphir.{buildkit.core,contrib.knowledge,extensibility,interop.borer,interop.zio.json,lib.interop,model,model.lowering,naming,prelude,tests,tools}.jvm.publishArtifacts",
-      "morphir.{buildkit.core,contrib.knowledge,intelligence.sdk,interop.borer,interop.zio.json,kit.kyo,langkit.core,langkit.elm.compiler.api,langkit.elm.core,langkit.trees,model,model.lowering,prelude,tests}.jvm.test",
+      "morphir.{buildkit.core,contrib.knowledge,intelligence.sdk,interop.borer,interop.zio.json,kit.kyo,langkit.core,langkit.elm.compiler.api,langkit.elm.core,langkit.markdown,langkit.trees,model,model.lowering,prelude,tests}.jvm.test",
       "morphir.langkit.itest.testCached"
     )
     val definitions = "(?m)^\\s*def testJVMPlatform\\b".r.findAllMatchIn(buildMill).size
@@ -1710,8 +1710,8 @@ class SquireCiPolicySpec extends Test[Any]:
       val reorderedAliasMutation = replaceOnce(
         buildMill,
         "    \"morphir.jvm.__.compile\",\n" +
-          "    \"morphir.{buildkit.core,contrib.knowledge,extensibility,intelligence.sdk,interop.borer,interop.zio.json,kit.kyo,langkit.core,langkit.elm.compiler.api,langkit.elm.core,langkit.trees,lib.interop,model,model.lowering,naming,prelude,testing.generators,testing.zio,tests,tools}.jvm.__.compile\",",
-        "    \"morphir.{buildkit.core,contrib.knowledge,extensibility,intelligence.sdk,interop.borer,interop.zio.json,kit.kyo,langkit.core,langkit.elm.compiler.api,langkit.elm.core,langkit.trees,lib.interop,model,model.lowering,naming,prelude,testing.generators,testing.zio,tests,tools}.jvm.__.compile\",\n" +
+          "    \"morphir.{buildkit.core,contrib.knowledge,extensibility,intelligence.sdk,interop.borer,interop.zio.json,kit.kyo,langkit.core,langkit.elm.compiler.api,langkit.elm.core,langkit.markdown,langkit.trees,lib.interop,model,model.lowering,naming,prelude,testing.generators,testing.zio,tests,tools}.jvm.__.compile\",",
+        "    \"morphir.{buildkit.core,contrib.knowledge,extensibility,intelligence.sdk,interop.borer,interop.zio.json,kit.kyo,langkit.core,langkit.elm.compiler.api,langkit.elm.core,langkit.markdown,langkit.trees,lib.interop,model,model.lowering,naming,prelude,testing.generators,testing.zio,tests,tools}.jvm.__.compile\",\n" +
           "    \"morphir.jvm.__.compile\","
       )
       val runtimeAliasMutation = replaceOnce(

--- a/.github/scripts/install-libuv.sh
+++ b/.github/scripts/install-libuv.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Install libuv headers for Scala Native on GitHub-hosted Ubuntu runners.
+#
+# The runner image prefers azure.archive.ubuntu.com via /etc/apt/apt-mirrors.txt. That mirror
+# stalls: apt prints Ign for each suite, eventually falls back, and can sit in `apt-get update`
+# until the step budget is gone. The job then looks cancelled rather than failed. Point apt at
+# archive.ubuntu.com first, bound each fetch, and retry. See actions/runner-images#12949.
+#
+# Used by the test-native and publish jobs in .github/workflows/ci.yml.
+
+set -euo pipefail
+
+if dpkg-query -W -f='${Status}\n' libuv1-dev 2>/dev/null | grep -q 'install ok installed'; then
+  echo "libuv1-dev is already installed"
+  exit 0
+fi
+
+if [[ -f /etc/apt/apt-mirrors.txt ]]; then
+  printf '%s\n' \
+    'http://archive.ubuntu.com/ubuntu/' \
+    'http://security.ubuntu.com/ubuntu/' |
+    sudo tee /etc/apt/apt-mirrors.txt >/dev/null
+fi
+
+# Some images also name the Azure archive directly in deb822 stanzas.
+sudo sed -i \
+  's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
+  /etc/apt/sources.list \
+  /etc/apt/sources.list.d/*.list \
+  /etc/apt/sources.list.d/*.sources \
+  2>/dev/null || true
+
+apt_opts=(
+  -o Acquire::Retries=2
+  -o Acquire::http::Timeout=15
+  -o Acquire::https::Timeout=15
+  -o Acquire::ForceIPv4=true
+)
+
+run_apt() {
+  local attempt
+  for attempt in 1 2 3; do
+    if sudo timeout -k 5 90 apt-get "${apt_opts[@]}" "$@"; then
+      return 0
+    fi
+    echo "apt-get $* failed (attempt ${attempt}); retrying..." >&2
+    sleep 2
+  done
+  echo "apt-get $* failed after 3 attempts" >&2
+  return 1
+}
+
+run_apt update
+run_apt install -y libuv1-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,12 +464,10 @@ jobs:
         uses: coursier/cache-action@v8
 
       - name: Install libuv
-        # Bounded for the reason the publish job's identical step records: a stalled Ubuntu mirror
-        # otherwise consumes the whole job budget and the job is reported as cancelled.
+        # Bounded: a stalled Ubuntu mirror otherwise consumes the job budget. The script skips the
+        # Azure archive (see actions/runner-images#12949) rather than waiting on it.
         timeout-minutes: 6
-        run: |
-          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20 update
-          sudo apt-get -o Acquire::Retries=3 install -y libuv1-dev
+        run: .github/scripts/install-libuv.sh
 
       # Reuse of this job's own native build output. Unlike test-js's cache, which is save-only and
       # restored by `publish` rather than by test-js itself, this both restores and saves, so a
@@ -896,19 +894,11 @@ jobs:
         uses: coursier/cache-action@v8
 
       - name: Install libuv
-        # Bounded, because an unreachable Ubuntu mirror stalls apt rather than failing. Run
-        # 32158142566, the develop run for the #991 merge, spent this job's entire 60-minute budget
-        # inside `apt-get update` and published nothing; the log's last line was an ordinary `Get`,
-        # so a stall reads exactly like slow progress. A job killed by its timeout is also reported
-        # as *cancelled*, which reads as though a person stopped it.
-        #
-        # Retries and per-connection timeouts make apt abandon a bad mirror quickly instead of
-        # blocking on it, and `timeout-minutes` bounds the step for the case where retrying does not
-        # help. Both are needed: the retry options cap each request, not the step.
+        # Bounded: run 32158142566 spent this job's entire 60-minute budget inside `apt-get update`
+        # against azure.archive.ubuntu.com. The shared script skips that mirror; timeout-minutes is
+        # the backstop if retrying still cannot finish.
         timeout-minutes: 6
-        run: |
-          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20 update
-          sudo apt-get -o Acquire::Retries=3 install -y libuv1-dev
+        run: .github/scripts/install-libuv.sh
 
       - name: Restore JVM Build Output From Cache
         uses: actions/cache/restore@v6

--- a/build.mill
+++ b/build.mill
@@ -863,10 +863,10 @@ object MyAliases extends Aliases {
   def testJVM       = alias("morphir.__.jvm.__.test")
   def testJVMPlatform = alias(
     "morphir.jvm.__.compile",
-    "morphir.{buildkit.core,contrib.knowledge,extensibility,intelligence.sdk,interop.borer,interop.zio.json,kit.kyo,langkit.core,langkit.elm.compiler.api,langkit.elm.core,langkit.trees,lib.interop,model,model.lowering,naming,prelude,testing.generators,testing.zio,tests,tools}.jvm.__.compile",
+    "morphir.{buildkit.core,contrib.knowledge,extensibility,intelligence.sdk,interop.borer,interop.zio.json,kit.kyo,langkit.core,langkit.elm.compiler.api,langkit.elm.core,langkit.markdown,langkit.trees,lib.interop,model,model.lowering,naming,prelude,testing.generators,testing.zio,tests,tools}.jvm.__.compile",
     "morphir.jvm.publishArtifacts",
     "morphir.{buildkit.core,contrib.knowledge,extensibility,interop.borer,interop.zio.json,lib.interop,model,model.lowering,naming,prelude,tests,tools}.jvm.publishArtifacts",
-    "morphir.{buildkit.core,contrib.knowledge,intelligence.sdk,interop.borer,interop.zio.json,kit.kyo,langkit.core,langkit.elm.compiler.api,langkit.elm.core,langkit.trees,model,model.lowering,prelude,tests}.jvm.test",
+    "morphir.{buildkit.core,contrib.knowledge,intelligence.sdk,interop.borer,interop.zio.json,kit.kyo,langkit.core,langkit.elm.compiler.api,langkit.elm.core,langkit.markdown,langkit.trees,model,model.lowering,prelude,tests}.jvm.test",
     "morphir.langkit.itest.testCached"
   )
   def testJVMCached = alias("morphir.__.jvm.__.testCached")

--- a/morphir/langkit/core/CONTRIBUTING.md
+++ b/morphir/langkit/core/CONTRIBUTING.md
@@ -6,10 +6,10 @@ The namespace guide [`morphir/langkit/CONTRIBUTING.md`](../CONTRIBUTING.md) gove
 
 ## The bar for adding something here
 
-This module has **no main dependencies** — not kyo, not parsley, not neotype. Its `package.mill.yaml` declares
-`mvnDeps` only inside the `object test:` blocks, for kyo-test itself. Every other langkit module sits above this one,
-so a dependency added to the main blocks is a dependency added under all of them. That is a stack-wide decision, not a
-module-local one.
+This module depends on Morphir Prelude and Kyo Core. Its `package.mill.yaml` declares those through
+`build.MorphirKyoCoreMvnDeps` and a direct `morphir-prelude` module dependency. Test blocks add kyo-test. Every other
+langkit module sits above this one, so a dependency added to the main blocks is a dependency added under all of them.
+That is a stack-wide decision, not a module-local one.
 
 Two questions before adding a type:
 

--- a/morphir/langkit/core/README.md
+++ b/morphir/langkit/core/README.md
@@ -67,6 +67,9 @@ before and one after by default, both overridable.
 `SourceScanner` gives parsers a scan-local cursor with deterministic ceilings for input length, work, nesting, and
 emitted nodes. The default entry point uses conservative safe limits, and a caller can supply narrower typed limits:
 
+A scanner session is mutable, single-owner state. It is not thread-safe and must not be shared across threads; keep
+all scanner use inside its `scan` callback on one execution path.
+
 ```scala
 import morphir.langkit.core.scanner.*
 

--- a/morphir/langkit/core/README.md
+++ b/morphir/langkit/core/README.md
@@ -2,9 +2,9 @@
 
 Source positions and diagnostic rendering, shared by every langkit.
 
-This module is the bottom of the langkit stack. It has no dependencies beyond the standard library, knows nothing
-about any particular language, and holds what every parser needs regardless of what it parses: a way to name a region
-of source text, a way to show that region back to a human, and a way to say how much a finding matters.
+This module is the bottom of the langkit stack. It depends on Morphir Prelude and Kyo Core, knows nothing about any
+particular language, and holds what every parser needs regardless of what it parses: a way to name a region of source
+text, a way to show that region back to a human, and a way to say how much a finding matters.
 
 ## Positions
 
@@ -71,6 +71,7 @@ A scanner session is mutable, single-owner state. It is not thread-safe and must
 all scanner use inside its `scan` callback on one execution path.
 
 ```scala
+import kyo.Result
 import morphir.langkit.core.scanner.*
 
 val defaultScan = SourceScanner.scan(source) { scanner =>
@@ -78,17 +79,25 @@ val defaultScan = SourceScanner.scan(source) { scanner =>
   scanner.metrics
 }
 
-val budget = ScanBudget.limited(
+ScanBudget.limited(
   maxInputLength = InputSize.mebibytes(1),
   maxWork = WorkUnits(8L * 1024L * 1024L),
   maxNestingDepth = NestingDepth(128),
   maxOutputNodes = NodeCount(100000L)
-)
-val limitedScan = SourceScanner.scan(source, budget) { scanner =>
-  // Parser work goes here.
-  scanner.metrics
-}
+) match
+  case Result.Success(budget) =>
+    val limitedScan = SourceScanner.scan(source, budget) { scanner =>
+      // Parser work goes here.
+      scanner.metrics
+    }
+  case Result.Failure(error) =>
+    // Report invalid caller-supplied configuration; no scan occurs.
+  case Result.Panic(error) =>
+    // Handle an unexpected panic; no scan occurs.
 ```
+
+Invalid limits return a typed `ScanBudgetError` in `Result.Failure`; they do not throw. Keep caller-supplied
+configuration in this result-handling path rather than unwrapping it.
 
 Cursor movement and lookahead consume work. Use `chargeWork` for deterministic work performed outside cursor
 movement, `withNesting` around recursive descent, and `chargeOutputNodes` immediately before emitting syntax nodes.

--- a/morphir/langkit/core/README.md
+++ b/morphir/langkit/core/README.md
@@ -62,6 +62,52 @@ It returns both the rendered string and the structured `contextLines` behind it,
 own way — a language server, a JSON envelope — does not have to parse the text back apart. Two lines of context
 before and one after by default, both overridable.
 
+## Budgeted source scanning
+
+`SourceScanner` gives parsers a scan-local cursor with deterministic ceilings for input length, work, nesting, and
+emitted nodes. The default entry point uses conservative safe limits, and a caller can supply narrower typed limits:
+
+```scala
+import morphir.langkit.core.scanner.*
+
+val defaultScan = SourceScanner.scan(source) { scanner =>
+  while !scanner.isAtEnd do scanner.advance()
+  scanner.metrics
+}
+
+val budget = ScanBudget.limited(
+  maxInputLength = InputSize.mebibytes(1),
+  maxWork = WorkUnits(8L * 1024L * 1024L),
+  maxNestingDepth = NestingDepth(128),
+  maxOutputNodes = NodeCount(100000L)
+)
+val limitedScan = SourceScanner.scan(source, budget) { scanner =>
+  // Parser work goes here.
+  scanner.metrics
+}
+```
+
+Cursor movement and lookahead consume work. Use `chargeWork` for deterministic work performed outside cursor
+movement, `withNesting` around recursive descent, and `chargeOutputNodes` immediately before emitting syntax nodes.
+`metrics` returns an immutable snapshot of work, output nodes, and maximum nesting depth; like every scanner
+operation, it is available only during the `scan` callback.
+
+Checkpoints restore the cursor but never refund work already consumed by speculation. Source offsets, input lengths,
+and view boundaries count UTF-16 code units, matching Scala `String` indices on every supported platform.
+
+An explicit opt-out exists for callers that independently control both input size and execution isolation:
+
+```scala
+val unsafeScan = SourceScanner.scan(source, ScanBudget.UnsafeUnbounded) { scanner =>
+  // The caller, not SourceScanner, now owns resource containment.
+  scanner.metrics
+}
+```
+
+`UnsafeUnbounded` removes all resource ceilings. Use it only when trusted upstream constraints guarantee bounded
+input and bounded parser behavior, and the execution environment can contain a faulty or unexpectedly expensive
+consumer. Cursor bounds, checkpoint ownership, progress checks, and callback lifetime rules still apply.
+
 ## Severity
 
 How much a finding matters is a property of the options a pipeline runs under, not of the finding itself: the same

--- a/morphir/langkit/core/README.md
+++ b/morphir/langkit/core/README.md
@@ -79,12 +79,14 @@ val defaultScan = SourceScanner.scan(source) { scanner =>
   scanner.metrics
 }
 
-ScanBudget.limited(
-  maxInputLength = InputSize.mebibytes(1),
+val compiledBudget = ScanBudget.limited(
+  maxInputLength = InputSize.megabytes(1),
   maxWork = WorkUnits(8L * 1024L * 1024L),
   maxNestingDepth = NestingDepth(128),
   maxOutputNodes = NodeCount(100000L)
-) match
+)
+
+compiledBudget match
   case Result.Success(budget) =>
     val limitedScan = SourceScanner.scan(source, budget) { scanner =>
       // Parser work goes here.
@@ -96,8 +98,13 @@ ScanBudget.limited(
     // Handle an unexpected panic; no scan occurs.
 ```
 
-Invalid limits return a typed `ScanBudgetError` in `Result.Failure`; they do not throw. Keep caller-supplied
-configuration in this result-handling path rather than unwrapping it.
+Literal measures (`InputSize.codeUnits(16)`, `WorkUnits(8L * 1024L * 1024L)`, and the other compile-time constructors)
+are checked by an inline macro; an invalid constant fails compilation. Dynamic values go through `fromCodeUnits`,
+`fromMegabytes` (and the other `from*` size constructors), and `from`, and return `Result`. Invalid budget ceilings
+still return a typed `ScanBudgetError` in
+`Result.Failure`; they do not throw. Keep caller-supplied configuration in this result-handling path rather than
+unwrapping it. Zero is a valid measure and an invalid ceiling: `InputSize.codeUnits(0)` is a valid size, and
+`ScanBudget.limited` then fails with `NonPositiveInputLength`.
 
 Cursor movement and lookahead consume work. Use `chargeWork` for deterministic work performed outside cursor
 movement, `withNesting` around recursive descent, and `chargeOutputNodes` immediately before emitting syntax nodes.

--- a/morphir/langkit/core/package.mill.yaml
+++ b/morphir/langkit/core/package.mill.yaml
@@ -1,17 +1,20 @@
 extends: Module
 
 object jvm:
-  extends: [build.MorphirJVMModule, build.MorphirPublishModule]
+  extends: [build.MorphirJVMModule, build.MorphirPublishModule, build.MorphirKyoCoreMvnDeps]
+  moduleDeps: [build.morphir.prelude.jvm]
   object test:
     extends: [ScalaTests, millbuild.KyoTest, build.MorphirKyoTestMvnDeps]
 
 object js:
-  extends: [build.MorphirJSModule, build.MorphirPublishModule]
+  extends: [build.MorphirJSModule, build.MorphirPublishModule, build.MorphirKyoCoreMvnDeps]
+  moduleDeps: [build.morphir.prelude.js]
   object test:
     extends: [ScalaJSTests, build.MorphirJSTestNoSourceMap, millbuild.KyoTestJS, build.MorphirKyoTestMvnDeps]
 
 object native:
-  extends: [build.MorphirNativeModule, build.MorphirPublishModule]
+  extends: [build.MorphirNativeModule, build.MorphirPublishModule, build.MorphirKyoCoreMvnDeps]
+  moduleDeps: [build.morphir.prelude.native]
   object test:
     extends: [ScalaNativeTests, millbuild.KyoTestNative, build.MorphirKyoTestMvnDeps]
     mvnDeps: !append

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanBudget.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanBudget.scala
@@ -1,0 +1,38 @@
+package morphir.langkit.core.scanner
+
+sealed trait ScanBudget derives CanEqual
+
+object ScanBudget:
+  sealed abstract case class Limited private[scanner] (
+      maxInputLength: InputSize,
+      maxWork: WorkUnits,
+      maxNestingDepth: NestingDepth,
+      maxOutputNodes: NodeCount
+  ) extends ScanBudget
+      derives CanEqual
+
+  case object UnsafeUnbounded extends ScanBudget
+
+  val default: Limited = limited(
+    maxInputLength = InputSize.mebibytes(16L),
+    maxWork = WorkUnits(256L * 1024L * 1024L),
+    maxNestingDepth = NestingDepth(1024),
+    maxOutputNodes = NodeCount(4L * 1024L * 1024L)
+  )
+
+  def limited(
+      maxInputLength: InputSize,
+      maxWork: WorkUnits,
+      maxNestingDepth: NestingDepth,
+      maxOutputNodes: NodeCount
+  ): Limited =
+    require(maxInputLength.toLong > 0L, "maximum input length must be positive")
+    require(maxWork.toLong > 0L, "maximum work must be positive")
+    require(maxNestingDepth.toInt > 0, "maximum nesting depth must be positive")
+    require(maxOutputNodes.toLong > 0L, "maximum output nodes must be positive")
+    new Limited(
+      maxInputLength = maxInputLength,
+      maxWork = maxWork,
+      maxNestingDepth = maxNestingDepth,
+      maxOutputNodes = maxOutputNodes
+    ) {}

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanBudget.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanBudget.scala
@@ -1,5 +1,7 @@
 package morphir.langkit.core.scanner
 
+import kyo.*
+
 sealed trait ScanBudget derives CanEqual
 
 object ScanBudget:
@@ -18,21 +20,24 @@ object ScanBudget:
     maxWork = WorkUnits(256L * 1024L * 1024L),
     maxNestingDepth = NestingDepth(1024),
     maxOutputNodes = NodeCount(4L * 1024L * 1024L)
-  )
+  ).getOrThrow
 
   def limited(
       maxInputLength: InputSize,
       maxWork: WorkUnits,
       maxNestingDepth: NestingDepth,
       maxOutputNodes: NodeCount
-  ): Limited =
-    require(maxInputLength.toLong > 0L, "maximum input length must be positive")
-    require(maxWork.toLong > 0L, "maximum work must be positive")
-    require(maxNestingDepth.toInt > 0, "maximum nesting depth must be positive")
-    require(maxOutputNodes.toLong > 0L, "maximum output nodes must be positive")
-    new Limited(
-      maxInputLength = maxInputLength,
-      maxWork = maxWork,
-      maxNestingDepth = maxNestingDepth,
-      maxOutputNodes = maxOutputNodes
-    ) {}
+  ): Result[ScanBudgetError, Limited] =
+    if maxInputLength.toLong <= 0L then Result.fail(ScanBudgetError.NonPositiveInputLength(maxInputLength))
+    else if maxWork.toLong <= 0L then Result.fail(ScanBudgetError.NonPositiveWork(maxWork))
+    else if maxNestingDepth.toInt <= 0 then Result.fail(ScanBudgetError.NonPositiveNestingDepth(maxNestingDepth))
+    else if maxOutputNodes.toLong <= 0L then Result.fail(ScanBudgetError.NonPositiveOutputNodes(maxOutputNodes))
+    else
+      Result.succeed(
+        new Limited(
+          maxInputLength = maxInputLength,
+          maxWork = maxWork,
+          maxNestingDepth = maxNestingDepth,
+          maxOutputNodes = maxOutputNodes
+        ) {}
+      )

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanBudget.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanBudget.scala
@@ -15,13 +15,18 @@ object ScanBudget:
 
   case object UnsafeUnbounded extends ScanBudget
 
-  val default: Limited = limited(
-    maxInputLength = InputSize.mebibytes(16L),
-    maxWork = WorkUnits(256L * 1024L * 1024L),
-    maxNestingDepth = NestingDepth(1024),
-    maxOutputNodes = NodeCount(4L * 1024L * 1024L)
-  ).getOrThrow
+  val default: Limited =
+    limited(
+      maxInputLength = InputSize.mebibytes(16L),
+      maxWork = WorkUnits(256L * 1024L * 1024L),
+      maxNestingDepth = NestingDepth(1024),
+      maxOutputNodes = NodeCount(4L * 1024L * 1024L)
+    ).getOrThrow
 
+  /**
+   * Validate caller-supplied ceilings. Dynamic measure factories report invalid representations as the same `Result`
+   * error type; compile-time constructors reject invalid literals before this method runs.
+   */
   def limited(
       maxInputLength: InputSize,
       maxWork: WorkUnits,

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanBudgetError.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanBudgetError.scala
@@ -3,6 +3,16 @@ package morphir.langkit.core.scanner
 import morphir.MorphirException
 
 enum ScanBudgetError(message: String) extends MorphirException(message) derives CanEqual:
+  case NegativeInputSize(value: Long)
+      extends ScanBudgetError(s"input size must be non-negative: $value")
+  case InputSizeOverflow(value: Long, unit: String)
+      extends ScanBudgetError(s"input size overflow: $value $unit")
+  case NegativeWork(value: Long)
+      extends ScanBudgetError(s"work units must be non-negative: $value")
+  case NegativeNestingDepth(value: Int)
+      extends ScanBudgetError(s"nesting depth must be non-negative: $value")
+  case NegativeOutputNodes(value: Long)
+      extends ScanBudgetError(s"node count must be non-negative: $value")
   case NonPositiveInputLength(inputSize: InputSize)
       extends ScanBudgetError(s"maximum input length must be positive: ${inputSize.toLong}")
   case NonPositiveWork(workUnits: WorkUnits)

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanBudgetError.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanBudgetError.scala
@@ -1,0 +1,13 @@
+package morphir.langkit.core.scanner
+
+import morphir.MorphirException
+
+enum ScanBudgetError(message: String) extends MorphirException(message) derives CanEqual:
+  case NonPositiveInputLength(inputSize: InputSize)
+      extends ScanBudgetError(s"maximum input length must be positive: ${inputSize.toLong}")
+  case NonPositiveWork(workUnits: WorkUnits)
+      extends ScanBudgetError(s"maximum work must be positive: ${workUnits.toLong}")
+  case NonPositiveNestingDepth(nestingDepth: NestingDepth)
+      extends ScanBudgetError(s"maximum nesting depth must be positive: ${nestingDepth.toInt}")
+  case NonPositiveOutputNodes(nodeCount: NodeCount)
+      extends ScanBudgetError(s"maximum output nodes must be positive: ${nodeCount.toLong}")

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanFailure.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanFailure.scala
@@ -1,5 +1,7 @@
 package morphir.langkit.core.scanner
 
+import kyo.*
+
 enum ScanLimitExceeded derives CanEqual:
   case InputLength(limit: InputSize, actual: InputSize)
   case Work(limit: WorkUnits, attempted: WorkUnits)
@@ -9,7 +11,7 @@ enum ScanLimitExceeded derives CanEqual:
 final case class ScanFailure(
     exceeded: ScanLimitExceeded,
     offset: SourceOffset,
-    phase: Option[ScanPhase]
+    phase: Maybe[ScanPhase]
 ) derives CanEqual
 
 enum ScanResult[+A] derives CanEqual:

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanFailure.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanFailure.scala
@@ -1,0 +1,22 @@
+package morphir.langkit.core.scanner
+
+enum ScanLimitExceeded derives CanEqual:
+  case InputLength(limit: InputSize, actual: InputSize)
+  case Work(limit: WorkUnits, attempted: WorkUnits)
+  case Nesting(limit: NestingDepth, attempted: NestingDepth)
+  case OutputNodes(limit: NodeCount, attempted: NodeCount)
+
+final case class ScanFailure(
+    exceeded: ScanLimitExceeded,
+    offset: SourceOffset,
+    phase: Option[ScanPhase]
+) derives CanEqual
+
+enum ScanResult[+A] derives CanEqual:
+  case Success(value: A)
+  case Failure(error: ScanFailure)
+
+  def map[B](f: A => B): ScanResult[B] =
+    this match
+      case Success(value) => Success(f(value))
+      case Failure(error) => Failure(error)

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanMeasures.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanMeasures.scala
@@ -5,6 +5,8 @@ opaque type InputSize = Long
 object InputSize:
   private val CodeUnitsPerMebibyte = 1024L * 1024L
 
+  given CanEqual[InputSize, InputSize] = CanEqual.derived
+
   def codeUnits(value: Long): InputSize =
     require(value >= 0L, "input size must be non-negative")
     value
@@ -22,6 +24,8 @@ object InputSize:
 opaque type CodeUnitCount = Int
 
 object CodeUnitCount:
+  given CanEqual[CodeUnitCount, CodeUnitCount] = CanEqual.derived
+
   val one: CodeUnitCount = 1
 
   def apply(value: Int): CodeUnitCount =
@@ -33,6 +37,8 @@ object CodeUnitCount:
 opaque type WorkUnits = Long
 
 object WorkUnits:
+  given CanEqual[WorkUnits, WorkUnits] = CanEqual.derived
+
   def apply(value: Long): WorkUnits =
     require(value >= 0L, "work units must be non-negative")
     value
@@ -44,6 +50,8 @@ object WorkUnits:
 opaque type NestingDepth = Int
 
 object NestingDepth:
+  given CanEqual[NestingDepth, NestingDepth] = CanEqual.derived
+
   def apply(value: Int): NestingDepth =
     require(value >= 0, "nesting depth must be non-negative")
     value
@@ -55,6 +63,8 @@ object NestingDepth:
 opaque type NodeCount = Long
 
 object NodeCount:
+  given CanEqual[NodeCount, NodeCount] = CanEqual.derived
+
   val one: NodeCount = 1L
 
   def apply(value: Long): NodeCount =
@@ -68,6 +78,8 @@ object NodeCount:
 opaque type SourceOffset = Int
 
 object SourceOffset:
+  given CanEqual[SourceOffset, SourceOffset] = CanEqual.derived
+
   val start: SourceOffset = 0
 
   def apply(value: Int): SourceOffset =
@@ -81,6 +93,8 @@ object SourceOffset:
 opaque type ScanPhase = String
 
 object ScanPhase:
+  given CanEqual[ScanPhase, ScanPhase] = CanEqual.derived
+
   def apply(value: String): ScanPhase =
     require(!value.isBlank, "scan phase must be non-empty and non-blank")
     value

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanMeasures.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanMeasures.scala
@@ -1,21 +1,63 @@
 package morphir.langkit.core.scanner
 
+import kyo.*
+import scala.compiletime.{codeOf, error}
+
+/** UTF-16 code-unit size. Byte-named constructors count code units using SI (1000) or IEC (1024) scales. */
 opaque type InputSize = Long
 
 object InputSize:
-  private val CodeUnitsPerMebibyte = 1024L * 1024L
+  private inline val CodeUnitsPerKilobyte = 1000L
+  private inline val CodeUnitsPerKibibyte = 1024L
+  private inline val CodeUnitsPerMegabyte = 1000L * 1000L
+  private inline val CodeUnitsPerMebibyte = 1024L * 1024L
+  private inline val CodeUnitsPerGigabyte = 1000L * 1000L * 1000L
+  private inline val CodeUnitsPerGibibyte = 1024L * 1024L * 1024L
 
   given CanEqual[InputSize, InputSize] = CanEqual.derived
 
-  def codeUnits(value: Long): InputSize =
-    require(value >= 0L, "input size must be non-negative")
-    value
+  /**
+   * Compile-time constructor for a size in UTF-16 code units. The argument must be a constant; a negative literal fails
+   * compilation. Dynamic values use [[fromCodeUnits]].
+   */
+  inline def codeUnits(inline value: Long): InputSize =
+    inline if value < 0L then error("input size must be non-negative: " + codeOf(value))
+    else unsafe(value)
 
-  def mebibytes(value: Long): InputSize =
-    require(value >= 0L, "input size must be non-negative")
-    if value > Long.MaxValue / CodeUnitsPerMebibyte then
-      throw new ArithmeticException("input size overflow")
-    value * CodeUnitsPerMebibyte
+  def fromCodeUnits(value: Long): Result[ScanBudgetError, InputSize] =
+    if value < 0L then Result.fail(ScanBudgetError.NegativeInputSize(value))
+    else Result.succeed(value)
+
+  inline def kilobytes(inline value: Long): InputSize = scaled(value, CodeUnitsPerKilobyte, "kilobytes")
+  inline def kibibytes(inline value: Long): InputSize = scaled(value, CodeUnitsPerKibibyte, "kibibytes")
+  inline def megabytes(inline value: Long): InputSize = scaled(value, CodeUnitsPerMegabyte, "megabytes")
+  inline def mebibytes(inline value: Long): InputSize = scaled(value, CodeUnitsPerMebibyte, "mebibytes")
+  inline def gigabytes(inline value: Long): InputSize = scaled(value, CodeUnitsPerGigabyte, "gigabytes")
+  inline def gibibytes(inline value: Long): InputSize = scaled(value, CodeUnitsPerGibibyte, "gibibytes")
+
+  def fromKilobytes(value: Long): Result[ScanBudgetError, InputSize] =
+    fromScaled(value, CodeUnitsPerKilobyte, "kilobytes")
+  def fromKibibytes(value: Long): Result[ScanBudgetError, InputSize] =
+    fromScaled(value, CodeUnitsPerKibibyte, "kibibytes")
+  def fromMegabytes(value: Long): Result[ScanBudgetError, InputSize] =
+    fromScaled(value, CodeUnitsPerMegabyte, "megabytes")
+  def fromMebibytes(value: Long): Result[ScanBudgetError, InputSize] =
+    fromScaled(value, CodeUnitsPerMebibyte, "mebibytes")
+  def fromGigabytes(value: Long): Result[ScanBudgetError, InputSize] =
+    fromScaled(value, CodeUnitsPerGigabyte, "gigabytes")
+  def fromGibibytes(value: Long): Result[ScanBudgetError, InputSize] =
+    fromScaled(value, CodeUnitsPerGibibyte, "gibibytes")
+
+  private inline def scaled(inline value: Long, inline unitsPer: Long, inline unit: String): InputSize =
+    inline if value < 0L then error("input size must be non-negative: " + codeOf(value))
+    else inline if value > Long.MaxValue / unitsPer then
+      error("input size overflow: " + codeOf(value) + " " + unit)
+    else unsafe(value * unitsPer)
+
+  private def fromScaled(value: Long, unitsPer: Long, unit: String): Result[ScanBudgetError, InputSize] =
+    if value < 0L then Result.fail(ScanBudgetError.NegativeInputSize(value))
+    else if value > Long.MaxValue / unitsPer then Result.fail(ScanBudgetError.InputSizeOverflow(value, unit))
+    else Result.succeed(value * unitsPer)
 
   private[scanner] def unsafe(value: Long): InputSize = value
 
@@ -39,9 +81,17 @@ opaque type WorkUnits = Long
 object WorkUnits:
   given CanEqual[WorkUnits, WorkUnits] = CanEqual.derived
 
-  def apply(value: Long): WorkUnits =
-    require(value >= 0L, "work units must be non-negative")
-    value
+  /**
+   * Compile-time constructor. The argument must be a constant; a negative literal fails compilation. Dynamic values use
+   * [[from]].
+   */
+  inline def apply(inline value: Long): WorkUnits =
+    inline if value < 0L then error("work units must be non-negative: " + codeOf(value))
+    else unsafe(value)
+
+  def from(value: Long): Result[ScanBudgetError, WorkUnits] =
+    if value < 0L then Result.fail(ScanBudgetError.NegativeWork(value))
+    else Result.succeed(value)
 
   private[scanner] def unsafe(value: Long): WorkUnits = value
 
@@ -52,9 +102,17 @@ opaque type NestingDepth = Int
 object NestingDepth:
   given CanEqual[NestingDepth, NestingDepth] = CanEqual.derived
 
-  def apply(value: Int): NestingDepth =
-    require(value >= 0, "nesting depth must be non-negative")
-    value
+  /**
+   * Compile-time constructor. The argument must be a constant; a negative literal fails compilation. Dynamic values use
+   * [[from]].
+   */
+  inline def apply(inline value: Int): NestingDepth =
+    inline if value < 0 then error("nesting depth must be non-negative: " + codeOf(value))
+    else unsafe(value)
+
+  def from(value: Int): Result[ScanBudgetError, NestingDepth] =
+    if value < 0 then Result.fail(ScanBudgetError.NegativeNestingDepth(value))
+    else Result.succeed(value)
 
   private[scanner] def unsafe(value: Int): NestingDepth = value
 
@@ -65,11 +123,19 @@ opaque type NodeCount = Long
 object NodeCount:
   given CanEqual[NodeCount, NodeCount] = CanEqual.derived
 
-  val one: NodeCount = 1L
+  val one: NodeCount = apply(1L)
 
-  def apply(value: Long): NodeCount =
-    require(value >= 0L, "node count must be non-negative")
-    value
+  /**
+   * Compile-time constructor. The argument must be a constant; a negative literal fails compilation. Dynamic values use
+   * [[from]].
+   */
+  inline def apply(inline value: Long): NodeCount =
+    inline if value < 0L then error("node count must be non-negative: " + codeOf(value))
+    else unsafe(value)
+
+  def from(value: Long): Result[ScanBudgetError, NodeCount] =
+    if value < 0L then Result.fail(ScanBudgetError.NegativeOutputNodes(value))
+    else Result.succeed(value)
 
   private[scanner] def unsafe(value: Long): NodeCount = value
 

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanMeasures.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanMeasures.scala
@@ -1,0 +1,88 @@
+package morphir.langkit.core.scanner
+
+opaque type InputSize = Long
+
+object InputSize:
+  private val CodeUnitsPerMebibyte = 1024L * 1024L
+
+  def codeUnits(value: Long): InputSize =
+    require(value >= 0L, "input size must be non-negative")
+    value
+
+  def mebibytes(value: Long): InputSize =
+    require(value >= 0L, "input size must be non-negative")
+    if value > Long.MaxValue / CodeUnitsPerMebibyte then
+      throw new ArithmeticException("input size overflow")
+    value * CodeUnitsPerMebibyte
+
+  private[scanner] def unsafe(value: Long): InputSize = value
+
+  extension (size: InputSize) def toLong: Long = size
+
+opaque type CodeUnitCount = Int
+
+object CodeUnitCount:
+  val one: CodeUnitCount = 1
+
+  def apply(value: Int): CodeUnitCount =
+    require(value >= 0, "code-unit count must be non-negative")
+    value
+
+  extension (count: CodeUnitCount) def toInt: Int = count
+
+opaque type WorkUnits = Long
+
+object WorkUnits:
+  def apply(value: Long): WorkUnits =
+    require(value >= 0L, "work units must be non-negative")
+    value
+
+  private[scanner] def unsafe(value: Long): WorkUnits = value
+
+  extension (units: WorkUnits) def toLong: Long = units
+
+opaque type NestingDepth = Int
+
+object NestingDepth:
+  def apply(value: Int): NestingDepth =
+    require(value >= 0, "nesting depth must be non-negative")
+    value
+
+  private[scanner] def unsafe(value: Int): NestingDepth = value
+
+  extension (depth: NestingDepth) def toInt: Int = depth
+
+opaque type NodeCount = Long
+
+object NodeCount:
+  val one: NodeCount = 1L
+
+  def apply(value: Long): NodeCount =
+    require(value >= 0L, "node count must be non-negative")
+    value
+
+  private[scanner] def unsafe(value: Long): NodeCount = value
+
+  extension (count: NodeCount) def toLong: Long = count
+
+opaque type SourceOffset = Int
+
+object SourceOffset:
+  val start: SourceOffset = 0
+
+  def apply(value: Int): SourceOffset =
+    require(value >= 0, "source offset must be non-negative")
+    value
+
+  private[scanner] def unsafe(value: Int): SourceOffset = value
+
+  extension (offset: SourceOffset) def toInt: Int = offset
+
+opaque type ScanPhase = String
+
+object ScanPhase:
+  def apply(value: String): ScanPhase =
+    require(!value.isBlank, "scan phase must be non-empty and non-blank")
+    value
+
+  extension (phase: ScanPhase) def value: String = phase

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanMetrics.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/ScanMetrics.scala
@@ -1,0 +1,8 @@
+package morphir.langkit.core.scanner
+
+/** An immutable snapshot of deterministic scanner resource consumption. */
+final case class ScanMetrics(
+    work: WorkUnits,
+    outputNodes: NodeCount,
+    maximumNestingDepth: NestingDepth
+) derives CanEqual

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceScanner.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceScanner.scala
@@ -1,0 +1,125 @@
+package morphir.langkit.core.scanner
+
+import morphir.langkit.core.Span
+import scala.util.control.ControlThrowable
+
+object SourceScanner:
+  def scan[A](
+      source: String,
+      budget: ScanBudget = ScanBudget.default,
+      phase: Option[ScanPhase] = None
+  )(use: SourceScanner => A): ScanResult[A] =
+    budget match
+      case limited: ScanBudget.Limited if source.length.toLong > limited.maxInputLength.toLong =>
+        ScanResult.Failure(
+          ScanFailure(
+            exceeded = ScanLimitExceeded.InputLength(
+              limit = limited.maxInputLength,
+              actual = InputSize.unsafe(source.length.toLong)
+            ),
+            offset = SourceOffset.start,
+            phase = phase
+          )
+        )
+      case _ =>
+        val scanner = budget match
+          case limited: ScanBudget.Limited =>
+            new SourceScanner(source, isWorkLimited = true, limited.maxWork.toLong, phase)
+          case ScanBudget.UnsafeUnbounded =>
+            new SourceScanner(source, isWorkLimited = false, Long.MaxValue, phase)
+
+        try
+          try ScanResult.Success(use(scanner))
+          catch case exhausted: WorkBudgetExhausted => ScanResult.Failure(exhausted.failure)
+        finally scanner.close()
+
+  private[scanner] def saturatingAdd(current: Long, increment: Long): Long =
+    if increment >= Long.MaxValue - current then Long.MaxValue
+    else current + increment
+
+  private final class WorkBudgetExhausted(val failure: ScanFailure) extends ControlThrowable
+
+final class SourceScanner private[scanner] (
+    originalSource: String,
+    isWorkLimited: Boolean,
+    maxWork: Long,
+    phase: Option[ScanPhase]
+):
+  import SourceScanner.WorkBudgetExhausted
+
+  private var currentOffset = 0
+  private var consumedWork  = 0L
+  private var active        = true
+
+  def source: String =
+    requireActive()
+    originalSource
+
+  def offset: SourceOffset =
+    requireActive()
+    SourceOffset.unsafe(currentOffset)
+
+  def isAtEnd: Boolean =
+    requireActive()
+    currentOffset == originalSource.length
+
+  def mark: SourceOffset =
+    requireActive()
+    SourceOffset.unsafe(currentOffset)
+
+  def peek(): Option[Char] = peek(CodeUnitCount(0))
+
+  def peek(distance: CodeUnitCount): Option[Char] =
+    requireActive()
+    val target = currentOffset.toLong + distance.toInt.toLong
+    if target >= originalSource.length.toLong then None
+    else
+      charge(1L)
+      Some(originalSource.charAt(target.toInt))
+
+  def advance(): Unit = advance(CodeUnitCount.one)
+
+  def advance(count: CodeUnitCount): Unit =
+    requireActive()
+    val target = currentOffset.toLong + count.toInt.toLong
+    if target > originalSource.length.toLong then
+      throw new IndexOutOfBoundsException(
+        s"cannot advance ${count.toInt} code units from offset $currentOffset in source of length ${originalSource.length}"
+      )
+    if count.toInt != 0 then
+      charge(count.toInt.toLong)
+      currentOffset = target.toInt
+
+  def viewFrom(start: SourceOffset): SourceView =
+    requireActive()
+    val startOffset = start.toInt
+    require(startOffset <= currentOffset, s"view start $startOffset must not exceed current offset $currentOffset")
+    SourceView.fromSpan(originalSource, Span(startOffset, currentOffset - startOffset))
+
+  def view(span: Span): SourceView =
+    requireActive()
+    SourceView.fromSpan(originalSource, span)
+
+  def remaining: SourceView =
+    requireActive()
+    SourceView.fromSpan(originalSource, Span(currentOffset, originalSource.length - currentOffset))
+
+  private def charge(increment: Long): Unit =
+    val attempted = SourceScanner.saturatingAdd(consumedWork, increment)
+    consumedWork = attempted
+    if isWorkLimited && attempted > maxWork then
+      throw new WorkBudgetExhausted(
+        ScanFailure(
+          exceeded = ScanLimitExceeded.Work(
+            limit = WorkUnits.unsafe(maxWork),
+            attempted = WorkUnits.unsafe(attempted)
+          ),
+          offset = SourceOffset.unsafe(currentOffset),
+          phase = phase
+        )
+      )
+
+  private def requireActive(): Unit =
+    if !active then throw new IllegalStateException("scanner session is closed")
+
+  private def close(): Unit = active = false

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceScanner.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceScanner.scala
@@ -1,5 +1,6 @@
 package morphir.langkit.core.scanner
 
+import kyo.*
 import morphir.langkit.core.Span
 import scala.util.control.ControlThrowable
 
@@ -12,7 +13,7 @@ object SourceScanner:
   def scan[A](
       source: String,
       budget: ScanBudget = ScanBudget.default,
-      phase: Option[ScanPhase] = None
+      phase: Maybe[ScanPhase] = Absent
   )(use: SourceScanner => A): ScanResult[A] =
     budget match
       case limited: ScanBudget.Limited if source.length.toLong > limited.maxInputLength.toLong =>
@@ -72,7 +73,7 @@ type ScanCheckpoint = SourceScanner.Checkpoint
 final class SourceScanner private[scanner] (
     originalSource: String,
     ceilings: SourceScanner.BudgetCeilings | Null,
-    phase: Option[ScanPhase]
+    phase: Maybe[ScanPhase]
 ):
   import SourceScanner.BudgetExhausted
 
@@ -162,15 +163,15 @@ final class SourceScanner private[scanner] (
         )
       outputNodes = attempted
 
-  def peek(): Option[Char] = peek(CodeUnitCount(0))
+  def peek(): Maybe[Char] = peek(CodeUnitCount(0))
 
-  def peek(distance: CodeUnitCount): Option[Char] =
+  def peek(distance: CodeUnitCount): Maybe[Char] =
     requireActive()
     val target = currentOffset.toLong + distance.toInt.toLong
-    if target >= originalSource.length.toLong then None
+    if target >= originalSource.length.toLong then Absent
     else
       charge(1L)
-      Some(originalSource.charAt(target.toInt))
+      Present(originalSource.charAt(target.toInt))
 
   def advance(): Unit = advance(CodeUnitCount.one)
 

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceScanner.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceScanner.scala
@@ -22,11 +22,16 @@ object SourceScanner:
           )
         )
       case _ =>
-        val scanner = budget match
+        val ceilings = budget match
           case limited: ScanBudget.Limited =>
-            new SourceScanner(source, isWorkLimited = true, limited.maxWork.toLong, phase)
+            new BudgetCeilings(
+              maxWork = limited.maxWork,
+              maxNestingDepth = limited.maxNestingDepth,
+              maxOutputNodes = limited.maxOutputNodes
+            )
           case ScanBudget.UnsafeUnbounded =>
-            new SourceScanner(source, isWorkLimited = false, Long.MaxValue, phase)
+            null
+        val scanner = new SourceScanner(source, ceilings, phase)
 
         try
           try
@@ -35,7 +40,7 @@ object SourceScanner:
               case null      => ScanResult.Success(value)
               case exhausted => ScanResult.Failure(exhausted.failure)
           catch
-            case exhausted: WorkBudgetExhausted if exhausted.owner.eq(scanner) =>
+            case exhausted: BudgetExhausted if exhausted.owner.eq(scanner) =>
               ScanResult.Failure(exhausted.failure)
         finally scanner.close()
 
@@ -43,20 +48,38 @@ object SourceScanner:
     if increment >= Long.MaxValue - current then Long.MaxValue
     else current + increment
 
-  private final class WorkBudgetExhausted(val owner: SourceScanner, val failure: ScanFailure) extends ControlThrowable
+  private[scanner] final class BudgetCeilings(
+      val maxWork: WorkUnits,
+      val maxNestingDepth: NestingDepth,
+      val maxOutputNodes: NodeCount
+  )
+
+  private final class BudgetExhausted(val owner: SourceScanner, val failure: ScanFailure) extends ControlThrowable
+
+final class ScanCheckpoint private (private val owner: SourceScanner, private val savedOffset: Int)
+
+object ScanCheckpoint:
+  private[scanner] def create(owner: SourceScanner, offset: Int): ScanCheckpoint =
+    new ScanCheckpoint(owner, offset)
+
+  private[scanner] def belongsTo(checkpoint: ScanCheckpoint, scanner: SourceScanner): Boolean =
+    checkpoint.owner.eq(scanner)
+
+  private[scanner] def offset(checkpoint: ScanCheckpoint): Int = checkpoint.savedOffset
 
 final class SourceScanner private[scanner] (
     originalSource: String,
-    isWorkLimited: Boolean,
-    maxWork: Long,
+    ceilings: SourceScanner.BudgetCeilings | Null,
     phase: Option[ScanPhase]
 ):
-  import SourceScanner.WorkBudgetExhausted
+  import SourceScanner.BudgetExhausted
 
-  private var currentOffset                          = 0
-  private var consumedWork                           = 0L
-  private var active                                 = true
-  private var exhaustion: WorkBudgetExhausted | Null = null
+  private var currentOffset                      = 0
+  private var consumedWork                       = 0L
+  private var currentNestingDepth                = 0
+  private var outputNodes                        = 0L
+  private var active                             = true
+  private var exhaustion: BudgetExhausted | Null = null
 
   def source: String =
     requireActive()
@@ -73,6 +96,50 @@ final class SourceScanner private[scanner] (
   def mark: SourceOffset =
     requireActive()
     SourceOffset.unsafe(currentOffset)
+
+  def checkpoint(): ScanCheckpoint =
+    requireActive()
+    ScanCheckpoint.create(this, currentOffset)
+
+  def restore(checkpoint: ScanCheckpoint): Unit =
+    requireActive()
+    require(ScanCheckpoint.belongsTo(checkpoint, this), "checkpoint belongs to another scanner session")
+    currentOffset = ScanCheckpoint.offset(checkpoint)
+
+  def requireProgress[A](phase: ScanPhase)(operation: => A): A =
+    requireActive()
+    val start = currentOffset
+    val value = operation
+    requireActive()
+    if currentOffset == start then throw new IllegalStateException(s"${phase.value} made no progress")
+    value
+
+  def withNesting[A](operation: => A): A =
+    requireActive()
+    val attempted = if currentNestingDepth == Int.MaxValue then Int.MaxValue else currentNestingDepth + 1
+    if ceilings != null && attempted > ceilings.maxNestingDepth.toInt then
+      failBudget(
+        ScanLimitExceeded.Nesting(
+          limit = ceilings.maxNestingDepth,
+          attempted = NestingDepth.unsafe(attempted)
+        )
+      )
+    currentNestingDepth = attempted
+    try operation
+    finally currentNestingDepth -= 1
+
+  def chargeOutputNodes(count: NodeCount): Unit =
+    requireActive()
+    if count.toLong != 0L then
+      val attempted = SourceScanner.saturatingAdd(outputNodes, count.toLong)
+      if ceilings != null && attempted > ceilings.maxOutputNodes.toLong then
+        failBudget(
+          ScanLimitExceeded.OutputNodes(
+            limit = ceilings.maxOutputNodes,
+            attempted = NodeCount.unsafe(attempted)
+          )
+        )
+      outputNodes = attempted
 
   def peek(): Option[Char] = peek(CodeUnitCount(0))
 
@@ -113,21 +180,26 @@ final class SourceScanner private[scanner] (
 
   private def charge(increment: Long): Unit =
     val attempted = SourceScanner.saturatingAdd(consumedWork, increment)
-    if isWorkLimited && attempted > maxWork then
-      val exhausted = new WorkBudgetExhausted(
-        owner = this,
-        failure = ScanFailure(
-          exceeded = ScanLimitExceeded.Work(
-            limit = WorkUnits.unsafe(maxWork),
-            attempted = WorkUnits.unsafe(attempted)
-          ),
-          offset = SourceOffset.unsafe(currentOffset),
-          phase = phase
+    if ceilings != null && attempted > ceilings.maxWork.toLong then
+      failBudget(
+        ScanLimitExceeded.Work(
+          limit = ceilings.maxWork,
+          attempted = WorkUnits.unsafe(attempted)
         )
       )
-      exhaustion = exhausted
-      throw exhausted
     consumedWork = attempted
+
+  private def failBudget(exceeded: ScanLimitExceeded): Nothing =
+    val exhausted = new BudgetExhausted(
+      owner = this,
+      failure = ScanFailure(
+        exceeded = exceeded,
+        offset = SourceOffset.unsafe(currentOffset),
+        phase = phase
+      )
+    )
+    exhaustion = exhausted
+    throw exhausted
 
   private def requireActive(): Unit =
     if !active then throw new IllegalStateException("scanner session is closed")

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceScanner.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceScanner.scala
@@ -56,6 +56,9 @@ object SourceScanner:
   private[scanner] def wouldExceedLimit(current: Long, increment: Long, limit: Long): Boolean =
     current > limit || increment > limit - current
 
+  private[scanner] def wouldExceedNesting(current: Long, limit: Int): Boolean =
+    current >= limit.toLong
+
   private[scanner] final class BudgetCeilings(
       val maxWork: WorkUnits,
       val maxNestingDepth: NestingDepth,
@@ -75,7 +78,7 @@ final class SourceScanner private[scanner] (
 
   private var currentOffset                      = 0
   private var consumedWork                       = 0L
-  private var currentNestingDepth                = 0
+  private var currentNestingDepth                = 0L
   private var outputNodes                        = 0L
   private var active                             = true
   private var exhaustion: BudgetExhausted | Null = null
@@ -110,22 +113,24 @@ final class SourceScanner private[scanner] (
     val start = currentOffset
     val value = operation
     requireActive()
-    if currentOffset == start then throw new IllegalStateException(s"${phase.value} made no progress")
+    if currentOffset <= start then throw new IllegalStateException(s"${phase.value} made no progress")
     value
 
   def withNesting[A](operation: => A): A =
     requireActive()
-    val attempted = if currentNestingDepth == Int.MaxValue then Int.MaxValue else currentNestingDepth + 1
-    if ceilings != null && attempted > ceilings.maxNestingDepth.toInt then
+    if ceilings != null && SourceScanner.wouldExceedNesting(currentNestingDepth, ceilings.maxNestingDepth.toInt) then
+      val attempted =
+        if currentNestingDepth >= Int.MaxValue.toLong then Int.MaxValue
+        else (currentNestingDepth + 1L).toInt
       failBudget(
         ScanLimitExceeded.Nesting(
           limit = ceilings.maxNestingDepth,
           attempted = NestingDepth.unsafe(attempted)
         )
       )
-    currentNestingDepth = attempted
+    currentNestingDepth += 1L
     try operation
-    finally currentNestingDepth -= 1
+    finally currentNestingDepth -= 1L
 
   def chargeOutputNodes(count: NodeCount): Unit =
     requireActive()

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceScanner.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceScanner.scala
@@ -79,6 +79,7 @@ final class SourceScanner private[scanner] (
   private var currentOffset                      = 0
   private var consumedWork                       = 0L
   private var currentNestingDepth                = 0L
+  private var maximumNestingDepth                = 0
   private var outputNodes                        = 0L
   private var active                             = true
   private var exhaustion: BudgetExhausted | Null = null
@@ -98,6 +99,14 @@ final class SourceScanner private[scanner] (
   def mark: SourceOffset =
     requireActive()
     SourceOffset.unsafe(currentOffset)
+
+  def metrics: ScanMetrics =
+    requireActive()
+    ScanMetrics(
+      work = WorkUnits.unsafe(consumedWork),
+      outputNodes = NodeCount.unsafe(outputNodes),
+      maximumNestingDepth = NestingDepth.unsafe(maximumNestingDepth)
+    )
 
   def checkpoint(): ScanCheckpoint =
     requireActive()
@@ -129,6 +138,8 @@ final class SourceScanner private[scanner] (
         )
       )
     currentNestingDepth += 1L
+    if currentNestingDepth > maximumNestingDepth.toLong then
+      maximumNestingDepth = math.min(currentNestingDepth, Int.MaxValue.toLong).toInt
     try operation
     finally currentNestingDepth -= 1L
 

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceScanner.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceScanner.scala
@@ -4,6 +4,11 @@ import morphir.langkit.core.Span
 import scala.util.control.ControlThrowable
 
 object SourceScanner:
+  final class Checkpoint private[SourceScanner] (
+      private[SourceScanner] val owner: SourceScanner,
+      private[SourceScanner] val savedOffset: Int
+  )
+
   def scan[A](
       source: String,
       budget: ScanBudget = ScanBudget.default,
@@ -48,6 +53,9 @@ object SourceScanner:
     if increment >= Long.MaxValue - current then Long.MaxValue
     else current + increment
 
+  private[scanner] def wouldExceedLimit(current: Long, increment: Long, limit: Long): Boolean =
+    current > limit || increment > limit - current
+
   private[scanner] final class BudgetCeilings(
       val maxWork: WorkUnits,
       val maxNestingDepth: NestingDepth,
@@ -56,16 +64,7 @@ object SourceScanner:
 
   private final class BudgetExhausted(val owner: SourceScanner, val failure: ScanFailure) extends ControlThrowable
 
-final class ScanCheckpoint private (private val owner: SourceScanner, private val savedOffset: Int)
-
-object ScanCheckpoint:
-  private[scanner] def create(owner: SourceScanner, offset: Int): ScanCheckpoint =
-    new ScanCheckpoint(owner, offset)
-
-  private[scanner] def belongsTo(checkpoint: ScanCheckpoint, scanner: SourceScanner): Boolean =
-    checkpoint.owner.eq(scanner)
-
-  private[scanner] def offset(checkpoint: ScanCheckpoint): Int = checkpoint.savedOffset
+type ScanCheckpoint = SourceScanner.Checkpoint
 
 final class SourceScanner private[scanner] (
     originalSource: String,
@@ -99,12 +98,12 @@ final class SourceScanner private[scanner] (
 
   def checkpoint(): ScanCheckpoint =
     requireActive()
-    ScanCheckpoint.create(this, currentOffset)
+    new SourceScanner.Checkpoint(this, currentOffset)
 
   def restore(checkpoint: ScanCheckpoint): Unit =
     requireActive()
-    require(ScanCheckpoint.belongsTo(checkpoint, this), "checkpoint belongs to another scanner session")
-    currentOffset = ScanCheckpoint.offset(checkpoint)
+    require(checkpoint.owner.eq(this), "checkpoint belongs to another scanner session")
+    currentOffset = checkpoint.savedOffset
 
   def requireProgress[A](phase: ScanPhase)(operation: => A): A =
     requireActive()
@@ -132,7 +131,8 @@ final class SourceScanner private[scanner] (
     requireActive()
     if count.toLong != 0L then
       val attempted = SourceScanner.saturatingAdd(outputNodes, count.toLong)
-      if ceilings != null && attempted > ceilings.maxOutputNodes.toLong then
+      if ceilings != null && SourceScanner.wouldExceedLimit(outputNodes, count.toLong, ceilings.maxOutputNodes.toLong)
+      then
         failBudget(
           ScanLimitExceeded.OutputNodes(
             limit = ceilings.maxOutputNodes,
@@ -180,7 +180,7 @@ final class SourceScanner private[scanner] (
 
   private def charge(increment: Long): Unit =
     val attempted = SourceScanner.saturatingAdd(consumedWork, increment)
-    if ceilings != null && attempted > ceilings.maxWork.toLong then
+    if ceilings != null && SourceScanner.wouldExceedLimit(consumedWork, increment, ceilings.maxWork.toLong) then
       failBudget(
         ScanLimitExceeded.Work(
           limit = ceilings.maxWork,

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceScanner.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceScanner.scala
@@ -132,6 +132,11 @@ final class SourceScanner private[scanner] (
     try operation
     finally currentNestingDepth -= 1L
 
+  /** Charge deterministic work performed outside cursor movement, such as a bounded pass over an acquired view. */
+  def chargeWork(units: WorkUnits): Unit =
+    requireActive()
+    if units.toLong != 0L then charge(units.toLong)
+
   def chargeOutputNodes(count: NodeCount): Unit =
     requireActive()
     if count.toLong != 0L then

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceScanner.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceScanner.scala
@@ -29,15 +29,21 @@ object SourceScanner:
             new SourceScanner(source, isWorkLimited = false, Long.MaxValue, phase)
 
         try
-          try ScanResult.Success(use(scanner))
-          catch case exhausted: WorkBudgetExhausted => ScanResult.Failure(exhausted.failure)
+          try
+            val value = use(scanner)
+            scanner.exhaustion match
+              case null      => ScanResult.Success(value)
+              case exhausted => ScanResult.Failure(exhausted.failure)
+          catch
+            case exhausted: WorkBudgetExhausted if exhausted.owner.eq(scanner) =>
+              ScanResult.Failure(exhausted.failure)
         finally scanner.close()
 
   private[scanner] def saturatingAdd(current: Long, increment: Long): Long =
     if increment >= Long.MaxValue - current then Long.MaxValue
     else current + increment
 
-  private final class WorkBudgetExhausted(val failure: ScanFailure) extends ControlThrowable
+  private final class WorkBudgetExhausted(val owner: SourceScanner, val failure: ScanFailure) extends ControlThrowable
 
 final class SourceScanner private[scanner] (
     originalSource: String,
@@ -47,9 +53,10 @@ final class SourceScanner private[scanner] (
 ):
   import SourceScanner.WorkBudgetExhausted
 
-  private var currentOffset = 0
-  private var consumedWork  = 0L
-  private var active        = true
+  private var currentOffset                          = 0
+  private var consumedWork                           = 0L
+  private var active                                 = true
+  private var exhaustion: WorkBudgetExhausted | Null = null
 
   def source: String =
     requireActive()
@@ -106,10 +113,10 @@ final class SourceScanner private[scanner] (
 
   private def charge(increment: Long): Unit =
     val attempted = SourceScanner.saturatingAdd(consumedWork, increment)
-    consumedWork = attempted
     if isWorkLimited && attempted > maxWork then
-      throw new WorkBudgetExhausted(
-        ScanFailure(
+      val exhausted = new WorkBudgetExhausted(
+        owner = this,
+        failure = ScanFailure(
           exceeded = ScanLimitExceeded.Work(
             limit = WorkUnits.unsafe(maxWork),
             attempted = WorkUnits.unsafe(attempted)
@@ -118,8 +125,12 @@ final class SourceScanner private[scanner] (
           phase = phase
         )
       )
+      exhaustion = exhausted
+      throw exhausted
+    consumedWork = attempted
 
   private def requireActive(): Unit =
     if !active then throw new IllegalStateException("scanner session is closed")
+    if exhaustion != null then throw exhaustion
 
   private def close(): Unit = active = false

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceView.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceView.scala
@@ -1,0 +1,32 @@
+package morphir.langkit.core.scanner
+
+import morphir.langkit.core.Span
+
+sealed abstract case class SourceView private (source: String, span: Span) derives CanEqual:
+  def start: SourceOffset = SourceOffset(span.offset)
+
+  def end: SourceOffset = SourceOffset(span.end)
+
+  def length: CodeUnitCount = CodeUnitCount(span.length)
+
+  def isEmpty: Boolean = span.length == 0
+
+  def nonEmpty: Boolean = !isEmpty
+
+  def charAt(relativeOffset: CodeUnitCount): Char =
+    val relativeIndex = relativeOffset.toInt
+    if relativeIndex >= span.length then
+      throw new IndexOutOfBoundsException(s"relative offset $relativeIndex outside view of length ${span.length}")
+    source.charAt(span.offset + relativeIndex)
+
+  def text: String = source.substring(span.offset, span.end)
+
+object SourceView:
+  def fromSpan(source: String, span: Span): SourceView =
+    require(span.offset >= 0, "span offset must be non-negative")
+    require(span.length >= 0, "span length must be non-negative")
+    require(
+      span.offset.toLong + span.length.toLong <= source.length.toLong,
+      "span end must not exceed source length"
+    )
+    new SourceView(source, span) {}

--- a/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceView.scala
+++ b/morphir/langkit/core/src/morphir/langkit/core/scanner/SourceView.scala
@@ -3,8 +3,10 @@ package morphir.langkit.core.scanner
 import morphir.langkit.core.Span
 
 sealed abstract case class SourceView private (source: String, span: Span) derives CanEqual:
+  /** Inclusive start of this half-open source range, measured in UTF-16 code units. */
   def start: SourceOffset = SourceOffset(span.offset)
 
+  /** Exclusive end of this half-open source range, measured in UTF-16 code units. */
   def end: SourceOffset = SourceOffset(span.end)
 
   def length: CodeUnitCount = CodeUnitCount(span.length)

--- a/morphir/langkit/core/test/src/morphir/langkit/core/scanner/ScanBudgetTests.scala
+++ b/morphir/langkit/core/test/src/morphir/langkit/core/scanner/ScanBudgetTests.scala
@@ -11,15 +11,12 @@ class ScanBudgetTests extends Test[Any]:
     try
       thunk
       false
-    catch case _: IllegalArgumentException | _: ArithmeticException => true
+    catch case _: IllegalArgumentException => true
 
-  private def throwsArithmetic(thunk: => Any): Boolean =
-    try
-      thunk
-      false
-    catch
-      case _: ArithmeticException => true
-      case _: Throwable           => false
+  private def input(value: Long): InputSize     = InputSize.fromCodeUnits(value).getOrThrow
+  private def work(value: Long): WorkUnits      = WorkUnits.from(value).getOrThrow
+  private def nesting(value: Int): NestingDepth = NestingDepth.from(value).getOrThrow
+  private def nodes(value: Long): NodeCount     = NodeCount.from(value).getOrThrow
 
   "ScanBudget" - {
     "has positive typed defaults" in {
@@ -36,65 +33,65 @@ class ScanBudgetTests extends Test[Any]:
     "returns an input-length failure rather than throwing for a zero input limit" in
       assert(
         ScanBudget.limited(
-          maxInputLength = InputSize.codeUnits(0L),
-          maxWork = WorkUnits(1L),
-          maxNestingDepth = NestingDepth(1),
+          maxInputLength = input(0L),
+          maxWork = work(1L),
+          maxNestingDepth = nesting(1),
           maxOutputNodes = NodeCount.one
-        ) == Result.fail(ScanBudgetError.NonPositiveInputLength(InputSize.codeUnits(0L)))
+        ) == Result.fail(ScanBudgetError.NonPositiveInputLength(input(0L)))
       )
 
     "returns a work failure rather than throwing for a zero work limit" in
       assert(
         ScanBudget.limited(
-          maxInputLength = InputSize.codeUnits(1L),
-          maxWork = WorkUnits(0L),
-          maxNestingDepth = NestingDepth(1),
+          maxInputLength = input(1L),
+          maxWork = work(0L),
+          maxNestingDepth = nesting(1),
           maxOutputNodes = NodeCount.one
-        ) == Result.fail(ScanBudgetError.NonPositiveWork(WorkUnits(0L)))
+        ) == Result.fail(ScanBudgetError.NonPositiveWork(work(0L)))
       )
 
     "returns a nesting-depth failure rather than throwing for a zero nesting limit" in
       assert(
         ScanBudget.limited(
-          maxInputLength = InputSize.codeUnits(1L),
-          maxWork = WorkUnits(1L),
-          maxNestingDepth = NestingDepth(0),
+          maxInputLength = input(1L),
+          maxWork = work(1L),
+          maxNestingDepth = nesting(0),
           maxOutputNodes = NodeCount.one
-        ) == Result.fail(ScanBudgetError.NonPositiveNestingDepth(NestingDepth(0)))
+        ) == Result.fail(ScanBudgetError.NonPositiveNestingDepth(nesting(0)))
       )
 
     "returns an output-node failure rather than throwing for a zero output-node limit" in
       assert(
         ScanBudget.limited(
-          maxInputLength = InputSize.codeUnits(1L),
-          maxWork = WorkUnits(1L),
-          maxNestingDepth = NestingDepth(1),
-          maxOutputNodes = NodeCount(0L)
-        ) == Result.fail(ScanBudgetError.NonPositiveOutputNodes(NodeCount(0L)))
+          maxInputLength = input(1L),
+          maxWork = work(1L),
+          maxNestingDepth = nesting(1),
+          maxOutputNodes = nodes(0L)
+        ) == Result.fail(ScanBudgetError.NonPositiveOutputNodes(nodes(0L)))
       )
 
     "returns the first validation failure in constructor-parameter order" in
       assert(
         ScanBudget.limited(
-          maxInputLength = InputSize.codeUnits(0L),
-          maxWork = WorkUnits(0L),
-          maxNestingDepth = NestingDepth(0),
-          maxOutputNodes = NodeCount(0L)
-        ) == Result.fail(ScanBudgetError.NonPositiveInputLength(InputSize.codeUnits(0L)))
+          maxInputLength = input(0L),
+          maxWork = work(0L),
+          maxNestingDepth = nesting(0),
+          maxOutputNodes = nodes(0L)
+        ) == Result.fail(ScanBudgetError.NonPositiveInputLength(input(0L)))
       )
 
     "uses MorphirException errors with stable messages" in {
-      val error: ScanBudgetError = ScanBudgetError.NonPositiveWork(WorkUnits(0L))
+      val error: ScanBudgetError = ScanBudgetError.NonPositiveWork(work(0L))
       assert(error.isInstanceOf[MorphirException])
       assert(error.getMessage == "maximum work must be positive: 0")
     }
 
     "preserves each distinct typed limit" in {
       val result = ScanBudget.limited(
-        maxInputLength = InputSize.codeUnits(11L),
-        maxWork = WorkUnits(22L),
-        maxNestingDepth = NestingDepth(33),
-        maxOutputNodes = NodeCount(44L)
+        maxInputLength = input(11L),
+        maxWork = work(22L),
+        maxNestingDepth = nesting(33),
+        maxOutputNodes = nodes(44L)
       )
 
       result match
@@ -126,40 +123,128 @@ class ScanBudgetTests extends Test[Any]:
 
   "scan measures" - {
     "support same-measure equality under strict equality" in {
-      assert(InputSize.codeUnits(1L) == InputSize.codeUnits(1L))
+      assert(input(1L) == input(1L))
       assert(CodeUnitCount.one == CodeUnitCount(1))
-      assert(WorkUnits(1L) == WorkUnits(1L))
-      assert(NestingDepth(1) == NestingDepth(1))
-      assert(NodeCount.one == NodeCount(1L))
+      assert(work(1L) == work(1L))
+      assert(nesting(1) == nesting(1))
+      assert(NodeCount.one == nodes(1L))
       assert(SourceOffset.start == SourceOffset(0))
       assert(ScanPhase("tokenize") == ScanPhase("tokenize"))
     }
 
-    "reject negative input sizes" in
-      assert(rejects(InputSize.codeUnits(-1L)))
-    "reject negative mebibyte input sizes" in
-      assert(rejects(InputSize.mebibytes(-1L)))
+    "returns a typed failure rather than throwing for a negative input size" in {
+      val error: MorphirException = ScanBudgetError.NegativeInputSize(-1L)
+      assert(InputSize.fromCodeUnits(-1L) == Result.fail(ScanBudgetError.NegativeInputSize(-1L)))
+      assert(error.getMessage == "input size must be non-negative: -1")
+    }
+    "returns a typed failure rather than throwing for a negative mebibyte input size" in
+      assert(InputSize.fromMebibytes(-1L) == Result.fail(ScanBudgetError.NegativeInputSize(-1L)))
+    "returns a typed failure rather than throwing for a negative megabyte input size" in
+      assert(InputSize.fromMegabytes(-1L) == Result.fail(ScanBudgetError.NegativeInputSize(-1L)))
     "reject negative code-unit counts" in
       assert(rejects(CodeUnitCount(-1)))
-    "reject negative work units" in
-      assert(rejects(WorkUnits(-1L)))
-    "reject negative nesting depths" in
-      assert(rejects(NestingDepth(-1)))
-    "reject negative node counts" in
-      assert(rejects(NodeCount(-1L)))
+    "returns a typed failure rather than throwing for negative work units" in
+      assert(WorkUnits.from(-1L) == Result.fail(ScanBudgetError.NegativeWork(-1L)))
+    "returns a typed failure rather than throwing for a negative nesting depth" in
+      assert(NestingDepth.from(-1) == Result.fail(ScanBudgetError.NegativeNestingDepth(-1)))
+    "returns a typed failure rather than throwing for a negative node count" in
+      assert(NodeCount.from(-1L) == Result.fail(ScanBudgetError.NegativeOutputNodes(-1L)))
     "reject negative source offsets" in
       assert(rejects(SourceOffset(-1)))
     "reject empty and blank scan phases" in {
       assert(rejects(ScanPhase("")))
       assert(rejects(ScanPhase(" \t\n")))
     }
-    "reject mebibyte overflow" in
-      assert(rejects(InputSize.mebibytes(Long.MaxValue)))
-    "accept the exact mebibyte boundary and reject its successor with arithmetic overflow" in {
+    "returns a typed failure rather than throwing for mebibyte overflow" in
+      assert(
+        InputSize.fromMebibytes(Long.MaxValue) ==
+          Result.fail(ScanBudgetError.InputSizeOverflow(Long.MaxValue, "mebibytes"))
+      )
+    "returns a typed failure rather than throwing for megabyte overflow" in
+      assert(
+        InputSize.fromMegabytes(Long.MaxValue) ==
+          Result.fail(ScanBudgetError.InputSizeOverflow(Long.MaxValue, "megabytes"))
+      )
+    "accepts the exact mebibyte boundary and returns overflow for its successor" in {
       val codeUnitsPerMebibyte = 1024L * 1024L
       val boundary             = Long.MaxValue / codeUnitsPerMebibyte
-      assert(InputSize.mebibytes(boundary).toLong == boundary * codeUnitsPerMebibyte)
-      assert(throwsArithmetic(InputSize.mebibytes(boundary + 1L)))
+      assert(InputSize.fromMebibytes(boundary) == Result.succeed(input(boundary * codeUnitsPerMebibyte)))
+      assert(
+        InputSize.fromMebibytes(boundary + 1L) ==
+          Result.fail(ScanBudgetError.InputSizeOverflow(boundary + 1L, "mebibytes"))
+      )
+    }
+    "scales SI and IEC byte units to UTF-16 code units" in {
+      assert(InputSize.kilobytes(1L).toLong == 1000L)
+      assert(InputSize.kibibytes(1L).toLong == 1024L)
+      assert(InputSize.megabytes(1L).toLong == 1000L * 1000L)
+      assert(InputSize.mebibytes(1L).toLong == 1024L * 1024L)
+      assert(InputSize.gigabytes(1L).toLong == 1000L * 1000L * 1000L)
+      assert(InputSize.gibibytes(1L).toLong == 1024L * 1024L * 1024L)
+      assert(InputSize.fromKilobytes(2L) == Result.succeed(InputSize.kilobytes(2L)))
+      assert(InputSize.fromGibibytes(1L) == Result.succeed(InputSize.gibibytes(1L)))
+    }
+
+    "constructs a literal input size at compile time" in {
+      assert(InputSize.codeUnits(0L).toLong == 0L)
+      assert(InputSize.codeUnits(16L).toLong == 16L)
+      assert(InputSize.kilobytes(1L).toLong == 1000L)
+      assert(InputSize.megabytes(1L).toLong == 1000L * 1000L)
+      assert(InputSize.mebibytes(1L).toLong == 1024L * 1024L)
+      assert(WorkUnits(2L * 3L).toLong == 6L)
+      assert(NestingDepth(4).toInt == 4)
+      assert(NodeCount(8L).toLong == 8L)
+    }
+
+    "rejects a negative literal input size at compile time" in {
+      val errors = scala.compiletime.testing.typeCheckErrors("""
+        import morphir.langkit.core.scanner.*
+        InputSize.codeUnits(-1L)
+      """)
+      assert(errors.exists(_.message.contains("input size must be non-negative")))
+    }
+
+    "rejects a negative literal megabyte size at compile time" in {
+      val errors = scala.compiletime.testing.typeCheckErrors("""
+        import morphir.langkit.core.scanner.*
+        InputSize.megabytes(-1L)
+      """)
+      assert(errors.exists(_.message.contains("input size must be non-negative")))
+    }
+
+    "rejects an overflowing literal megabyte size at compile time" in {
+      val errors = scala.compiletime.testing.typeCheckErrors("""
+        import morphir.langkit.core.scanner.*
+        InputSize.megabytes(Long.MaxValue)
+      """)
+      assert(errors.exists(_.message.contains("input size overflow")))
+    }
+
+    "rejects a negative literal work, nesting, and node count at compile time" in {
+      val workErrors = scala.compiletime.testing.typeCheckErrors("""
+        import morphir.langkit.core.scanner.*
+        WorkUnits(-1L)
+      """)
+      val nestingErrors = scala.compiletime.testing.typeCheckErrors("""
+        import morphir.langkit.core.scanner.*
+        NestingDepth(-1)
+      """)
+      val nodeErrors = scala.compiletime.testing.typeCheckErrors("""
+        import morphir.langkit.core.scanner.*
+        NodeCount(-1L)
+      """)
+      assert(workErrors.exists(_.message.contains("work units must be non-negative")))
+      assert(nestingErrors.exists(_.message.contains("nesting depth must be non-negative")))
+      assert(nodeErrors.exists(_.message.contains("node count must be non-negative")))
+    }
+
+    "rejects a dynamic input size at the compile-time constructor" in {
+      val errors = scala.compiletime.testing.typeCheckErrors("""
+        import morphir.langkit.core.scanner.*
+        val n = 1L
+        InputSize.codeUnits(n)
+      """)
+      assert(errors.nonEmpty)
     }
   }
 
@@ -169,9 +254,9 @@ class ScanBudgetTests extends Test[Any]:
 
     "preserves an exact typed failure" in {
       val failure = ScanFailure(
-        exceeded = ScanLimitExceeded.Work(limit = WorkUnits(10L), attempted = WorkUnits(11L)),
+        exceeded = ScanLimitExceeded.Work(limit = work(10L), attempted = work(11L)),
         offset = SourceOffset(7),
-        phase = Some(ScanPhase("tokenize"))
+        phase = Present(ScanPhase("tokenize"))
       )
       assert(ScanResult.Failure(failure).map((value: Int) => value + 1) == ScanResult.Failure(failure))
     }

--- a/morphir/langkit/core/test/src/morphir/langkit/core/scanner/ScanBudgetTests.scala
+++ b/morphir/langkit/core/test/src/morphir/langkit/core/scanner/ScanBudgetTests.scala
@@ -1,6 +1,7 @@
 package morphir.langkit.core.scanner
 
 import kyo.test.*
+import scala.language.strictEquality
 
 class ScanBudgetTests extends Test[Any]:
 
@@ -9,6 +10,14 @@ class ScanBudgetTests extends Test[Any]:
       thunk
       false
     catch case _: IllegalArgumentException | _: ArithmeticException => true
+
+  private def throwsArithmetic(thunk: => Any): Boolean =
+    try
+      thunk
+      false
+    catch
+      case _: ArithmeticException => true
+      case _: Throwable           => false
 
   "ScanBudget" - {
     "has positive typed defaults" in {
@@ -34,6 +43,42 @@ class ScanBudgetTests extends Test[Any]:
       assert(rejected)
     }
 
+    "rejects a zero work limit while all other limits are positive" in {
+      val rejected = rejects {
+        ScanBudget.limited(
+          maxInputLength = InputSize.codeUnits(1L),
+          maxWork = WorkUnits(0L),
+          maxNestingDepth = NestingDepth(1),
+          maxOutputNodes = NodeCount.one
+        )
+      }
+      assert(rejected)
+    }
+
+    "rejects a zero nesting limit while all other limits are positive" in {
+      val rejected = rejects {
+        ScanBudget.limited(
+          maxInputLength = InputSize.codeUnits(1L),
+          maxWork = WorkUnits(1L),
+          maxNestingDepth = NestingDepth(0),
+          maxOutputNodes = NodeCount.one
+        )
+      }
+      assert(rejected)
+    }
+
+    "rejects a zero output-node limit while all other limits are positive" in {
+      val rejected = rejects {
+        ScanBudget.limited(
+          maxInputLength = InputSize.codeUnits(1L),
+          maxWork = WorkUnits(1L),
+          maxNestingDepth = NestingDepth(1),
+          maxOutputNodes = NodeCount(0L)
+        )
+      }
+      assert(rejected)
+    }
+
     "preserves each distinct typed limit" in {
       val budget = ScanBudget.limited(
         maxInputLength = InputSize.codeUnits(11L),
@@ -49,7 +94,7 @@ class ScanBudgetTests extends Test[Any]:
     }
 
     "names the unsafe policy explicitly" in
-      assert(ScanBudget.UnsafeUnbounded == ScanBudget.UnsafeUnbounded)
+      assert(ScanBudget.UnsafeUnbounded.toString == "UnsafeUnbounded")
 
     "does not allow input and work limits to be swapped" in {
       val errors = scala.compiletime.testing.typeCheckErrors("""
@@ -66,6 +111,16 @@ class ScanBudgetTests extends Test[Any]:
   }
 
   "scan measures" - {
+    "support same-measure equality under strict equality" in {
+      assert(InputSize.codeUnits(1L) == InputSize.codeUnits(1L))
+      assert(CodeUnitCount.one == CodeUnitCount(1))
+      assert(WorkUnits(1L) == WorkUnits(1L))
+      assert(NestingDepth(1) == NestingDepth(1))
+      assert(NodeCount.one == NodeCount(1L))
+      assert(SourceOffset.start == SourceOffset(0))
+      assert(ScanPhase("tokenize") == ScanPhase("tokenize"))
+    }
+
     "reject negative input sizes" in
       assert(rejects(InputSize.codeUnits(-1L)))
     "reject negative mebibyte input sizes" in
@@ -86,6 +141,12 @@ class ScanBudgetTests extends Test[Any]:
     }
     "reject mebibyte overflow" in
       assert(rejects(InputSize.mebibytes(Long.MaxValue)))
+    "accept the exact mebibyte boundary and reject its successor with arithmetic overflow" in {
+      val codeUnitsPerMebibyte = 1024L * 1024L
+      val boundary             = Long.MaxValue / codeUnitsPerMebibyte
+      assert(InputSize.mebibytes(boundary).toLong == boundary * codeUnitsPerMebibyte)
+      assert(throwsArithmetic(InputSize.mebibytes(boundary + 1L)))
+    }
   }
 
   "ScanResult.map" - {

--- a/morphir/langkit/core/test/src/morphir/langkit/core/scanner/ScanBudgetTests.scala
+++ b/morphir/langkit/core/test/src/morphir/langkit/core/scanner/ScanBudgetTests.scala
@@ -1,0 +1,103 @@
+package morphir.langkit.core.scanner
+
+import kyo.test.*
+
+class ScanBudgetTests extends Test[Any]:
+
+  private def rejects(thunk: => Any): Boolean =
+    try
+      thunk
+      false
+    catch case _: IllegalArgumentException | _: ArithmeticException => true
+
+  "ScanBudget" - {
+    "has positive typed defaults" in {
+      def check(policy: ScanBudget): Unit = policy match
+        case budget: ScanBudget.Limited =>
+          assert(budget.maxInputLength.toLong > 0L)
+          assert(budget.maxWork.toLong > 0L)
+          assert(budget.maxNestingDepth.toInt > 0)
+          assert(budget.maxOutputNodes.toLong > 0L)
+        case ScanBudget.UnsafeUnbounded => assert(false)
+      check(ScanBudget.default)
+    }
+
+    "rejects a zero input limit while all other limits are positive" in {
+      val rejected = rejects {
+        ScanBudget.limited(
+          maxInputLength = InputSize.codeUnits(0L),
+          maxWork = WorkUnits(1L),
+          maxNestingDepth = NestingDepth(1),
+          maxOutputNodes = NodeCount.one
+        )
+      }
+      assert(rejected)
+    }
+
+    "preserves each distinct typed limit" in {
+      val budget = ScanBudget.limited(
+        maxInputLength = InputSize.codeUnits(11L),
+        maxWork = WorkUnits(22L),
+        maxNestingDepth = NestingDepth(33),
+        maxOutputNodes = NodeCount(44L)
+      )
+
+      assert(budget.maxInputLength.toLong == 11L)
+      assert(budget.maxWork.toLong == 22L)
+      assert(budget.maxNestingDepth.toInt == 33)
+      assert(budget.maxOutputNodes.toLong == 44L)
+    }
+
+    "names the unsafe policy explicitly" in
+      assert(ScanBudget.UnsafeUnbounded == ScanBudget.UnsafeUnbounded)
+
+    "does not allow input and work limits to be swapped" in {
+      val errors = scala.compiletime.testing.typeCheckErrors("""
+        import morphir.langkit.core.scanner.*
+        ScanBudget.limited(
+          maxInputLength = WorkUnits(1L),
+          maxWork = InputSize.codeUnits(1L),
+          maxNestingDepth = NestingDepth(1),
+          maxOutputNodes = NodeCount.one
+        )
+      """)
+      assert(errors.nonEmpty)
+    }
+  }
+
+  "scan measures" - {
+    "reject negative input sizes" in
+      assert(rejects(InputSize.codeUnits(-1L)))
+    "reject negative mebibyte input sizes" in
+      assert(rejects(InputSize.mebibytes(-1L)))
+    "reject negative code-unit counts" in
+      assert(rejects(CodeUnitCount(-1)))
+    "reject negative work units" in
+      assert(rejects(WorkUnits(-1L)))
+    "reject negative nesting depths" in
+      assert(rejects(NestingDepth(-1)))
+    "reject negative node counts" in
+      assert(rejects(NodeCount(-1L)))
+    "reject negative source offsets" in
+      assert(rejects(SourceOffset(-1)))
+    "reject empty and blank scan phases" in {
+      assert(rejects(ScanPhase("")))
+      assert(rejects(ScanPhase(" \t\n")))
+    }
+    "reject mebibyte overflow" in
+      assert(rejects(InputSize.mebibytes(Long.MaxValue)))
+  }
+
+  "ScanResult.map" - {
+    "transforms a success" in
+      assert(ScanResult.Success(2).map(_ * 3) == ScanResult.Success(6))
+
+    "preserves an exact typed failure" in {
+      val failure = ScanFailure(
+        exceeded = ScanLimitExceeded.Work(limit = WorkUnits(10L), attempted = WorkUnits(11L)),
+        offset = SourceOffset(7),
+        phase = Some(ScanPhase("tokenize"))
+      )
+      assert(ScanResult.Failure(failure).map((value: Int) => value + 1) == ScanResult.Failure(failure))
+    }
+  }

--- a/morphir/langkit/core/test/src/morphir/langkit/core/scanner/ScanBudgetTests.scala
+++ b/morphir/langkit/core/test/src/morphir/langkit/core/scanner/ScanBudgetTests.scala
@@ -1,6 +1,8 @@
 package morphir.langkit.core.scanner
 
+import kyo.*
 import kyo.test.*
+import morphir.MorphirException
 import scala.language.strictEquality
 
 class ScanBudgetTests extends Test[Any]:
@@ -31,66 +33,78 @@ class ScanBudgetTests extends Test[Any]:
       check(ScanBudget.default)
     }
 
-    "rejects a zero input limit while all other limits are positive" in {
-      val rejected = rejects {
+    "returns an input-length failure rather than throwing for a zero input limit" in
+      assert(
         ScanBudget.limited(
           maxInputLength = InputSize.codeUnits(0L),
           maxWork = WorkUnits(1L),
           maxNestingDepth = NestingDepth(1),
           maxOutputNodes = NodeCount.one
-        )
-      }
-      assert(rejected)
-    }
+        ) == Result.fail(ScanBudgetError.NonPositiveInputLength(InputSize.codeUnits(0L)))
+      )
 
-    "rejects a zero work limit while all other limits are positive" in {
-      val rejected = rejects {
+    "returns a work failure rather than throwing for a zero work limit" in
+      assert(
         ScanBudget.limited(
           maxInputLength = InputSize.codeUnits(1L),
           maxWork = WorkUnits(0L),
           maxNestingDepth = NestingDepth(1),
           maxOutputNodes = NodeCount.one
-        )
-      }
-      assert(rejected)
-    }
+        ) == Result.fail(ScanBudgetError.NonPositiveWork(WorkUnits(0L)))
+      )
 
-    "rejects a zero nesting limit while all other limits are positive" in {
-      val rejected = rejects {
+    "returns a nesting-depth failure rather than throwing for a zero nesting limit" in
+      assert(
         ScanBudget.limited(
           maxInputLength = InputSize.codeUnits(1L),
           maxWork = WorkUnits(1L),
           maxNestingDepth = NestingDepth(0),
           maxOutputNodes = NodeCount.one
-        )
-      }
-      assert(rejected)
-    }
+        ) == Result.fail(ScanBudgetError.NonPositiveNestingDepth(NestingDepth(0)))
+      )
 
-    "rejects a zero output-node limit while all other limits are positive" in {
-      val rejected = rejects {
+    "returns an output-node failure rather than throwing for a zero output-node limit" in
+      assert(
         ScanBudget.limited(
           maxInputLength = InputSize.codeUnits(1L),
           maxWork = WorkUnits(1L),
           maxNestingDepth = NestingDepth(1),
           maxOutputNodes = NodeCount(0L)
-        )
-      }
-      assert(rejected)
+        ) == Result.fail(ScanBudgetError.NonPositiveOutputNodes(NodeCount(0L)))
+      )
+
+    "returns the first validation failure in constructor-parameter order" in
+      assert(
+        ScanBudget.limited(
+          maxInputLength = InputSize.codeUnits(0L),
+          maxWork = WorkUnits(0L),
+          maxNestingDepth = NestingDepth(0),
+          maxOutputNodes = NodeCount(0L)
+        ) == Result.fail(ScanBudgetError.NonPositiveInputLength(InputSize.codeUnits(0L)))
+      )
+
+    "uses MorphirException errors with stable messages" in {
+      val error: ScanBudgetError = ScanBudgetError.NonPositiveWork(WorkUnits(0L))
+      assert(error.isInstanceOf[MorphirException])
+      assert(error.getMessage == "maximum work must be positive: 0")
     }
 
     "preserves each distinct typed limit" in {
-      val budget = ScanBudget.limited(
+      val result = ScanBudget.limited(
         maxInputLength = InputSize.codeUnits(11L),
         maxWork = WorkUnits(22L),
         maxNestingDepth = NestingDepth(33),
         maxOutputNodes = NodeCount(44L)
       )
 
-      assert(budget.maxInputLength.toLong == 11L)
-      assert(budget.maxWork.toLong == 22L)
-      assert(budget.maxNestingDepth.toInt == 33)
-      assert(budget.maxOutputNodes.toLong == 44L)
+      result match
+        case Result.Success(budget) =>
+          assert(budget.maxInputLength.toLong == 11L)
+          assert(budget.maxWork.toLong == 22L)
+          assert(budget.maxNestingDepth.toInt == 33)
+          assert(budget.maxOutputNodes.toLong == 44L)
+        case Result.Failure(error) =>
+          assert(false, s"unexpected validation failure: ${error.getMessage}")
     }
 
     "names the unsafe policy explicitly" in

--- a/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceScannerTests.scala
+++ b/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceScannerTests.scala
@@ -74,8 +74,10 @@ class SourceScannerTests extends Test[Any]:
     }
 
     "fails at the exact work boundary before the rejected operation" in {
-      val phase  = ScanPhase("test")
-      val result = SourceScanner.scan("abc", limited(input = 3L, work = 2L), Some(phase)) { scanner =>
+      val phase                   = ScanPhase("test")
+      var retained: SourceScanner = null
+      val result                  = SourceScanner.scan("abc", limited(input = 3L, work = 2L), Some(phase)) { scanner =>
+        retained = scanner
         scanner.peek()
         scanner.advance()
         scanner.peek()
@@ -87,6 +89,81 @@ class SourceScannerTests extends Test[Any]:
             exceeded = ScanLimitExceeded.Work(limit = WorkUnits(2L), attempted = WorkUnits(3L)),
             offset = SourceOffset(1),
             phase = Some(phase)
+          )
+        )
+      )
+      assert(closedMessage(retained.offset).contains("scanner session is closed"))
+    }
+
+    "returns the first work failure when the callback swallows exhaustion" in {
+      val result = SourceScanner.scan("a", limited(input = 1L, work = 1L)) { scanner =>
+        scanner.peek()
+        try scanner.peek()
+        catch case _: Throwable => ()
+        "ignored"
+      }
+
+      assert(
+        result == ScanResult.Failure(
+          ScanFailure(
+            exceeded = ScanLimitExceeded.Work(limit = WorkUnits(1L), attempted = WorkUnits(2L)),
+            offset = SourceOffset.start,
+            phase = None
+          )
+        )
+      )
+    }
+
+    "propagates exhaustion replayed into a different scan and closes that scan" in {
+      val callbackFailure             = new RuntimeException("leave first callback")
+      var captured: Throwable         = null
+      var firstScanner: SourceScanner = null
+
+      try
+        SourceScanner.scan("a", limited(input = 1L, work = 1L)) { scanner =>
+          firstScanner = scanner
+          scanner.peek()
+          try scanner.peek()
+          catch case error: Throwable => captured = error
+          throw callbackFailure
+        }
+      catch case error: Throwable => assert(error.eq(callbackFailure))
+
+      var secondScanner: SourceScanner = null
+      var replayed: Throwable          = null
+      try
+        SourceScanner.scan("b") { scanner =>
+          secondScanner = scanner
+          throw captured
+        }
+      catch case error: Throwable => replayed = error
+
+      assert(captured != null)
+      assert(replayed.eq(captured))
+      assert(closedMessage(firstScanner.offset).contains("scanner session is closed"))
+      assert(closedMessage(secondScanner.offset).contains("scanner session is closed"))
+    }
+
+    "rethrows the same first exhaustion after repeated caught attempts" in {
+      var first: Throwable  = null
+      var second: Throwable = null
+      val result            = SourceScanner.scan("a", limited(input = 1L, work = 1L)) { scanner =>
+        scanner.peek()
+        try scanner.peek()
+        catch case error: Throwable => first = error
+        try scanner.peek()
+        catch case error: Throwable => second = error
+        ()
+      }
+
+      assert(first != null)
+      assert(second.eq(first))
+      assert(
+        result == ScanResult.Failure(
+          ScanFailure(
+            exceeded = ScanLimitExceeded.Work(limit = WorkUnits(1L), attempted = WorkUnits(2L)),
+            offset = SourceOffset.start,
+            phase = None
           )
         )
       )
@@ -117,13 +194,19 @@ class SourceScannerTests extends Test[Any]:
     }
 
     "propagates callback exceptions unchanged" in {
-      val expected          = new RuntimeException("callback failed")
-      var caught: Throwable = null
+      val expected                = new RuntimeException("callback failed")
+      var caught: Throwable       = null
+      var retained: SourceScanner = null
 
-      try SourceScanner.scan("a")(_ => throw expected)
+      try
+        SourceScanner.scan("a") { scanner =>
+          retained = scanner
+          throw expected
+        }
       catch case error: Throwable => caught = error
 
       assert(caught.eq(expected))
+      assert(closedMessage(retained.offset).contains("scanner session is closed"))
     }
 
     "closes a retained scanner after its callback returns" in {
@@ -154,6 +237,21 @@ class SourceScannerTests extends Test[Any]:
       }
 
       assert(result == ScanResult.Success(SourceOffset(source.length)))
+    }
+
+    "navigates an empty source without work" in {
+      val result = SourceScanner.scan("", limited(input = 1L, work = 1L)) { scanner =>
+        assert(scanner.offset == SourceOffset.start)
+        assert(scanner.isAtEnd)
+        assert(scanner.mark == SourceOffset.start)
+        assert(scanner.peek().isEmpty)
+        assert(scanner.peek(CodeUnitCount(Int.MaxValue)).isEmpty)
+        assert(scanner.remaining.isEmpty)
+        assert(scanner.remaining.span == Span.zero)
+        scanner.offset
+      }
+
+      assert(result == ScanResult.Success(SourceOffset.start))
     }
 
     "rejects invalid source-view ranges without cursor movement" in {

--- a/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceScannerTests.scala
+++ b/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceScannerTests.scala
@@ -1,5 +1,6 @@
 package morphir.langkit.core.scanner
 
+import kyo.*
 import kyo.test.*
 import morphir.langkit.core.Span
 import scala.compiletime.testing.typeCheckErrors
@@ -18,7 +19,7 @@ class SourceScannerTests extends Test[Any]:
       maxWork = WorkUnits(work),
       maxNestingDepth = NestingDepth(nesting),
       maxOutputNodes = NodeCount(output)
-    )
+    ).getOrThrow
 
   private def rejectsArgument(thunk: => Any): Boolean =
     try

--- a/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceScannerTests.scala
+++ b/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceScannerTests.scala
@@ -2,6 +2,7 @@ package morphir.langkit.core.scanner
 
 import kyo.test.*
 import morphir.langkit.core.Span
+import scala.compiletime.testing.typeCheckErrors
 import scala.language.strictEquality
 
 class SourceScannerTests extends Test[Any]:
@@ -336,6 +337,14 @@ class SourceScannerTests extends Test[Any]:
       assert(result == ScanResult.Success(SourceOffset.start))
     }
 
+    "does not expose checkpoint construction to scanner-package consumers" in {
+      val constructorErrors = typeCheckErrors("new SourceScanner.Checkpoint(null, 0)")
+      val factoryErrors     = typeCheckErrors("ScanCheckpoint.create(null, 0)")
+
+      assert(constructorErrors.nonEmpty)
+      assert(factoryErrors.nonEmpty)
+    }
+
     "rejects foreign checkpoints without damaging the receiving scanner" in {
       var foreign: ScanCheckpoint = null
       SourceScanner.scan("a") { scanner => foreign = scanner.checkpoint() }
@@ -472,6 +481,32 @@ class SourceScannerTests extends Test[Any]:
       )
     }
 
+    "rejects output beyond Long.MaxValue after accepting the exact ceiling" in {
+      var caught: Throwable = null
+      val result            = SourceScanner.scan(
+        "a",
+        limited(input = 1L, work = 10L, output = Long.MaxValue)
+      ) { scanner =>
+        scanner.chargeOutputNodes(NodeCount(Long.MaxValue))
+        try scanner.chargeOutputNodes(NodeCount.one)
+        catch case error: Throwable => caught = error
+      }
+
+      assert(caught != null)
+      assert(
+        result == ScanResult.Failure(
+          ScanFailure(
+            exceeded = ScanLimitExceeded.OutputNodes(
+              limit = NodeCount(Long.MaxValue),
+              attempted = NodeCount(Long.MaxValue)
+            ),
+            offset = SourceOffset.start,
+            phase = None
+          )
+        )
+      )
+    }
+
     "contains swallowed nesting exhaustion and foreign replay" in {
       var captured: Throwable = null
       val first               = SourceScanner.scan("a", limited(input = 1L, work = 10L)) { scanner =>
@@ -582,5 +617,11 @@ class SourceScannerTests extends Test[Any]:
       assert(SourceScanner.saturatingAdd(Long.MaxValue - 1L, 1L) == Long.MaxValue)
       assert(SourceScanner.saturatingAdd(Long.MaxValue - 1L, 2L) == Long.MaxValue)
       assert(SourceScanner.saturatingAdd(Long.MaxValue, 1L) == Long.MaxValue)
+    }
+
+    "detects work beyond Long.MaxValue despite saturated reporting" in {
+      assert(!SourceScanner.wouldExceedLimit(0L, Long.MaxValue, Long.MaxValue))
+      assert(!SourceScanner.wouldExceedLimit(Long.MaxValue - 1L, 1L, Long.MaxValue))
+      assert(SourceScanner.wouldExceedLimit(Long.MaxValue, 1L, Long.MaxValue))
     }
   }

--- a/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceScannerTests.scala
+++ b/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceScannerTests.scala
@@ -6,12 +6,17 @@ import scala.language.strictEquality
 
 class SourceScannerTests extends Test[Any]:
 
-  private def limited(input: Long, work: Long): ScanBudget.Limited =
+  private def limited(
+      input: Long,
+      work: Long,
+      nesting: Int = 1,
+      output: Long = 1L
+  ): ScanBudget.Limited =
     ScanBudget.limited(
       maxInputLength = InputSize.codeUnits(input),
       maxWork = WorkUnits(work),
-      maxNestingDepth = NestingDepth(1),
-      maxOutputNodes = NodeCount.one
+      maxNestingDepth = NestingDepth(nesting),
+      maxOutputNodes = NodeCount(output)
     )
 
   private def rejectsArgument(thunk: => Any): Boolean =
@@ -291,6 +296,286 @@ class SourceScannerTests extends Test[Any]:
         )
       )
       assert(unbounded == ScanResult.Success(SourceOffset.start))
+    }
+
+    "restores checkpoints without refunding speculative work" in {
+      val result = SourceScanner.scan("abc", limited(input = 3L, work = 4L)) { scanner =>
+        val checkpoint = scanner.checkpoint()
+        scanner.advance(CodeUnitCount(2))
+        assert(scanner.offset == SourceOffset(2))
+        scanner.restore(checkpoint)
+        assert(scanner.offset == SourceOffset.start)
+        scanner.advance(CodeUnitCount(2))
+        assert(scanner.offset == SourceOffset(2))
+        scanner.peek()
+      }
+
+      assert(
+        result == ScanResult.Failure(
+          ScanFailure(
+            exceeded = ScanLimitExceeded.Work(limit = WorkUnits(4L), attempted = WorkUnits(5L)),
+            offset = SourceOffset(2),
+            phase = None
+          )
+        )
+      )
+    }
+
+    "restores checkpoints captured before and after movement to their exact offsets" in {
+      val result = SourceScanner.scan("abc") { scanner =>
+        val before = scanner.checkpoint()
+        scanner.advance()
+        val after = scanner.checkpoint()
+        scanner.advance()
+        scanner.restore(after)
+        assert(scanner.offset == SourceOffset(1))
+        scanner.restore(before)
+        scanner.offset
+      }
+
+      assert(result == ScanResult.Success(SourceOffset.start))
+    }
+
+    "rejects foreign checkpoints without damaging the receiving scanner" in {
+      var foreign: ScanCheckpoint = null
+      SourceScanner.scan("a") { scanner => foreign = scanner.checkpoint() }
+
+      var retained: SourceScanner = null
+      val result                  = SourceScanner.scan("b") { scanner =>
+        retained = scanner
+        assert(rejectsArgument(scanner.restore(foreign)))
+        assert(scanner.peek().contains('b'))
+        scanner.offset
+      }
+
+      assert(result == ScanResult.Success(SourceOffset.start))
+      assert(closedMessage(retained.offset).contains("scanner session is closed"))
+    }
+
+    "rejects checkpoint restoration after the owning scanner closes" in {
+      var retained: SourceScanner    = null
+      var checkpoint: ScanCheckpoint = null
+      SourceScanner.scan("a") { scanner =>
+        retained = scanner
+        checkpoint = scanner.checkpoint()
+      }
+
+      assert(closedMessage(retained.restore(checkpoint)).contains("scanner session is closed"))
+    }
+
+    "requires successful parser phases to advance" in {
+      val phase  = ScanPhase("inline parser")
+      val result = SourceScanner.scan("a") { scanner =>
+        val value = scanner.requireProgress(phase) {
+          scanner.advance()
+          42
+        }
+        assert(value == 42)
+        scanner.offset
+      }
+
+      assert(result == ScanResult.Success(SourceOffset(1)))
+    }
+
+    "rejects parser phases that finish at their starting offset" in {
+      val phase                     = ScanPhase("block parser")
+      var stationaryMessage: String = null
+      var restoredMessage: String   = null
+
+      val result = SourceScanner.scan("a") { scanner =>
+        try scanner.requireProgress(phase)(())
+        catch case error: IllegalStateException => stationaryMessage = error.getMessage
+
+        val checkpoint = scanner.checkpoint()
+        try
+          scanner.requireProgress(phase) {
+            scanner.advance()
+            scanner.restore(checkpoint)
+          }
+        catch case error: IllegalStateException => restoredMessage = error.getMessage
+      }
+
+      assert(result == ScanResult.Success(()))
+      assert(stationaryMessage == "block parser made no progress")
+      assert(restoredMessage == "block parser made no progress")
+    }
+
+    "propagates requireProgress operation exceptions unchanged" in {
+      val expected          = new RuntimeException("phase failed")
+      var caught: Throwable = null
+
+      try SourceScanner.scan("a")(_.requireProgress(ScanPhase("parser"))(throw expected))
+      catch case error: Throwable => caught = error
+
+      assert(caught.eq(expected))
+    }
+
+    "enforces nesting at the exact boundary without entering rejected work" in {
+      val phase        = ScanPhase("nested parser")
+      var innerEntered = false
+      val result       = SourceScanner.scan("a", limited(input = 1L, work = 10L), Some(phase)) { scanner =>
+        scanner.withNesting {
+          scanner.withNesting {
+            innerEntered = true
+          }
+        }
+      }
+
+      assert(!innerEntered)
+      assert(
+        result == ScanResult.Failure(
+          ScanFailure(
+            exceeded = ScanLimitExceeded.Nesting(limit = NestingDepth(1), attempted = NestingDepth(2)),
+            offset = SourceOffset.start,
+            phase = Some(phase)
+          )
+        )
+      )
+    }
+
+    "unwinds accepted nesting after an ordinary exception" in {
+      val expected          = new RuntimeException("nested operation failed")
+      var caught: Throwable = null
+      val result            = SourceScanner.scan("a", limited(input = 1L, work = 10L)) { scanner =>
+        try scanner.withNesting(throw expected)
+        catch case error: Throwable => caught = error
+        scanner.withNesting(7)
+      }
+
+      assert(caught.eq(expected))
+      assert(result == ScanResult.Success(7))
+    }
+
+    "enforces output nodes at the exact boundary and keeps exhaustion sticky" in {
+      val phase             = ScanPhase("output builder")
+      var first: Throwable  = null
+      var second: Throwable = null
+      val result = SourceScanner.scan("a", limited(input = 1L, work = 10L, output = 2L), Some(phase)) { scanner =>
+        scanner.chargeOutputNodes(NodeCount(2L))
+        scanner.chargeOutputNodes(NodeCount(0L))
+        try scanner.chargeOutputNodes(NodeCount.one)
+        catch case error: Throwable => first = error
+        try scanner.chargeOutputNodes(NodeCount(0L))
+        catch case error: Throwable => second = error
+      }
+
+      assert(first != null)
+      assert(second.eq(first))
+      assert(
+        result == ScanResult.Failure(
+          ScanFailure(
+            exceeded = ScanLimitExceeded.OutputNodes(limit = NodeCount(2L), attempted = NodeCount(3L)),
+            offset = SourceOffset.start,
+            phase = Some(phase)
+          )
+        )
+      )
+    }
+
+    "contains swallowed nesting exhaustion and foreign replay" in {
+      var captured: Throwable = null
+      val first               = SourceScanner.scan("a", limited(input = 1L, work = 10L)) { scanner =>
+        scanner.withNesting {
+          try scanner.withNesting(())
+          catch case error: Throwable => captured = error
+        }
+        "ignored"
+      }
+
+      var secondScanner: SourceScanner = null
+      var replayed: Throwable          = null
+      try
+        SourceScanner.scan("b") { scanner =>
+          secondScanner = scanner
+          throw captured
+        }
+      catch case error: Throwable => replayed = error
+
+      assert(
+        first == ScanResult.Failure(
+          ScanFailure(
+            exceeded = ScanLimitExceeded.Nesting(limit = NestingDepth(1), attempted = NestingDepth(2)),
+            offset = SourceOffset.start,
+            phase = None
+          )
+        )
+      )
+      assert(replayed.eq(captured))
+      assert(closedMessage(secondScanner.offset).contains("scanner session is closed"))
+    }
+
+    "contains swallowed output exhaustion and foreign replay" in {
+      var captured: Throwable = null
+      val first               = SourceScanner.scan("a", limited(input = 1L, work = 10L)) { scanner =>
+        scanner.chargeOutputNodes(NodeCount.one)
+        try scanner.chargeOutputNodes(NodeCount.one)
+        catch case error: Throwable => captured = error
+        "ignored"
+      }
+
+      var secondScanner: SourceScanner = null
+      var replayed: Throwable          = null
+      try
+        SourceScanner.scan("b") { scanner =>
+          secondScanner = scanner
+          throw captured
+        }
+      catch case error: Throwable => replayed = error
+
+      assert(
+        first == ScanResult.Failure(
+          ScanFailure(
+            exceeded = ScanLimitExceeded.OutputNodes(limit = NodeCount.one, attempted = NodeCount(2L)),
+            offset = SourceOffset.start,
+            phase = None
+          )
+        )
+      )
+      assert(replayed.eq(captured))
+      assert(closedMessage(secondScanner.offset).contains("scanner session is closed"))
+    }
+
+    "keeps ownership progress and lifecycle invariants when budgets are unbounded" in {
+      var foreign: ScanCheckpoint = null
+      SourceScanner.scan("a") { scanner => foreign = scanner.checkpoint() }
+
+      var retained: SourceScanner = null
+      var own: ScanCheckpoint     = null
+      val result                  = SourceScanner.scan("abc", ScanBudget.UnsafeUnbounded) { scanner =>
+        retained = scanner
+        own = scanner.checkpoint()
+        assert(rejectsArgument(scanner.restore(foreign)))
+
+        def nest(remaining: Int): Int =
+          if remaining == 0 then 0
+          else scanner.withNesting(nest(remaining - 1) + 1)
+
+        assert(nest(32) == 32)
+        scanner.chargeOutputNodes(NodeCount(1024L))
+        scanner.requireProgress(ScanPhase("unbounded parser")) {
+          scanner.advance()
+        }
+        scanner.offset
+      }
+
+      assert(result == ScanResult.Success(SourceOffset(1)))
+      assert(closedMessage(retained.restore(own)).contains("scanner session is closed"))
+    }
+
+    "rejects every new operation after the scanner closes" in {
+      var retained: SourceScanner    = null
+      var checkpoint: ScanCheckpoint = null
+      SourceScanner.scan("a") { scanner =>
+        retained = scanner
+        checkpoint = scanner.checkpoint()
+      }
+
+      val closed = "scanner session is closed"
+      assert(closedMessage(retained.checkpoint()).contains(closed))
+      assert(closedMessage(retained.restore(checkpoint)).contains(closed))
+      assert(closedMessage(retained.requireProgress(ScanPhase("parser"))(())).contains(closed))
+      assert(closedMessage(retained.withNesting(())).contains(closed))
+      assert(closedMessage(retained.chargeOutputNodes(NodeCount.one)).contains(closed))
     }
 
     "saturates work arithmetic at Long.MaxValue" in {

--- a/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceScannerTests.scala
+++ b/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceScannerTests.scala
@@ -748,4 +748,57 @@ class SourceScannerTests extends Test[Any]:
       assert(SourceScanner.wouldExceedNesting(1, 1))
       assert(SourceScanner.wouldExceedNesting(Int.MaxValue, Int.MaxValue))
     }
+
+    "snapshots immutable typed metrics including maximum nesting depth" in {
+      var retained: SourceScanner = null
+      val result                  = SourceScanner.scan("abc", ScanBudget.UnsafeUnbounded) { scanner =>
+        retained = scanner
+        val empty = scanner.metrics
+        scanner.chargeWork(WorkUnits(3L))
+        scanner.peek()
+        scanner.advance()
+        scanner.chargeOutputNodes(NodeCount(2L))
+        scanner.withNesting {
+          scanner.withNesting {
+            assert(
+              scanner.metrics == ScanMetrics(
+                work = WorkUnits(5L),
+                outputNodes = NodeCount(2L),
+                maximumNestingDepth = NestingDepth(2)
+              )
+            )
+          }
+        }
+        scanner.chargeWork(WorkUnits(1L))
+        (empty, scanner.metrics)
+      }
+
+      assert(
+        result == ScanResult.Success((
+          ScanMetrics(WorkUnits(0L), NodeCount(0L), NestingDepth(0)),
+          ScanMetrics(WorkUnits(6L), NodeCount(2L), NestingDepth(2))
+        ))
+      )
+      assert(closedMessage(retained.metrics).contains("scanner session is closed"))
+    }
+
+    "saturates unbounded metric counters without wrapping" in {
+      val result = SourceScanner.scan("", ScanBudget.UnsafeUnbounded) { scanner =>
+        scanner.chargeWork(WorkUnits(Long.MaxValue))
+        scanner.chargeWork(WorkUnits(1L))
+        scanner.chargeOutputNodes(NodeCount(Long.MaxValue))
+        scanner.chargeOutputNodes(NodeCount.one)
+        scanner.metrics
+      }
+
+      assert(
+        result == ScanResult.Success(
+          ScanMetrics(
+            work = WorkUnits(Long.MaxValue),
+            outputNodes = NodeCount(Long.MaxValue),
+            maximumNestingDepth = NestingDepth(0)
+          )
+        )
+      )
+    }
   }

--- a/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceScannerTests.scala
+++ b/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceScannerTests.scala
@@ -1,0 +1,203 @@
+package morphir.langkit.core.scanner
+
+import kyo.test.*
+import morphir.langkit.core.Span
+import scala.language.strictEquality
+
+class SourceScannerTests extends Test[Any]:
+
+  private def limited(input: Long, work: Long): ScanBudget.Limited =
+    ScanBudget.limited(
+      maxInputLength = InputSize.codeUnits(input),
+      maxWork = WorkUnits(work),
+      maxNestingDepth = NestingDepth(1),
+      maxOutputNodes = NodeCount.one
+    )
+
+  private def rejectsArgument(thunk: => Any): Boolean =
+    try
+      thunk
+      false
+    catch case _: IllegalArgumentException => true
+
+  private def rejectsIndex(thunk: => Any): Boolean =
+    try
+      thunk
+      false
+    catch case _: IndexOutOfBoundsException => true
+
+  private def closedMessage(thunk: => Any): Option[String] =
+    try
+      thunk
+      None
+    catch case error: IllegalStateException => Some(error.getMessage)
+
+  "SourceScanner" - {
+    "navigates and creates source views in typed UTF-16 coordinates" in {
+      val result = SourceScanner.scan("abc") { scanner =>
+        assert(scanner.source == "abc")
+        assert(scanner.offset == SourceOffset.start)
+        assert(!scanner.isAtEnd)
+        assert(scanner.peek().contains('a'))
+        assert(scanner.peek(CodeUnitCount(2)).contains('c'))
+        assert(scanner.peek(CodeUnitCount(3)).isEmpty)
+        val start = scanner.mark
+        scanner.advance(CodeUnitCount(2))
+        assert(scanner.viewFrom(start).text == "ab")
+        assert(scanner.remaining.span == Span(2, 1))
+        scanner.offset
+      }
+
+      assert(result == ScanResult.Success(SourceOffset(2)))
+    }
+
+    "rejects oversized input before invoking the callback" in {
+      var invoked = false
+      val budget  = limited(input = 3L, work = 1L)
+      val result  = SourceScanner.scan("abcd", budget) { _ =>
+        invoked = true
+      }
+
+      assert(!invoked)
+      assert(
+        result == ScanResult.Failure(
+          ScanFailure(
+            exceeded = ScanLimitExceeded.InputLength(
+              limit = InputSize.codeUnits(3L),
+              actual = InputSize.codeUnits(4L)
+            ),
+            offset = SourceOffset.start,
+            phase = None
+          )
+        )
+      )
+    }
+
+    "fails at the exact work boundary before the rejected operation" in {
+      val phase  = ScanPhase("test")
+      val result = SourceScanner.scan("abc", limited(input = 3L, work = 2L), Some(phase)) { scanner =>
+        scanner.peek()
+        scanner.advance()
+        scanner.peek()
+      }
+
+      assert(
+        result == ScanResult.Failure(
+          ScanFailure(
+            exceeded = ScanLimitExceeded.Work(limit = WorkUnits(2L), attempted = WorkUnits(3L)),
+            offset = SourceOffset(1),
+            phase = Some(phase)
+          )
+        )
+      )
+    }
+
+    "charges no work for EOF lookahead" in {
+      val result = SourceScanner.scan("a", limited(input = 1L, work = 1L)) { scanner =>
+        scanner.advance()
+        assert(scanner.peek().isEmpty)
+        assert(scanner.peek(CodeUnitCount(0)).isEmpty)
+        assert(scanner.peek(CodeUnitCount(1)).isEmpty)
+        assert(scanner.peek(CodeUnitCount(Int.MaxValue)).isEmpty)
+        scanner.offset
+      }
+
+      assert(result == ScanResult.Success(SourceOffset(1)))
+    }
+
+    "rejects movement past EOF without moving or charging" in {
+      val result = SourceScanner.scan("a", limited(input = 1L, work = 1L)) { scanner =>
+        assert(rejectsIndex(scanner.advance(CodeUnitCount(2))))
+        assert(scanner.offset == SourceOffset.start)
+        assert(scanner.peek().contains('a'))
+        scanner.offset
+      }
+
+      assert(result == ScanResult.Success(SourceOffset.start))
+    }
+
+    "propagates callback exceptions unchanged" in {
+      val expected          = new RuntimeException("callback failed")
+      var caught: Throwable = null
+
+      try SourceScanner.scan("a")(_ => throw expected)
+      catch case error: Throwable => caught = error
+
+      assert(caught.eq(expected))
+    }
+
+    "closes a retained scanner after its callback returns" in {
+      var retained: SourceScanner = null
+      assert(SourceScanner.scan("a") { scanner => retained = scanner } == ScanResult.Success(()))
+
+      val closed = "scanner session is closed"
+      assert(closedMessage(retained.source).contains(closed))
+      assert(closedMessage(retained.offset).contains(closed))
+      assert(closedMessage(retained.isAtEnd).contains(closed))
+      assert(closedMessage(retained.mark).contains(closed))
+      assert(closedMessage(retained.peek()).contains(closed))
+      assert(closedMessage(retained.peek(CodeUnitCount.one)).contains(closed))
+      assert(closedMessage(retained.advance()).contains(closed))
+      assert(closedMessage(retained.advance(CodeUnitCount.one)).contains(closed))
+      assert(closedMessage(retained.viewFrom(SourceOffset.start)).contains(closed))
+      assert(closedMessage(retained.view(Span.zero)).contains(closed))
+      assert(closedMessage(retained.remaining).contains(closed))
+    }
+
+    "preserves original UTF-16 coordinates including surrogate code units" in {
+      val source = "a\r\n\t\ud83d\ude00"
+      val result = SourceScanner.scan(source) { scanner =>
+        assert(scanner.peek(CodeUnitCount(4)).exists(_.isHighSurrogate))
+        assert(scanner.peek(CodeUnitCount(5)).exists(_.isLowSurrogate))
+        scanner.advance(CodeUnitCount(source.length))
+        scanner.offset
+      }
+
+      assert(result == ScanResult.Success(SourceOffset(source.length)))
+    }
+
+    "rejects invalid source-view ranges without cursor movement" in {
+      val result = SourceScanner.scan("abc") { scanner =>
+        scanner.advance()
+        assert(rejectsArgument(scanner.viewFrom(SourceOffset(2))))
+        assert(rejectsArgument(scanner.viewFrom(SourceOffset(4))))
+        assert(rejectsArgument(scanner.view(Span(-1, 1))))
+        assert(rejectsArgument(scanner.view(Span(0, -1))))
+        assert(rejectsArgument(scanner.view(Span(Int.MaxValue, 1))))
+        assert(rejectsArgument(scanner.view(Span(1, Int.MaxValue))))
+        scanner.offset
+      }
+
+      assert(result == ScanResult.Success(SourceOffset(1)))
+    }
+
+    "allows unbounded work while retaining movement invariants" in {
+      val bounded = SourceScanner.scan("a", limited(input = 1L, work = 1L)) { scanner =>
+        scanner.peek()
+        scanner.peek()
+      }
+      val unbounded = SourceScanner.scan("a", ScanBudget.UnsafeUnbounded) { scanner =>
+        scanner.peek()
+        scanner.peek()
+        assert(rejectsIndex(scanner.advance(CodeUnitCount(2))))
+        scanner.offset
+      }
+
+      assert(
+        bounded == ScanResult.Failure(
+          ScanFailure(
+            exceeded = ScanLimitExceeded.Work(limit = WorkUnits(1L), attempted = WorkUnits(2L)),
+            offset = SourceOffset.start,
+            phase = None
+          )
+        )
+      )
+      assert(unbounded == ScanResult.Success(SourceOffset.start))
+    }
+
+    "saturates work arithmetic at Long.MaxValue" in {
+      assert(SourceScanner.saturatingAdd(Long.MaxValue - 1L, 1L) == Long.MaxValue)
+      assert(SourceScanner.saturatingAdd(Long.MaxValue - 1L, 2L) == Long.MaxValue)
+      assert(SourceScanner.saturatingAdd(Long.MaxValue, 1L) == Long.MaxValue)
+    }
+  }

--- a/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceScannerTests.scala
+++ b/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceScannerTests.scala
@@ -101,6 +101,24 @@ class SourceScannerTests extends Test[Any]:
       assert(closedMessage(retained.offset).contains("scanner session is closed"))
     }
 
+    "charges explicit typed work at the exact boundary" in {
+      val phase  = ScanPhase("line-local inspection")
+      val result = SourceScanner.scan("", limited(input = 1L, work = 2L), Some(phase)) { scanner =>
+        scanner.chargeWork(WorkUnits(2L))
+        scanner.chargeWork(WorkUnits(1L))
+      }
+
+      assert(
+        result == ScanResult.Failure(
+          ScanFailure(
+            exceeded = ScanLimitExceeded.Work(limit = WorkUnits(2L), attempted = WorkUnits(3L)),
+            offset = SourceOffset.start,
+            phase = Some(phase)
+          )
+        )
+      )
+    }
+
     "returns the first work failure when the callback swallows exhaustion" in {
       val result = SourceScanner.scan("a", limited(input = 1L, work = 1L)) { scanner =>
         scanner.peek()
@@ -228,6 +246,7 @@ class SourceScannerTests extends Test[Any]:
       assert(closedMessage(retained.peek(CodeUnitCount.one)).contains(closed))
       assert(closedMessage(retained.advance()).contains(closed))
       assert(closedMessage(retained.advance(CodeUnitCount.one)).contains(closed))
+      assert(closedMessage(retained.chargeWork(WorkUnits(1L))).contains(closed))
       assert(closedMessage(retained.viewFrom(SourceOffset.start)).contains(closed))
       assert(closedMessage(retained.view(Span.zero)).contains(closed))
       assert(closedMessage(retained.remaining).contains(closed))

--- a/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceScannerTests.scala
+++ b/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceScannerTests.scala
@@ -15,10 +15,10 @@ class SourceScannerTests extends Test[Any]:
       output: Long = 1L
   ): ScanBudget.Limited =
     ScanBudget.limited(
-      maxInputLength = InputSize.codeUnits(input),
-      maxWork = WorkUnits(work),
-      maxNestingDepth = NestingDepth(nesting),
-      maxOutputNodes = NodeCount(output)
+      maxInputLength = InputSize.fromCodeUnits(input).getOrThrow,
+      maxWork = WorkUnits.from(work).getOrThrow,
+      maxNestingDepth = NestingDepth.from(nesting).getOrThrow,
+      maxOutputNodes = NodeCount.from(output).getOrThrow
     ).getOrThrow
 
   private def rejectsArgument(thunk: => Any): Boolean =
@@ -74,7 +74,7 @@ class SourceScannerTests extends Test[Any]:
               actual = InputSize.codeUnits(4L)
             ),
             offset = SourceOffset.start,
-            phase = None
+            phase = Absent
           )
         )
       )
@@ -83,7 +83,7 @@ class SourceScannerTests extends Test[Any]:
     "fails at the exact work boundary before the rejected operation" in {
       val phase                   = ScanPhase("test")
       var retained: SourceScanner = null
-      val result                  = SourceScanner.scan("abc", limited(input = 3L, work = 2L), Some(phase)) { scanner =>
+      val result = SourceScanner.scan("abc", limited(input = 3L, work = 2L), Present(phase)) { scanner =>
         retained = scanner
         scanner.peek()
         scanner.advance()
@@ -95,7 +95,7 @@ class SourceScannerTests extends Test[Any]:
           ScanFailure(
             exceeded = ScanLimitExceeded.Work(limit = WorkUnits(2L), attempted = WorkUnits(3L)),
             offset = SourceOffset(1),
-            phase = Some(phase)
+            phase = Present(phase)
           )
         )
       )
@@ -104,7 +104,7 @@ class SourceScannerTests extends Test[Any]:
 
     "charges explicit typed work at the exact boundary" in {
       val phase  = ScanPhase("line-local inspection")
-      val result = SourceScanner.scan("", limited(input = 1L, work = 2L), Some(phase)) { scanner =>
+      val result = SourceScanner.scan("", limited(input = 1L, work = 2L), Present(phase)) { scanner =>
         scanner.chargeWork(WorkUnits(2L))
         scanner.chargeWork(WorkUnits(1L))
       }
@@ -114,7 +114,7 @@ class SourceScannerTests extends Test[Any]:
           ScanFailure(
             exceeded = ScanLimitExceeded.Work(limit = WorkUnits(2L), attempted = WorkUnits(3L)),
             offset = SourceOffset.start,
-            phase = Some(phase)
+            phase = Present(phase)
           )
         )
       )
@@ -133,7 +133,7 @@ class SourceScannerTests extends Test[Any]:
           ScanFailure(
             exceeded = ScanLimitExceeded.Work(limit = WorkUnits(1L), attempted = WorkUnits(2L)),
             offset = SourceOffset.start,
-            phase = None
+            phase = Absent
           )
         )
       )
@@ -188,7 +188,7 @@ class SourceScannerTests extends Test[Any]:
           ScanFailure(
             exceeded = ScanLimitExceeded.Work(limit = WorkUnits(1L), attempted = WorkUnits(2L)),
             offset = SourceOffset.start,
-            phase = None
+            phase = Absent
           )
         )
       )
@@ -312,7 +312,7 @@ class SourceScannerTests extends Test[Any]:
           ScanFailure(
             exceeded = ScanLimitExceeded.Work(limit = WorkUnits(1L), attempted = WorkUnits(2L)),
             offset = SourceOffset.start,
-            phase = None
+            phase = Absent
           )
         )
       )
@@ -336,7 +336,7 @@ class SourceScannerTests extends Test[Any]:
           ScanFailure(
             exceeded = ScanLimitExceeded.Work(limit = WorkUnits(4L), attempted = WorkUnits(5L)),
             offset = SourceOffset(2),
-            phase = None
+            phase = Absent
           )
         )
       )
@@ -480,7 +480,7 @@ class SourceScannerTests extends Test[Any]:
     "enforces nesting at the exact boundary without entering rejected work" in {
       val phase        = ScanPhase("nested parser")
       var innerEntered = false
-      val result       = SourceScanner.scan("a", limited(input = 1L, work = 10L), Some(phase)) { scanner =>
+      val result       = SourceScanner.scan("a", limited(input = 1L, work = 10L), Present(phase)) { scanner =>
         scanner.withNesting {
           scanner.withNesting {
             innerEntered = true
@@ -492,9 +492,10 @@ class SourceScannerTests extends Test[Any]:
       assert(
         result == ScanResult.Failure(
           ScanFailure(
-            exceeded = ScanLimitExceeded.Nesting(limit = NestingDepth(1), attempted = NestingDepth(2)),
+            exceeded =
+              ScanLimitExceeded.Nesting(limit = NestingDepth(1), attempted = NestingDepth(2)),
             offset = SourceOffset.start,
-            phase = Some(phase)
+            phase = Present(phase)
           )
         )
       )
@@ -517,7 +518,7 @@ class SourceScannerTests extends Test[Any]:
       val phase             = ScanPhase("output builder")
       var first: Throwable  = null
       var second: Throwable = null
-      val result = SourceScanner.scan("a", limited(input = 1L, work = 10L, output = 2L), Some(phase)) { scanner =>
+      val result = SourceScanner.scan("a", limited(input = 1L, work = 10L, output = 2L), Present(phase)) { scanner =>
         scanner.chargeOutputNodes(NodeCount(2L))
         scanner.chargeOutputNodes(NodeCount(0L))
         try scanner.chargeOutputNodes(NodeCount.one)
@@ -531,9 +532,10 @@ class SourceScannerTests extends Test[Any]:
       assert(
         result == ScanResult.Failure(
           ScanFailure(
-            exceeded = ScanLimitExceeded.OutputNodes(limit = NodeCount(2L), attempted = NodeCount(3L)),
+            exceeded =
+              ScanLimitExceeded.OutputNodes(limit = NodeCount(2L), attempted = NodeCount(3L)),
             offset = SourceOffset.start,
-            phase = Some(phase)
+            phase = Present(phase)
           )
         )
       )
@@ -559,7 +561,7 @@ class SourceScannerTests extends Test[Any]:
               attempted = NodeCount(Long.MaxValue)
             ),
             offset = SourceOffset.start,
-            phase = None
+            phase = Absent
           )
         )
       )
@@ -587,9 +589,10 @@ class SourceScannerTests extends Test[Any]:
       assert(
         first == ScanResult.Failure(
           ScanFailure(
-            exceeded = ScanLimitExceeded.Nesting(limit = NestingDepth(1), attempted = NestingDepth(2)),
+            exceeded =
+              ScanLimitExceeded.Nesting(limit = NestingDepth(1), attempted = NestingDepth(2)),
             offset = SourceOffset.start,
-            phase = None
+            phase = Absent
           )
         )
       )
@@ -620,7 +623,7 @@ class SourceScannerTests extends Test[Any]:
           ScanFailure(
             exceeded = ScanLimitExceeded.OutputNodes(limit = NodeCount.one, attempted = NodeCount(2L)),
             offset = SourceOffset.start,
-            phase = None
+            phase = Absent
           )
         )
       )
@@ -693,11 +696,11 @@ class SourceScannerTests extends Test[Any]:
         workLimited == ScanResult.Failure(
           ScanFailure(
             exceeded = ScanLimitExceeded.Work(
-              limit = WorkUnits(repetitions.toLong - 1L),
-              attempted = WorkUnits(repetitions.toLong)
+              limit = WorkUnits.from(repetitions.toLong - 1L).getOrThrow,
+              attempted = WorkUnits.from(repetitions.toLong).getOrThrow
             ),
             offset = SourceOffset.start,
-            phase = None
+            phase = Absent
           )
         )
       )
@@ -705,11 +708,11 @@ class SourceScannerTests extends Test[Any]:
         outputLimited == ScanResult.Failure(
           ScanFailure(
             exceeded = ScanLimitExceeded.OutputNodes(
-              limit = NodeCount(repetitions.toLong - 1L),
-              attempted = NodeCount(repetitions.toLong)
+              limit = NodeCount.from(repetitions.toLong - 1L).getOrThrow,
+              attempted = NodeCount.from(repetitions.toLong).getOrThrow
             ),
             offset = SourceOffset.start,
-            phase = None
+            phase = Absent
           )
         )
       )

--- a/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceScannerTests.scala
+++ b/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceScannerTests.scala
@@ -409,6 +409,44 @@ class SourceScannerTests extends Test[Any]:
       assert(restoredMessage == "block parser made no progress")
     }
 
+    "rejects parser phases that restore from offset one to an earlier offset" in {
+      val phase                   = ScanPhase("backtracking parser")
+      var backwardMessage: String = null
+      val result                  = SourceScanner.scan("ab") { scanner =>
+        val earlier = scanner.checkpoint()
+        scanner.advance()
+        try scanner.requireProgress(phase)(scanner.restore(earlier))
+        catch case error: IllegalStateException => backwardMessage = error.getMessage
+        scanner.offset
+      }
+
+      assert(result == ScanResult.Success(SourceOffset.start))
+      assert(backwardMessage == "backtracking parser made no progress")
+    }
+
+    "rejects both backward legs when alternating between checkpoints" in {
+      val phase                  = ScanPhase("alternating parser")
+      var firstBackward: String  = null
+      var secondBackward: String = null
+      val result                 = SourceScanner.scan("ab") { scanner =>
+        val zero = scanner.checkpoint()
+        scanner.advance()
+        val one = scanner.checkpoint()
+
+        try scanner.requireProgress(phase)(scanner.restore(zero))
+        catch case error: IllegalStateException => firstBackward = error.getMessage
+
+        scanner.requireProgress(phase)(scanner.restore(one))
+
+        try scanner.requireProgress(phase)(scanner.restore(zero))
+        catch case error: IllegalStateException => secondBackward = error.getMessage
+      }
+
+      assert(result == ScanResult.Success(()))
+      assert(firstBackward == "alternating parser made no progress")
+      assert(secondBackward == "alternating parser made no progress")
+    }
+
     "propagates requireProgress operation exceptions unchanged" in {
       val expected          = new RuntimeException("phase failed")
       var caught: Throwable = null
@@ -597,6 +635,67 @@ class SourceScannerTests extends Test[Any]:
       assert(closedMessage(retained.restore(own)).contains("scanner session is closed"))
     }
 
+    "sustains repeated work and output charges only when unbounded" in {
+      val repetitions = 10000
+      val workLimited = SourceScanner.scan(
+        "a",
+        limited(input = 1L, work = repetitions.toLong - 1L, output = repetitions.toLong)
+      ) { scanner =>
+        var index = 0
+        while index < repetitions do
+          scanner.peek()
+          index += 1
+      }
+      val outputLimited = SourceScanner.scan(
+        "a",
+        limited(input = 1L, work = repetitions.toLong, output = repetitions.toLong - 1L)
+      ) { scanner =>
+        var index = 0
+        while index < repetitions do
+          scanner.chargeOutputNodes(NodeCount.one)
+          index += 1
+      }
+      val unbounded = SourceScanner.scan("a", ScanBudget.UnsafeUnbounded) { scanner =>
+        var workIndex = 0
+        while workIndex < repetitions do
+          scanner.peek()
+          workIndex += 1
+
+        var outputIndex = 0
+        while outputIndex < repetitions do
+          scanner.chargeOutputNodes(NodeCount.one)
+          outputIndex += 1
+
+        (workIndex, outputIndex)
+      }
+
+      assert(
+        workLimited == ScanResult.Failure(
+          ScanFailure(
+            exceeded = ScanLimitExceeded.Work(
+              limit = WorkUnits(repetitions.toLong - 1L),
+              attempted = WorkUnits(repetitions.toLong)
+            ),
+            offset = SourceOffset.start,
+            phase = None
+          )
+        )
+      )
+      assert(
+        outputLimited == ScanResult.Failure(
+          ScanFailure(
+            exceeded = ScanLimitExceeded.OutputNodes(
+              limit = NodeCount(repetitions.toLong - 1L),
+              attempted = NodeCount(repetitions.toLong)
+            ),
+            offset = SourceOffset.start,
+            phase = None
+          )
+        )
+      )
+      assert(unbounded == ScanResult.Success((repetitions, repetitions)))
+    }
+
     "rejects every new operation after the scanner closes" in {
       var retained: SourceScanner    = null
       var checkpoint: ScanCheckpoint = null
@@ -623,5 +722,11 @@ class SourceScannerTests extends Test[Any]:
       assert(!SourceScanner.wouldExceedLimit(0L, Long.MaxValue, Long.MaxValue))
       assert(!SourceScanner.wouldExceedLimit(Long.MaxValue - 1L, 1L, Long.MaxValue))
       assert(SourceScanner.wouldExceedLimit(Long.MaxValue, 1L, Long.MaxValue))
+    }
+
+    "detects saturated nesting attempts without incrementing Int.MaxValue" in {
+      assert(!SourceScanner.wouldExceedNesting(0, 1))
+      assert(SourceScanner.wouldExceedNesting(1, 1))
+      assert(SourceScanner.wouldExceedNesting(Int.MaxValue, Int.MaxValue))
     }
   }

--- a/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceViewTests.scala
+++ b/morphir/langkit/core/test/src/morphir/langkit/core/scanner/SourceViewTests.scala
@@ -1,0 +1,74 @@
+package morphir.langkit.core.scanner
+
+import kyo.test.*
+import morphir.langkit.core.Span
+import scala.language.strictEquality
+
+class SourceViewTests extends Test[Any]:
+
+  private def rejects(thunk: => Any): Boolean =
+    try
+      thunk
+      false
+    catch case _: IllegalArgumentException => true
+
+  private def rejectsIndex(thunk: => Any): Boolean =
+    try
+      thunk
+      false
+    catch case _: IndexOutOfBoundsException => true
+
+  "SourceView" - {
+    "retains its source and exposes typed boundaries without materializing text" in {
+      val source = "alpha beta"
+      val span   = Span(6, 4)
+      val view   = SourceView.fromSpan(source, span)
+
+      assert(view.source.eq(source))
+      assert(view.span == span)
+      assert(view.start == SourceOffset(6))
+      assert(view.end == SourceOffset(10))
+      assert(view.length == CodeUnitCount(4))
+      assert(view.charAt(CodeUnitCount(0)) == 'b')
+      assert(view.charAt(CodeUnitCount(3)) == 'a')
+      assert(view.text == "beta")
+    }
+
+    "accepts an empty view at the end of the source" in {
+      val view = SourceView.fromSpan("alpha", Span(5, 0))
+
+      assert(view.isEmpty)
+      assert(!view.nonEmpty)
+      assert(view.text.isEmpty)
+    }
+
+    "rejects a negative span offset" in
+      assert(rejects(SourceView.fromSpan("alpha", Span(-1, 1))))
+
+    "rejects a negative span length" in
+      assert(rejects(SourceView.fromSpan("alpha", Span(0, -1))))
+
+    "rejects a span extending beyond the source" in
+      assert(rejects(SourceView.fromSpan("alpha", Span(4, 2))))
+
+    "rejects a relative offset exactly at the view length" in {
+      val view = SourceView.fromSpan("alpha beta", Span(6, 4))
+      assert(rejectsIndex(view.charAt(CodeUnitCount(4))))
+    }
+
+    "uses UTF-16 code units for lengths and character access" in {
+      val source = "\ud83d\ude00"
+      val view   = SourceView.fromSpan(source, Span(0, 2))
+
+      assert(view.length == CodeUnitCount(2))
+      assert(view.charAt(CodeUnitCount(0)) == source.charAt(0))
+      assert(view.charAt(CodeUnitCount(1)) == source.charAt(1))
+      assert(view.charAt(CodeUnitCount(0)).isHighSurrogate)
+      assert(view.charAt(CodeUnitCount(1)).isLowSurrogate)
+    }
+
+    "supports strict equality for equivalent views" in {
+      val source = "alpha"
+      assert(SourceView.fromSpan(source, Span(1, 3)) == SourceView.fromSpan(source, Span(1, 3)))
+    }
+  }

--- a/morphir/langkit/markdown/README.md
+++ b/morphir/langkit/markdown/README.md
@@ -20,6 +20,37 @@ Parser.parse("# Title\n\nHello") match
   case kyo.Result.Failure(err) => throw err
 ```
 
+## Parser budgets
+
+`Parser.parse` uses `ScanBudget.default`, which bounds input length, deterministic scanner work, nesting, and emitted
+nodes. Resource exhaustion is returned as `Result.Failure(ParseError.Scan(...))`, with the exact typed limit and
+UTF-16 source offset:
+
+```scala
+import morphir.langkit.core.scanner.*
+import morphir.langkit.markdown.*
+
+val safe = Parser.parse(source)
+
+val smallerBudget = ScanBudget.limited(
+  maxInputLength = InputSize.mebibytes(1),
+  maxWork = WorkUnits(8L * 1024L * 1024L),
+  maxNestingDepth = NestingDepth(128),
+  maxOutputNodes = NodeCount(100000L)
+)
+val limited = Parser.parse(source, smallerBudget)
+```
+
+Trusted callers can explicitly remove the ceilings:
+
+```scala
+val unsafe = Parser.parse(source, ScanBudget.UnsafeUnbounded)
+```
+
+`UnsafeUnbounded` is not the safe path. Use it only when the caller independently controls input size and execution
+isolation and accepts responsibility for resource containment. It does not change parse results or relax scanner
+cursor and progress invariants; it only removes the resource limits.
+
 ## Fenced code info
 
 CommonMark treats the fence info string as opaque. `FenceInfo` keeps that string as `raw` and derives conventions

--- a/morphir/langkit/markdown/README.md
+++ b/morphir/langkit/markdown/README.md
@@ -51,6 +51,11 @@ val unsafe = Parser.parse(source, ScanBudget.UnsafeUnbounded)
 isolation and accepts responsibility for resource containment. It does not change parse results or relax scanner
 cursor and progress invariants; it only removes the resource limits.
 
+The output-node budget includes the document, emitted blocks, and a conservative eight-unit reservation for every
+fenced-code metadata token. Metadata reservations happen before token materialization and cover retained token text,
+token-list linkage, and derived arguments, flags, classes, and attributes. This prevents whitespace-heavy fence info
+strings from amplifying into an unbounded metadata collection.
+
 ## Fenced code info
 
 CommonMark treats the fence info string as opaque. `FenceInfo` keeps that string as `raw` and derives conventions

--- a/morphir/langkit/markdown/README.md
+++ b/morphir/langkit/markdown/README.md
@@ -10,7 +10,8 @@ later if one compiles on JVM, JS, and Native.
 
 `org.finos.morphir::morphir-langkit-markdown` — JVM, Scala.js, and Scala Native.
 
-Depends on `morphir-langkit-core` for `Span`. A `QueryableTree` instance is later work against `morphir-langkit-trees`.
+Depends on `morphir-langkit-core` and Kyo Core; core brings Morphir Prelude for its typed exception hierarchy. A
+`QueryableTree` instance is later work against `morphir-langkit-trees`.
 
 ```scala
 import morphir.langkit.markdown.*
@@ -27,19 +28,28 @@ nodes. Resource exhaustion is returned as `Result.Failure(ParseError.Scan(...))`
 UTF-16 source offset:
 
 ```scala
+import kyo.Result
 import morphir.langkit.core.scanner.*
 import morphir.langkit.markdown.*
 
 val safe = Parser.parse(source)
 
-val smallerBudget = ScanBudget.limited(
+ScanBudget.limited(
   maxInputLength = InputSize.mebibytes(1),
   maxWork = WorkUnits(8L * 1024L * 1024L),
   maxNestingDepth = NestingDepth(128),
   maxOutputNodes = NodeCount(100000L)
-)
-val limited = Parser.parse(source, smallerBudget)
+) match
+  case Result.Success(smallerBudget) =>
+    val limited = Parser.parse(source, smallerBudget)
+  case Result.Failure(error) =>
+    // Report invalid caller-supplied configuration; no parse occurs.
+  case Result.Panic(error) =>
+    // Handle an unexpected panic; no parse occurs.
 ```
+
+Invalid limits return a typed `ScanBudgetError` in `Result.Failure`; they do not throw. Keep caller-supplied
+configuration in this result-handling path rather than unwrapping it.
 
 Trusted callers can explicitly remove the ceilings:
 

--- a/morphir/langkit/markdown/README.md
+++ b/morphir/langkit/markdown/README.md
@@ -10,8 +10,8 @@ later if one compiles on JVM, JS, and Native.
 
 `org.finos.morphir::morphir-langkit-markdown` — JVM, Scala.js, and Scala Native.
 
-Depends on `morphir-langkit-core` and Kyo Core; core brings Morphir Prelude for its typed exception hierarchy. A
-`QueryableTree` instance is later work against `morphir-langkit-trees`.
+Depends on `morphir-langkit-core`, Morphir Prelude, and Kyo Core. A `QueryableTree` instance is later work against
+`morphir-langkit-trees`.
 
 ```scala
 import morphir.langkit.markdown.*
@@ -19,6 +19,7 @@ import morphir.langkit.markdown.*
 Parser.parse("# Title\n\nHello") match
   case kyo.Result.Success(doc) => doc.blocks
   case kyo.Result.Failure(err) => throw err
+  case kyo.Result.Panic(err)   => throw err
 ```
 
 ## Parser budgets
@@ -34,12 +35,14 @@ import morphir.langkit.markdown.*
 
 val safe = Parser.parse(source)
 
-ScanBudget.limited(
-  maxInputLength = InputSize.mebibytes(1),
+val compiledBudget = ScanBudget.limited(
+  maxInputLength = InputSize.megabytes(1),
   maxWork = WorkUnits(8L * 1024L * 1024L),
   maxNestingDepth = NestingDepth(128),
   maxOutputNodes = NodeCount(100000L)
-) match
+)
+
+compiledBudget match
   case Result.Success(smallerBudget) =>
     val limited = Parser.parse(source, smallerBudget)
   case Result.Failure(error) =>
@@ -48,8 +51,12 @@ ScanBudget.limited(
     // Handle an unexpected panic; no parse occurs.
 ```
 
-Invalid limits return a typed `ScanBudgetError` in `Result.Failure`; they do not throw. Keep caller-supplied
-configuration in this result-handling path rather than unwrapping it.
+Literal measures are checked by an inline macro; an invalid constant fails compilation. Dynamic values go through
+`fromCodeUnits`, `fromMegabytes` (and the other `from*` size constructors), and `from`, and return `Result`. Invalid
+budget ceilings still return a typed
+`ScanBudgetError` in `Result.Failure`; they do not throw. Keep caller-supplied configuration in this result-handling
+path rather than unwrapping it. Zero is a valid measure and an invalid ceiling: `InputSize.codeUnits(0)` is a valid
+size, and `ScanBudget.limited` then fails with `NonPositiveInputLength`.
 
 Trusted callers can explicitly remove the ceilings:
 

--- a/morphir/langkit/markdown/package.mill.yaml
+++ b/morphir/langkit/markdown/package.mill.yaml
@@ -2,19 +2,19 @@ extends: Module
 
 object jvm:
   extends: [build.MorphirJVMModule, build.MorphirPublishModule, build.MorphirKyoCoreMvnDeps]
-  moduleDeps: [build.morphir.langkit.core.jvm]
+  moduleDeps: [build.morphir.langkit.core.jvm, build.morphir.prelude.jvm]
   object test:
     extends: [ScalaTests, millbuild.KyoTest, build.MorphirKyoTestMvnDeps]
 
 object js:
   extends: [build.MorphirJSModule, build.MorphirPublishModule, build.MorphirKyoCoreMvnDeps]
-  moduleDeps: [build.morphir.langkit.core.js]
+  moduleDeps: [build.morphir.langkit.core.js, build.morphir.prelude.js]
   object test:
     extends: [ScalaJSTests, build.MorphirJSTestNoSourceMap, millbuild.KyoTestJS, build.MorphirKyoTestMvnDeps]
 
 object native:
   extends: [build.MorphirNativeModule, build.MorphirPublishModule, build.MorphirKyoCoreMvnDeps]
-  moduleDeps: [build.morphir.langkit.core.native]
+  moduleDeps: [build.morphir.langkit.core.native, build.morphir.prelude.native]
   object test:
     extends: [ScalaNativeTests, millbuild.KyoTestNative, build.MorphirKyoTestMvnDeps]
     mvnDeps: !append

--- a/morphir/langkit/markdown/src/morphir/langkit/markdown/FenceInfo.scala
+++ b/morphir/langkit/markdown/src/morphir/langkit/markdown/FenceInfo.scala
@@ -1,6 +1,7 @@
 package morphir.langkit.markdown
 
 import kyo.*
+import morphir.langkit.core.scanner.*
 
 /**
  * Structured view of a CommonMark fenced-code info string.
@@ -21,6 +22,11 @@ sealed abstract case class FenceInfo private[markdown] (
 
 object FenceInfo:
 
+  /** Covers token text, token-list linkage, and derived metadata collection retention. */
+  private[markdown] val TokenOutputReservation: NodeCount = NodeCount(8L)
+
+  private val WorkUnitsPerCodeUnit = 8L
+
   val empty: FenceInfo =
     make(
       raw = "",
@@ -34,10 +40,17 @@ object FenceInfo:
 
   /** Derive structured fields from a CommonMark info string. Never fails the fence. */
   def parse(raw: String): FenceInfo =
+    parseWithReservation(raw)(() => ())
+
+  private[markdown] def parseBudgeted(raw: String, scanner: SourceScanner): FenceInfo =
+    scanner.chargeWork(WorkUnits(raw.length.toLong * WorkUnitsPerCodeUnit))
+    parseWithReservation(raw)(() => scanner.chargeOutputNodes(TokenOutputReservation))
+
+  private def parseWithReservation(raw: String)(reserveToken: () => Unit): FenceInfo =
     val trimmed = trimSpacesOrTabs(raw)
     if trimmed.isEmpty then empty
-    else if trimmed.charAt(0) == '{' then parseBraceLed(trimmed)
-    else parseBareLed(trimmed)
+    else if trimmed.charAt(0) == '{' then parseBraceLed(trimmed, reserveToken)
+    else parseBareLed(trimmed, reserveToken)
 
   extension (self: FenceInfo)
     def tokens: Chunk[String] =
@@ -64,10 +77,10 @@ object FenceInfo:
   ): FenceInfo =
     new FenceInfo(raw, language, args, id, classes, attributes, flags) {}
 
-  private def parseBraceLed(raw: String): FenceInfo =
+  private def parseBraceLed(raw: String, reserveToken: () => Unit): FenceInfo =
     extractBalancedBrace(raw) match
       case Present((contents = contents, rest = rest)) if isSpacesOrTabs(rest) =>
-        val attrs = parsePandocAttrs(contents, promoteFirstClass = true)
+        val attrs = parsePandocAttrs(contents, promoteFirstClass = true, reserveToken)
         make(
           raw = raw,
           language = attrs.language,
@@ -88,14 +101,14 @@ object FenceInfo:
           flags = Chunk.empty
         )
 
-  private def parseBareLed(raw: String): FenceInfo =
+  private def parseBareLed(raw: String, reserveToken: () => Unit): FenceInfo =
     splitTrailingBrace(raw) match
       case (cli = cli, brace = brace) =>
-        val cliTokens = splitTokens(cli)
+        val cliTokens = splitTokens(cli, reserveToken)
         if cliTokens.isEmpty then
           brace match
             case Present(contents) =>
-              val attrs = parsePandocAttrs(contents, promoteFirstClass = true)
+              val attrs = parsePandocAttrs(contents, promoteFirstClass = true, reserveToken)
               make(
                 raw = raw,
                 language = attrs.language,
@@ -127,7 +140,7 @@ object FenceInfo:
               case Absent        => flagsBuilder += token
           }
           val braceAttrs = brace match
-            case Present(contents) => parsePandocAttrs(contents, promoteFirstClass = false)
+            case Present(contents) => parsePandocAttrs(contents, promoteFirstClass = false, reserveToken)
             case Absent            => PandocAttrs.empty
           make(
             raw = raw,
@@ -156,8 +169,12 @@ object FenceInfo:
    *   [[FenceInfo.classes]]; when false (trailing braces after a bare language), every class stays in
    *   [[FenceInfo.classes]].
    */
-  private def parsePandocAttrs(contents: String, promoteFirstClass: Boolean): PandocAttrs =
-    val tokens   = splitTokens(contents)
+  private def parsePandocAttrs(
+      contents: String,
+      promoteFirstClass: Boolean,
+      reserveToken: () => Unit
+  ): PandocAttrs =
+    val tokens   = splitTokens(contents, reserveToken)
     var id       = Option.empty[String]
     val classBuf = List.newBuilder[String]
     val attrBuf  = List.newBuilder[(key: String, value: String)]
@@ -249,7 +266,7 @@ object FenceInfo:
       else value
     else value
 
-  private def splitTokens(text: String): List[String] =
+  private def splitTokens(text: String, reserveToken: () => Unit): List[String] =
     val result = List.newBuilder[String]
     var i      = 0
     while i < text.length do
@@ -259,12 +276,14 @@ object FenceInfo:
         val first = text.charAt(i)
         if first == '"' || first == '\'' then
           i = skipQuoted(text, i)
+          reserveToken()
           result += text.substring(start, i)
         else
           while i < text.length && !isSpaceOrTab(text.charAt(i)) do
             if text.charAt(i) == '=' && i + 1 < text.length && isQuote(text.charAt(i + 1)) then
               i = skipQuoted(text, i + 1)
             else i += 1
+          reserveToken()
           result += text.substring(start, i)
     result.result()
 

--- a/morphir/langkit/markdown/src/morphir/langkit/markdown/FenceInfo.scala
+++ b/morphir/langkit/markdown/src/morphir/langkit/markdown/FenceInfo.scala
@@ -43,7 +43,7 @@ object FenceInfo:
     parseWithReservation(raw)(() => ())
 
   private[markdown] def parseBudgeted(raw: String, scanner: SourceScanner): FenceInfo =
-    scanner.chargeWork(WorkUnits(raw.length.toLong * WorkUnitsPerCodeUnit))
+    scanner.chargeWork(WorkUnits.from(raw.length.toLong * WorkUnitsPerCodeUnit).getOrThrow)
     parseWithReservation(raw)(() => scanner.chargeOutputNodes(TokenOutputReservation))
 
   private def parseWithReservation(raw: String)(reserveToken: () => Unit): FenceInfo =

--- a/morphir/langkit/markdown/src/morphir/langkit/markdown/ParseError.scala
+++ b/morphir/langkit/markdown/src/morphir/langkit/markdown/ParseError.scala
@@ -1,9 +1,10 @@
 package morphir.langkit.markdown
 
+import morphir.MorphirException
 import morphir.langkit.core.scanner.*
 
 /** A failure from the markdown parser. */
-sealed abstract class ParseError(val message: String) extends Exception(message)
+sealed abstract class ParseError(val message: String) extends MorphirException(message)
 
 object ParseError:
   final case class Syntax(override val message: String) extends ParseError(message)

--- a/morphir/langkit/markdown/src/morphir/langkit/markdown/ParseError.scala
+++ b/morphir/langkit/markdown/src/morphir/langkit/markdown/ParseError.scala
@@ -1,5 +1,6 @@
 package morphir.langkit.markdown
 
+import kyo.*
 import morphir.MorphirException
 import morphir.langkit.core.scanner.*
 

--- a/morphir/langkit/markdown/src/morphir/langkit/markdown/ParseError.scala
+++ b/morphir/langkit/markdown/src/morphir/langkit/markdown/ParseError.scala
@@ -3,14 +3,14 @@ package morphir.langkit.markdown
 import morphir.langkit.core.scanner.*
 
 /** A failure from the markdown parser. */
-sealed abstract class ParseError(message: String) extends Exception(message)
+sealed abstract class ParseError(val message: String) extends Exception(message)
 
 object ParseError:
-  final case class Syntax(message: String) extends ParseError(message)
+  final case class Syntax(override val message: String) extends ParseError(message)
 
   final case class Scan(error: ScanFailure) extends ParseError(renderScanFailure(error))
 
-  def apply(message: String): ParseError = Syntax(message)
+  def apply(message: String): Syntax = Syntax(message)
 
   def unapply(error: ParseError): Some[String] = Some(error.getMessage)
 

--- a/morphir/langkit/markdown/src/morphir/langkit/markdown/ParseError.scala
+++ b/morphir/langkit/markdown/src/morphir/langkit/markdown/ParseError.scala
@@ -1,4 +1,19 @@
 package morphir.langkit.markdown
 
+import morphir.langkit.core.scanner.*
+
 /** A failure from the markdown parser. */
-final case class ParseError(message: String) extends Exception(message)
+sealed abstract class ParseError(message: String) extends Exception(message)
+
+object ParseError:
+  final case class Syntax(message: String) extends ParseError(message)
+
+  final case class Scan(error: ScanFailure) extends ParseError(renderScanFailure(error))
+
+  def apply(message: String): ParseError = Syntax(message)
+
+  def unapply(error: ParseError): Some[String] = Some(error.getMessage)
+
+  private def renderScanFailure(error: ScanFailure): String =
+    val renderedPhase = error.phase.fold("")(phase => s" during ${phase.value}")
+    s"Markdown scan failed at offset ${error.offset.toInt}$renderedPhase: ${error.exceeded}"

--- a/morphir/langkit/markdown/src/morphir/langkit/markdown/Parser.scala
+++ b/morphir/langkit/markdown/src/morphir/langkit/markdown/Parser.scala
@@ -12,116 +12,156 @@ import morphir.langkit.core.scanner.*
  */
 object Parser:
 
+  private val BlocksPhase = ScanPhase("markdown.blocks")
+  private val LinesPhase  = ScanPhase("markdown.lines")
+
   def parse(source: String, budget: ScanBudget = ScanBudget.default): Result[ParseError, Document] =
-    SourceScanner.scan(source, budget, phase = Some(ScanPhase("markdown.blocks"))) { scanner =>
-      // Task 6 replaces this materialization with scanner-backed block parsing.
-      val blocks = parseBlocks(scanner.remaining.text)
-      scanner.chargeOutputNodes(NodeCount(blocks.size.toLong + 1L))
+    SourceScanner.scan(source, budget, phase = Some(BlocksPhase)) { scanner =>
+      scanner.chargeOutputNodes(NodeCount.one)
+      val blocks = parseBlocks(scanner)
       // Keep the caller's coordinate space: do not rewrite CRLF before measuring spans.
       Document(blocks, Span(0, source.length))
     } match
       case ScanResult.Success(document) => Result.succeed(document)
       case ScanResult.Failure(error)    => Result.fail(ParseError.Scan(error))
 
-  private final case class Line(offset: Int, text: String)
+  private final case class Line(view: SourceView, text: String, terminatedByLf: Boolean):
+    def offset: Int = view.start.toInt
+    def end: Int    = view.end.toInt
+    def length: Int = view.length.toInt
 
-  private def parseBlocks(source: String): Chunk[Block] =
-    val lines  = splitLines(source)
+  private def parseBlocks(scanner: SourceScanner): Chunk[Block] =
     val blocks = List.newBuilder[Block]
-    var i      = 0
-    while i < lines.length do
-      val line = lines(i)
-      if line.text.trim.isEmpty then i += 1
-      else
-        headingPrefix(line.text.trim) match
-          case Present((level, rest)) =>
-            blocks += Block.Heading(level, rest.trim, Span(line.offset, line.text.length))
-            i += 1
-          case Absent =>
-            fenceOpen(line.text) match
-              case Present(open) =>
-                val (block, next) = readFencedCode(lines, i, open)
-                blocks += block
-                i = next
+    while !scanner.isAtEnd do
+      scanner.requireProgress(BlocksPhase) {
+        val line = readLine(scanner)
+        if !isBlank(scanner, line) then
+          val block =
+            headingPrefix(scanner, line) match
+              case Present((level, rest)) =>
+                Block.Heading(level, rest, Span(line.offset, line.length))
               case Absent =>
-                if isThematicBreak(line.text) then
-                  blocks += Block.ThematicBreak(Span(line.offset, line.text.length))
-                  i += 1
-                else
-                  unorderedItem(line.text) match
-                    case Present(_) =>
-                      val (block, next) = readUnorderedList(lines, i)
-                      blocks += block
-                      i = next
-                    case Absent =>
-                      val (block, next) = readParagraph(lines, i)
-                      blocks += block
-                      i = next
+                fenceOpen(scanner, line) match
+                  case Present(open) => readFencedCode(scanner, line, open)
+                  case Absent        =>
+                    if isThematicBreak(scanner, line) then Block.ThematicBreak(Span(line.offset, line.length))
+                    else
+                      unorderedItem(scanner, line) match
+                        case Present(item) => readUnorderedList(scanner, line, item)
+                        case Absent        => readParagraph(scanner, line)
+          scanner.chargeOutputNodes(NodeCount.one)
+          blocks += block
+      }
     Chunk.from(blocks.result())
+
+  private def readLine(scanner: SourceScanner): Line =
+    scanner.requireProgress(LinesPhase) {
+      val start              = scanner.mark
+      var previous           = Option.empty[Char]
+      var terminatedByLf     = false
+      var acquisitionRunning = true
+      while acquisitionRunning do
+        scanner.peek() match
+          case Some(char) =>
+            scanner.advance()
+            if char == '\n' then
+              terminatedByLf = true
+              acquisitionRunning = false
+            else previous = Some(char)
+          case None => acquisitionRunning = false
+
+      val rawEnd  = scanner.offset.toInt - (if terminatedByLf then 1 else 0)
+      val textEnd =
+        if terminatedByLf && previous.contains('\r') then rawEnd - 1
+        else rawEnd
+      val view = scanner.view(Span.fromStartEnd(start.toInt, textEnd))
+      scanner.chargeWork(WorkUnits(view.length.toInt.toLong))
+      Line(view, view.text, terminatedByLf)
+    }
 
   private type FenceOpen = (marker: Char, length: Int, indentation: Int, info: String)
 
-  private def readFencedCode(lines: Vector[Line], start: Int, open: FenceOpen): (Block, Int) =
-    val opening = lines(start)
-    var i       = start + 1
-    val body    = StringBuilder()
-    var closed  = false
-    while i < lines.length && !closed do
-      val line = lines(i)
-      if isClosingFence(line.text, open.marker, open.length) then closed = true
+  private def readFencedCode(scanner: SourceScanner, opening: Line, open: FenceOpen): Block =
+    val body            = StringBuilder()
+    var closed          = false
+    var closingEnd      = opening.end
+    var bodyEndedWithLf = false
+    while !scanner.isAtEnd && !closed do
+      val line = readLine(scanner)
+      if isClosingFence(scanner, line, open.marker, open.length) then
+        closed = true
+        closingEnd = line.end
       else
         if body.nonEmpty then body.append('\n')
-        body.append(removeFenceIndentation(line.text, open.indentation))
-        i += 1
-    val endLine = if closed then lines(i) else lines(lines.length - 1)
-    val end     = endLine.offset + endLine.text.length
+        body.append(removeFenceIndentation(scanner, line, open.indentation))
+        bodyEndedWithLf = line.terminatedByLf
+
+    val end     = if closed then closingEnd else scanner.offset.toInt
     val content =
       if closed then
         if body.nonEmpty then body.append('\n')
         body.toString
-      else body.toString
-    val next = if closed then i + 1 else i
-    (Block.FencedCode(FenceInfo.parse(open.info), content, Span.fromStartEnd(opening.offset, end)), next)
+      else
+        if body.nonEmpty && bodyEndedWithLf then body.append('\n')
+        body.toString
 
-  private def readParagraph(lines: Vector[Line], start: Int): (Block, Int) =
-    val first = lines(start)
-    var i     = start + 1
-    val text  = StringBuilder(first.text)
-    while i < lines.length && continuesParagraph(lines(i)) do
-      text.append('\n').append(lines(i).text)
-      i += 1
-    val last = lines(i - 1)
-    (Block.Paragraph(text.toString.trim, Span.fromStartEnd(first.offset, last.offset + last.text.length)), i)
+    // FenceInfo performs its own line-bounded interpretation of an already charged opening-line value.
+    Block.FencedCode(FenceInfo.parse(open.info), content, Span.fromStartEnd(opening.offset, end))
 
-  private def continuesParagraph(line: Line): Boolean =
-    line.text.trim.nonEmpty &&
-      fenceOpen(line.text).isEmpty &&
-      headingPrefix(line.text.trim).isEmpty &&
-      unorderedItem(line.text).isEmpty &&
-      !isThematicBreak(line.text)
+  private def readParagraph(scanner: SourceScanner, first: Line): Block =
+    val text        = StringBuilder(first.text)
+    var last        = first
+    var interrupted = false
+    while !scanner.isAtEnd && !interrupted do
+      val checkpoint = scanner.checkpoint()
+      val line       = readLine(scanner)
+      if continuesParagraph(scanner, line) then
+        text.append('\n').append(line.text)
+        last = line
+      else
+        scanner.restore(checkpoint)
+        interrupted = true
 
-  private def isThematicBreak(text: String): Boolean =
-    val compact = text.filterNot(_.isWhitespace)
-    compact.length >= 3 && (
-      compact.forall(_ == '-') || compact.forall(_ == '*') || compact.forall(_ == '_')
-    )
+    scanner.chargeWork(WorkUnits(text.length.toLong))
+    Block.Paragraph(text.toString.trim, Span.fromStartEnd(first.offset, last.end))
 
-  private def readUnorderedList(lines: Vector[Line], start: Int): (Block, Int) =
-    val first = lines(start)
-    var i     = start
+  private def continuesParagraph(scanner: SourceScanner, line: Line): Boolean =
+    !isBlank(scanner, line) &&
+      fenceOpen(scanner, line).isEmpty &&
+      headingPrefix(scanner, line).isEmpty &&
+      unorderedItem(scanner, line).isEmpty &&
+      !isThematicBreak(scanner, line)
+
+  private def isBlank(scanner: SourceScanner, line: Line): Boolean =
+    inspectLine(scanner, line)(_.trim.isEmpty)
+
+  private def isThematicBreak(scanner: SourceScanner, line: Line): Boolean =
+    inspectLine(scanner, line) { text =>
+      val compact = text.filterNot(_.isWhitespace)
+      compact.length >= 3 && (
+        compact.forall(_ == '-') || compact.forall(_ == '*') || compact.forall(_ == '_')
+      )
+    }
+
+  private def readUnorderedList(scanner: SourceScanner, first: Line, firstItem: String): Block =
     val items = List.newBuilder[String]
-    var done  = false
-    while i < lines.length && !done do
-      unorderedItem(lines(i).text) match
+    items += firstItem
+    var last = first
+    var done = false
+    while !scanner.isAtEnd && !done do
+      val checkpoint = scanner.checkpoint()
+      val line       = readLine(scanner)
+      unorderedItem(scanner, line) match
         case Present(item) =>
           items += item
-          i += 1
-        case Absent => done = true
-    val last = lines(i - 1)
-    (
-      Block.UnorderedList(Chunk.from(items.result()), Span.fromStartEnd(first.offset, last.offset + last.text.length)),
-      i
-    )
+          last = line
+        case Absent =>
+          scanner.restore(checkpoint)
+          done = true
+    Block.UnorderedList(Chunk.from(items.result()), Span.fromStartEnd(first.offset, last.end))
+
+  private def unorderedItem(scanner: SourceScanner, line: Line): Maybe[String] =
+    inspectLine(scanner, line)(unorderedItem)
 
   private def unorderedItem(text: String): Maybe[String] =
     val trimmed = text.stripLeading
@@ -129,28 +169,19 @@ object Parser:
     then Present(trimmed.drop(2).trim)
     else Absent
 
-  private def splitLines(source: String): Vector[Line] =
-    if source.isEmpty then Vector.empty
-    else
-      val result = Vector.newBuilder[Line]
-      var start  = 0
-      var i      = 0
-      while i < source.length do
-        if source.charAt(i) == '\n' then
-          val end = if i > start && source.charAt(i - 1) == '\r' then i - 1 else i
-          result += Line(start, source.substring(start, end))
-          i += 1
-          start = i
-        else i += 1
-      if start < source.length || source.charAt(source.length - 1) == '\n' then
-        result += Line(start, source.substring(start))
-      result.result()
+  private def headingPrefix(scanner: SourceScanner, line: Line): Maybe[(Int, String)] =
+    inspectLine(scanner, line) { text =>
+      headingPrefix(text.trim).map { case (level, rest) => (level, rest.trim) }
+    }
 
   private def headingPrefix(text: String): Maybe[(Int, String)] =
     val hashes = text.takeWhile(_ == '#')
     if hashes.nonEmpty && hashes.length <= 6 && text.length > hashes.length && text.charAt(hashes.length) == ' '
     then Present((hashes.length, text.drop(hashes.length + 1)))
     else Absent
+
+  private def fenceOpen(scanner: SourceScanner, line: Line): Maybe[FenceOpen] =
+    inspectLine(scanner, line)(fenceOpen)
 
   private def fenceOpen(text: String): Maybe[FenceOpen] =
     fenceIndent(text).flatMap { case (indentation = indentation, rest = trimmed) =>
@@ -170,6 +201,14 @@ object Parser:
         case None => Absent
     }
 
+  private def isClosingFence(
+      scanner: SourceScanner,
+      line: Line,
+      marker: Char,
+      openingLength: Int
+  ): Boolean =
+    inspectLine(scanner, line)(text => isClosingFence(text, marker, openingLength))
+
   private def isClosingFence(text: String, marker: Char, openingLength: Int): Boolean =
     fenceIndent(text).exists { case (rest = trimmed) =>
       val run = trimmed.takeWhile(_ == marker)
@@ -179,6 +218,9 @@ object Parser:
   private def fenceIndent(text: String): Maybe[(indentation: Int, rest: String)] =
     val indent = text.takeWhile(_ == ' ').length
     if indent <= 3 then Present((indentation = indent, rest = text.drop(indent))) else Absent
+
+  private def removeFenceIndentation(scanner: SourceScanner, line: Line, indentation: Int): String =
+    inspectLine(scanner, line)(text => removeFenceIndentation(text, indentation))
 
   private def removeFenceIndentation(text: String, indentation: Int): String =
     text.drop(math.min(indentation, text.takeWhile(_ == ' ').length))
@@ -192,3 +234,7 @@ object Parser:
     else
       val end = text.lastIndexWhere(char => char != ' ' && char != '\t')
       text.substring(start, end + 1)
+
+  private def inspectLine[A](scanner: SourceScanner, line: Line)(operation: String => A): A =
+    scanner.chargeWork(WorkUnits(line.length.toLong))
+    operation(line.text)

--- a/morphir/langkit/markdown/src/morphir/langkit/markdown/Parser.scala
+++ b/morphir/langkit/markdown/src/morphir/langkit/markdown/Parser.scala
@@ -16,14 +16,23 @@ object Parser:
   private val LinesPhase  = ScanPhase("markdown.lines")
 
   def parse(source: String, budget: ScanBudget = ScanBudget.default): Result[ParseError, Document] =
+    parseWithMetrics(source, budget) match
+      case Result.Success((document, _)) => Result.succeed(document)
+      case Result.Failure(error)         => Result.fail(error)
+
+  private[markdown] def parseWithMetrics(
+      source: String,
+      budget: ScanBudget
+  ): Result[ParseError, (Document, ScanMetrics)] =
     SourceScanner.scan(source, budget, phase = Some(BlocksPhase)) { scanner =>
       scanner.chargeOutputNodes(NodeCount.one)
       val blocks = parseBlocks(scanner)
       // Keep the caller's coordinate space: do not rewrite CRLF before measuring spans.
-      Document(blocks, Span(0, source.length))
+      val document = Document(blocks, Span(0, source.length))
+      (document, scanner.metrics)
     } match
-      case ScanResult.Success(document) => Result.succeed(document)
-      case ScanResult.Failure(error)    => Result.fail(ParseError.Scan(error))
+      case ScanResult.Success(value) => Result.succeed(value)
+      case ScanResult.Failure(error) => Result.fail(ParseError.Scan(error))
 
   private final case class Line(view: SourceView, text: String, terminatedByLf: Boolean):
     def offset: Int = view.start.toInt

--- a/morphir/langkit/markdown/src/morphir/langkit/markdown/Parser.scala
+++ b/morphir/langkit/markdown/src/morphir/langkit/markdown/Parser.scala
@@ -2,6 +2,7 @@ package morphir.langkit.markdown
 
 import kyo.*
 import morphir.langkit.core.Span
+import morphir.langkit.core.scanner.*
 
 /**
  * A CommonMark subset parser: ATX headings, paragraphs, fenced code, unordered lists, and thematic breaks.
@@ -11,9 +12,16 @@ import morphir.langkit.core.Span
  */
 object Parser:
 
-  def parse(source: String): Result[ParseError, Document] =
-    // Keep the caller's coordinate space: do not rewrite CRLF before measuring spans.
-    Result.succeed(Document(parseBlocks(source), Span(0, source.length)))
+  def parse(source: String, budget: ScanBudget = ScanBudget.default): Result[ParseError, Document] =
+    SourceScanner.scan(source, budget, phase = Some(ScanPhase("markdown.blocks"))) { scanner =>
+      // Task 6 replaces this materialization with scanner-backed block parsing.
+      val blocks = parseBlocks(scanner.remaining.text)
+      scanner.chargeOutputNodes(NodeCount(blocks.size.toLong + 1L))
+      // Keep the caller's coordinate space: do not rewrite CRLF before measuring spans.
+      Document(blocks, Span(0, source.length))
+    } match
+      case ScanResult.Success(document) => Result.succeed(document)
+      case ScanResult.Failure(error)    => Result.fail(ParseError.Scan(error))
 
   private final case class Line(offset: Int, text: String)
 

--- a/morphir/langkit/markdown/src/morphir/langkit/markdown/Parser.scala
+++ b/morphir/langkit/markdown/src/morphir/langkit/markdown/Parser.scala
@@ -114,8 +114,8 @@ object Parser:
         if body.nonEmpty && bodyEndedWithLf then body.append('\n')
         body.toString
 
-    // FenceInfo performs its own line-bounded interpretation of an already charged opening-line value.
-    Block.FencedCode(FenceInfo.parse(open.info), content, Span.fromStartEnd(opening.offset, end))
+    // The budgeted FenceInfo path reserves deterministic work and output before token materialization.
+    Block.FencedCode(FenceInfo.parseBudgeted(open.info, scanner), content, Span.fromStartEnd(opening.offset, end))
 
   private def readParagraph(scanner: SourceScanner, first: Line): Block =
     val text        = StringBuilder(first.text)

--- a/morphir/langkit/markdown/src/morphir/langkit/markdown/Parser.scala
+++ b/morphir/langkit/markdown/src/morphir/langkit/markdown/Parser.scala
@@ -19,15 +19,13 @@ object Parser:
     parse(source, ScanBudget.default)
 
   def parse(source: String, budget: ScanBudget): Result[ParseError, Document] =
-    parseWithMetrics(source, budget) match
-      case Result.Success((document, _)) => Result.succeed(document)
-      case Result.Failure(error)         => Result.fail(error)
+    parseWithMetrics(source, budget).map(_._1)
 
   private[markdown] def parseWithMetrics(
       source: String,
       budget: ScanBudget
   ): Result[ParseError, (Document, ScanMetrics)] =
-    SourceScanner.scan(source, budget, phase = Some(BlocksPhase)) { scanner =>
+    SourceScanner.scan(source, budget, phase = Present(BlocksPhase)) { scanner =>
       scanner.chargeOutputNodes(NodeCount.one)
       val blocks = parseBlocks(scanner)
       // Keep the caller's coordinate space: do not rewrite CRLF before measuring spans.
@@ -68,26 +66,26 @@ object Parser:
 
   private def readLine(scanner: SourceScanner): Line =
     scanner.requireProgress(LinesPhase) {
-      val start              = scanner.mark
-      var previous           = Option.empty[Char]
-      var terminatedByLf     = false
-      var acquisitionRunning = true
+      val start                 = scanner.mark
+      var previous: Maybe[Char] = Absent
+      var terminatedByLf        = false
+      var acquisitionRunning    = true
       while acquisitionRunning do
         scanner.peek() match
-          case Some(char) =>
+          case Present(char) =>
             scanner.advance()
             if char == '\n' then
               terminatedByLf = true
               acquisitionRunning = false
-            else previous = Some(char)
-          case None => acquisitionRunning = false
+            else previous = Present(char)
+          case Absent => acquisitionRunning = false
 
       val rawEnd  = scanner.offset.toInt - (if terminatedByLf then 1 else 0)
       val textEnd =
         if terminatedByLf && previous.contains('\r') then rawEnd - 1
         else rawEnd
       val view = scanner.view(Span.fromStartEnd(start.toInt, textEnd))
-      scanner.chargeWork(WorkUnits(view.length.toInt.toLong))
+      scanner.chargeWork(WorkUnits.from(view.length.toInt.toLong).getOrThrow)
       Line(view, view.text, terminatedByLf)
     }
 
@@ -134,7 +132,7 @@ object Parser:
         scanner.restore(checkpoint)
         interrupted = true
 
-    scanner.chargeWork(WorkUnits(text.length.toLong))
+    scanner.chargeWork(WorkUnits.from(text.length.toLong).getOrThrow)
     Block.Paragraph(text.toString.trim, Span.fromStartEnd(first.offset, last.end))
 
   private def continuesParagraph(scanner: SourceScanner, line: Line): Boolean =
@@ -248,5 +246,5 @@ object Parser:
       text.substring(start, end + 1)
 
   private def inspectLine[A](scanner: SourceScanner, line: Line)(operation: String => A): A =
-    scanner.chargeWork(WorkUnits(line.length.toLong))
+    scanner.chargeWork(WorkUnits.from(line.length.toLong).getOrThrow)
     operation(line.text)

--- a/morphir/langkit/markdown/src/morphir/langkit/markdown/Parser.scala
+++ b/morphir/langkit/markdown/src/morphir/langkit/markdown/Parser.scala
@@ -15,7 +15,10 @@ object Parser:
   private val BlocksPhase = ScanPhase("markdown.blocks")
   private val LinesPhase  = ScanPhase("markdown.lines")
 
-  def parse(source: String, budget: ScanBudget = ScanBudget.default): Result[ParseError, Document] =
+  def parse(source: String): Result[ParseError, Document] =
+    parse(source, ScanBudget.default)
+
+  def parse(source: String, budget: ScanBudget): Result[ParseError, Document] =
     parseWithMetrics(source, budget) match
       case Result.Success((document, _)) => Result.succeed(document)
       case Result.Failure(error)         => Result.fail(error)

--- a/morphir/langkit/markdown/test/src-jvm/morphir/langkit/markdown/ParserBinaryCompatibilityTests.scala
+++ b/morphir/langkit/markdown/test/src-jvm/morphir/langkit/markdown/ParserBinaryCompatibilityTests.scala
@@ -1,6 +1,8 @@
 package morphir.langkit.markdown
 
+import java.lang.reflect.Modifier
 import kyo.test.*
+import morphir.MorphirException
 
 class ParserBinaryCompatibilityTests extends Test[Any]:
 
@@ -9,8 +11,16 @@ class ParserBinaryCompatibilityTests extends Test[Any]:
       val method = Parser.getClass.getMethods.find { candidate =>
         candidate.getName == "parse" &&
         candidate.getParameterTypes.toList == List(classOf[String])
-      }
+      }.getOrElse(throw new AssertionError("missing parse(String)"))
 
-      assert(method.nonEmpty)
+      val result = method.invoke(Parser, "# Title")
+      assert(result != null)
+    }
+
+    "publishes ParseError as a MorphirException hierarchy" in {
+      assert(Modifier.isAbstract(classOf[ParseError].getModifiers))
+      assert(classOf[MorphirException].isAssignableFrom(classOf[ParseError]))
+      assert(classOf[ParseError].isAssignableFrom(classOf[ParseError.Syntax]))
+      assert(classOf[ParseError].isAssignableFrom(classOf[ParseError.Scan]))
     }
   }

--- a/morphir/langkit/markdown/test/src-jvm/morphir/langkit/markdown/ParserBinaryCompatibilityTests.scala
+++ b/morphir/langkit/markdown/test/src-jvm/morphir/langkit/markdown/ParserBinaryCompatibilityTests.scala
@@ -1,0 +1,16 @@
+package morphir.langkit.markdown
+
+import kyo.test.*
+
+class ParserBinaryCompatibilityTests extends Test[Any]:
+
+  "Parser JVM API" - {
+    "retains the one-argument parse descriptor" in {
+      val method = Parser.getClass.getMethods.find { candidate =>
+        candidate.getName == "parse" &&
+        candidate.getParameterTypes.toList == List(classOf[String])
+      }
+
+      assert(method.nonEmpty)
+    }
+  }

--- a/morphir/langkit/markdown/test/src/morphir/langkit/markdown/ParserTests.scala
+++ b/morphir/langkit/markdown/test/src/morphir/langkit/markdown/ParserTests.scala
@@ -42,7 +42,7 @@ class ParserTests extends Test[Any]:
 
   private def tightWorkBudget(inputLength: Int): ScanBudget.Limited =
     limitedBudget(
-      maxInputLength = InputSize.codeUnits(inputLength.toLong),
+      maxInputLength = InputSize.fromCodeUnits(inputLength.toLong).getOrThrow,
       maxWork = WorkUnits(32L),
       maxNestingDepth = NestingDepth(16),
       maxOutputNodes = NodeCount(16L)
@@ -133,7 +133,7 @@ class ParserTests extends Test[Any]:
                 actual = InputSize.codeUnits(5L)
               ),
               offset = SourceOffset.start,
-              phase = Some(ScanPhase("markdown.blocks"))
+              phase = Present(ScanPhase("markdown.blocks"))
             )
           )
         case _ => assert(false)
@@ -152,7 +152,7 @@ class ParserTests extends Test[Any]:
             error == ScanFailure(
               exceeded = ScanLimitExceeded.OutputNodes(limit = NodeCount.one, attempted = NodeCount(2L)),
               offset = SourceOffset(7),
-              phase = Some(ScanPhase("markdown.blocks"))
+              phase = Present(ScanPhase("markdown.blocks"))
             )
           )
         case _ => assert(false)
@@ -171,7 +171,7 @@ class ParserTests extends Test[Any]:
             error == ScanFailure(
               exceeded = ScanLimitExceeded.Work(limit = WorkUnits(8L), attempted = WorkUnits(9L)),
               offset = SourceOffset(1),
-              phase = Some(ScanPhase("markdown.blocks"))
+              phase = Present(ScanPhase("markdown.blocks"))
             )
           )
         case _ => assert(false)
@@ -189,9 +189,10 @@ class ParserTests extends Test[Any]:
         case Result.Failure(ParseError.Scan(error)) =>
           assert(
             error == ScanFailure(
-              exceeded = ScanLimitExceeded.Work(limit = WorkUnits(30L), attempted = WorkUnits(31L)),
+              exceeded =
+                ScanLimitExceeded.Work(limit = WorkUnits(30L), attempted = WorkUnits(31L)),
               offset = SourceOffset(2),
-              phase = Some(ScanPhase("markdown.blocks"))
+              phase = Present(ScanPhase("markdown.blocks"))
             )
           )
         case _ => assert(false)
@@ -232,7 +233,7 @@ class ParserTests extends Test[Any]:
       infoStrings.foreach { info =>
         val source = s"~~~ $info\n~~~"
         val budget = limitedBudget(
-          maxInputLength = InputSize.codeUnits(source.length.toLong + 1L),
+          maxInputLength = InputSize.fromCodeUnits(source.length.toLong + 1L).getOrThrow,
           maxWork = WorkUnits(100000000L),
           maxNestingDepth = NestingDepth(16),
           maxOutputNodes = NodeCount(10L)
@@ -247,12 +248,12 @@ class ParserTests extends Test[Any]:
     }
     "accepts the exact fence metadata output boundary and preserves structured info" in {
       val source        = "~~~ scala flag key=value {.class}\n~~~"
-      val metadataNodes = NodeCount(FenceInfo.TokenOutputReservation.toLong * 4L)
+      val metadataNodes = NodeCount.from(FenceInfo.TokenOutputReservation.toLong * 4L).getOrThrow
       val budget        = limitedBudget(
-        maxInputLength = InputSize.codeUnits(source.length.toLong),
+        maxInputLength = InputSize.fromCodeUnits(source.length.toLong).getOrThrow,
         maxWork = WorkUnits(10000L),
         maxNestingDepth = NestingDepth(16),
-        maxOutputNodes = NodeCount(metadataNodes.toLong + 2L)
+        maxOutputNodes = NodeCount.from(metadataNodes.toLong + 2L).getOrThrow
       )
 
       Parser.parse(source, budget) match
@@ -506,7 +507,7 @@ class ParserTests extends Test[Any]:
             actual = InputSize.codeUnits(5L)
           ),
           offset = SourceOffset.start,
-          phase = Some(ScanPhase("markdown.blocks"))
+          phase = Present(ScanPhase("markdown.blocks"))
         )
       )
 
@@ -520,7 +521,7 @@ class ParserTests extends Test[Any]:
         ScanFailure(
           exceeded = ScanLimitExceeded.Work(limit = WorkUnits(0L), attempted = WorkUnits(1L)),
           offset = SourceOffset.start,
-          phase = None
+          phase = Absent
         )
       )
 

--- a/morphir/langkit/markdown/test/src/morphir/langkit/markdown/ParserTests.scala
+++ b/morphir/langkit/markdown/test/src/morphir/langkit/markdown/ParserTests.scala
@@ -208,6 +208,48 @@ class ParserTests extends Test[Any]:
           assert(blocks == Chunk(Block.Heading(1, "Title", Span(0, 7))))
         case _ => assert(false)
     }
+    "budgets fence metadata tokens before whitespace-heavy allocation amplification" in {
+      val infoStrings = Chunk(
+        "scala " + ("flag " * 20000),
+        "{" + (".class " * 20000) + "}",
+        "scala " + ("key=value " * 10000)
+      )
+
+      infoStrings.foreach { info =>
+        val source = s"~~~ $info\n~~~"
+        val budget = ScanBudget.limited(
+          maxInputLength = InputSize.codeUnits(source.length.toLong + 1L),
+          maxWork = WorkUnits(100000000L),
+          maxNestingDepth = NestingDepth(16),
+          maxOutputNodes = NodeCount(10L)
+        )
+
+        Parser.parse(source, budget) match
+          case Result.Failure(ParseError.Scan(ScanFailure(ScanLimitExceeded.OutputNodes(limit, attempted), _, _))) =>
+            assert(limit == NodeCount(10L))
+            assert(attempted == NodeCount(17L))
+          case other => throw new AssertionError(s"expected typed metadata output exhaustion, got $other")
+      }
+    }
+    "accepts the exact fence metadata output boundary and preserves structured info" in {
+      val source        = "~~~ scala flag key=value {.class}\n~~~"
+      val metadataNodes = NodeCount(FenceInfo.TokenOutputReservation.toLong * 4L)
+      val budget        = ScanBudget.limited(
+        maxInputLength = InputSize.codeUnits(source.length.toLong),
+        maxWork = WorkUnits(10000L),
+        maxNestingDepth = NestingDepth(16),
+        maxOutputNodes = NodeCount(metadataNodes.toLong + 2L)
+      )
+
+      Parser.parse(source, budget) match
+        case Result.Success(Document(Chunk(Block.FencedCode(info, "", _)), _)) =>
+          assert(info == FenceInfo.parse("scala flag key=value {.class}"))
+          assert(info.language == Present("scala"))
+          assert(info.flag("flag"))
+          assert(info.option("key") == Present("value"))
+          assert(info.classes == Chunk("class"))
+        case other => throw new AssertionError(s"expected exact-boundary fence success, got $other")
+    }
     "reads an ATX heading and a paragraph" in {
       Parser.parse("# Title\n\nHello") match
         case Result.Success(doc) =>
@@ -427,6 +469,14 @@ class ParserTests extends Test[Any]:
   }
 
   "ParseError" - {
+    "exposes the root message and returns Syntax from its compatibility constructor" in {
+      val syntax: ParseError.Syntax = ParseError("expected closing fence")
+      val root: ParseError          = syntax
+
+      assert(root.message == "expected closing fence")
+      assert(root.getMessage == root.message)
+      assert(ParseError.unapply(root).contains(root.message))
+    }
     "keeps Syntax apply and unapply compatibility" in {
       val error = ParseError("expected closing fence")
       error match

--- a/morphir/langkit/markdown/test/src/morphir/langkit/markdown/ParserTests.scala
+++ b/morphir/langkit/markdown/test/src/morphir/langkit/markdown/ParserTests.scala
@@ -26,8 +26,21 @@ class ParserTests extends Test[Any]:
       else smaller * 3L + 64L
     assert(larger <= bound, s"$name work grew from $smaller to $larger (bound $bound)")
 
-  private def tightWorkBudget(inputLength: Int): ScanBudget.Limited =
+  private def limitedBudget(
+      maxInputLength: InputSize,
+      maxWork: WorkUnits,
+      maxNestingDepth: NestingDepth,
+      maxOutputNodes: NodeCount
+  ): ScanBudget.Limited =
     ScanBudget.limited(
+      maxInputLength = maxInputLength,
+      maxWork = maxWork,
+      maxNestingDepth = maxNestingDepth,
+      maxOutputNodes = maxOutputNodes
+    ).getOrThrow
+
+  private def tightWorkBudget(inputLength: Int): ScanBudget.Limited =
+    limitedBudget(
       maxInputLength = InputSize.codeUnits(inputLength.toLong),
       maxWork = WorkUnits(32L),
       maxNestingDepth = NestingDepth(16),
@@ -103,7 +116,7 @@ class ParserTests extends Test[Any]:
       }
     }
     "maps an input-size ceiling to an exact typed scanner failure" in {
-      val budget = ScanBudget.limited(
+      val budget = limitedBudget(
         maxInputLength = InputSize.codeUnits(4L),
         maxWork = WorkUnits(100L),
         maxNestingDepth = NestingDepth(10),
@@ -125,7 +138,7 @@ class ParserTests extends Test[Any]:
         case _ => assert(false)
     }
     "reports incremental output exhaustion at the consumed heading end" in {
-      val budget = ScanBudget.limited(
+      val budget = limitedBudget(
         maxInputLength = InputSize.codeUnits(100L),
         maxWork = WorkUnits(100L),
         maxNestingDepth = NestingDepth(10),
@@ -144,7 +157,7 @@ class ParserTests extends Test[Any]:
         case _ => assert(false)
     }
     "charges deterministic work for scanner movement and line-local inspection" in {
-      val budget = ScanBudget.limited(
+      val budget = limitedBudget(
         maxInputLength = InputSize.codeUnits(100L),
         maxWork = WorkUnits(8L),
         maxNestingDepth = NestingDepth(10),
@@ -163,7 +176,7 @@ class ParserTests extends Test[Any]:
         case _ => assert(false)
     }
     "does not refund speculative paragraph lookahead work" in {
-      val budget = ScanBudget.limited(
+      val budget = limitedBudget(
         maxInputLength = InputSize.codeUnits(100L),
         maxWork = WorkUnits(30L),
         maxNestingDepth = NestingDepth(10),
@@ -183,7 +196,7 @@ class ParserTests extends Test[Any]:
         case _ => assert(false)
     }
     "accepts the exact incremental output ceiling and preserves the default result" in {
-      val budget = ScanBudget.limited(
+      val budget = limitedBudget(
         maxInputLength = InputSize.codeUnits(100L),
         maxWork = WorkUnits(100L),
         maxNestingDepth = NestingDepth(10),
@@ -193,7 +206,7 @@ class ParserTests extends Test[Any]:
       assert(Parser.parse("# Title", budget) == Parser.parse("# Title"))
     }
     "charges exactly one output node for an empty document" in {
-      val exact = ScanBudget.limited(
+      val exact = limitedBudget(
         maxInputLength = InputSize.codeUnits(1L),
         maxWork = WorkUnits(1L),
         maxNestingDepth = NestingDepth(1),
@@ -217,7 +230,7 @@ class ParserTests extends Test[Any]:
 
       infoStrings.foreach { info =>
         val source = s"~~~ $info\n~~~"
-        val budget = ScanBudget.limited(
+        val budget = limitedBudget(
           maxInputLength = InputSize.codeUnits(source.length.toLong + 1L),
           maxWork = WorkUnits(100000000L),
           maxNestingDepth = NestingDepth(16),
@@ -234,7 +247,7 @@ class ParserTests extends Test[Any]:
     "accepts the exact fence metadata output boundary and preserves structured info" in {
       val source        = "~~~ scala flag key=value {.class}\n~~~"
       val metadataNodes = NodeCount(FenceInfo.TokenOutputReservation.toLong * 4L)
-      val budget        = ScanBudget.limited(
+      val budget        = limitedBudget(
         maxInputLength = InputSize.codeUnits(source.length.toLong),
         maxWork = WorkUnits(10000L),
         maxNestingDepth = NestingDepth(16),

--- a/morphir/langkit/markdown/test/src/morphir/langkit/markdown/ParserTests.scala
+++ b/morphir/langkit/markdown/test/src/morphir/langkit/markdown/ParserTests.scala
@@ -3,10 +3,69 @@ package morphir.langkit.markdown
 import kyo.*
 import kyo.test.*
 import morphir.langkit.core.Span
+import morphir.langkit.core.scanner.*
 
 class ParserTests extends Test[Any]:
 
   "Parser.parse" - {
+    "maps an input-size ceiling to an exact typed scanner failure" in {
+      val budget = ScanBudget.limited(
+        maxInputLength = InputSize.codeUnits(4L),
+        maxWork = WorkUnits(100L),
+        maxNestingDepth = NestingDepth(10),
+        maxOutputNodes = NodeCount(10L)
+      )
+
+      Parser.parse("hello", budget) match
+        case Result.Failure(ParseError.Scan(error)) =>
+          assert(
+            error == ScanFailure(
+              exceeded = ScanLimitExceeded.InputLength(
+                limit = InputSize.codeUnits(4L),
+                actual = InputSize.codeUnits(5L)
+              ),
+              offset = SourceOffset.start,
+              phase = Some(ScanPhase("markdown.blocks"))
+            )
+          )
+        case _ => assert(false)
+    }
+    "reports aggregate output exhaustion at the temporary scanner start offset" in {
+      val budget = ScanBudget.limited(
+        maxInputLength = InputSize.codeUnits(100L),
+        maxWork = WorkUnits(100L),
+        maxNestingDepth = NestingDepth(10),
+        maxOutputNodes = NodeCount.one
+      )
+
+      Parser.parse("# Title", budget) match
+        case Result.Failure(ParseError.Scan(error)) =>
+          assert(
+            error == ScanFailure(
+              exceeded = ScanLimitExceeded.OutputNodes(limit = NodeCount.one, attempted = NodeCount(2L)),
+              // Task 5 parses remaining.text without advancing; Task 6 moves this to the scanner-backed parser.
+              offset = SourceOffset.start,
+              phase = Some(ScanPhase("markdown.blocks"))
+            )
+          )
+        case _ => assert(false)
+    }
+    "accepts the exact aggregate output ceiling and preserves the default result" in {
+      val budget = ScanBudget.limited(
+        maxInputLength = InputSize.codeUnits(100L),
+        maxWork = WorkUnits(100L),
+        maxNestingDepth = NestingDepth(10),
+        maxOutputNodes = NodeCount(2L)
+      )
+
+      assert(Parser.parse("# Title", budget) == Parser.parse("# Title"))
+    }
+    "accepts an explicitly unsafe unbounded budget" in {
+      Parser.parse("# Title", ScanBudget.UnsafeUnbounded) match
+        case Result.Success(Document(blocks, _)) =>
+          assert(blocks == Chunk(Block.Heading(1, "Title", Span(0, 7))))
+        case _ => assert(false)
+    }
     "reads an ATX heading and a paragraph" in {
       Parser.parse("# Title\n\nHello") match
         case Result.Success(doc) =>
@@ -213,5 +272,31 @@ class ParserTests extends Test[Any]:
             case Block.Paragraph(text, _) => assert(text == "World")
             case _                        => assert(false)
         case _ => assert(false)
+    }
+  }
+
+  "ParseError" - {
+    "keeps Syntax apply and unapply compatibility" in {
+      val error = ParseError("expected closing fence")
+      error match
+        case ParseError(message) =>
+          assert(error == ParseError.Syntax("expected closing fence"))
+          assert(message == "expected closing fence")
+    }
+    "keeps typed scanner failures exception-compatible with a stable informative message" in {
+      val error = ParseError.Scan(
+        ScanFailure(
+          exceeded = ScanLimitExceeded.InputLength(
+            limit = InputSize.codeUnits(4L),
+            actual = InputSize.codeUnits(5L)
+          ),
+          offset = SourceOffset.start,
+          phase = Some(ScanPhase("markdown.blocks"))
+        )
+      )
+
+      assert(error.isInstanceOf[Exception])
+      assert(error.getMessage == "Markdown scan failed at offset 0 during markdown.blocks: InputLength(4,5)")
+      assert(ParseError.unapply(error).contains(error.getMessage))
     }
   }

--- a/morphir/langkit/markdown/test/src/morphir/langkit/markdown/ParserTests.scala
+++ b/morphir/langkit/markdown/test/src/morphir/langkit/markdown/ParserTests.scala
@@ -2,6 +2,7 @@ package morphir.langkit.markdown
 
 import kyo.*
 import kyo.test.*
+import morphir.MorphirException
 import morphir.langkit.core.Span
 import morphir.langkit.core.scanner.*
 
@@ -512,5 +513,18 @@ class ParserTests extends Test[Any]:
       assert(error.isInstanceOf[Exception])
       assert(error.getMessage == "Markdown scan failed at offset 0 during markdown.blocks: InputLength(4,5)")
       assert(ParseError.unapply(error).contains(error.getMessage))
+    }
+    "unifies syntax and scanner failures as MorphirException values while retaining their messages" in {
+      val syntax: MorphirException = ParseError.Syntax("expected closing fence")
+      val scan: MorphirException   = ParseError.Scan(
+        ScanFailure(
+          exceeded = ScanLimitExceeded.Work(limit = WorkUnits(0L), attempted = WorkUnits(1L)),
+          offset = SourceOffset.start,
+          phase = None
+        )
+      )
+
+      assert(syntax.getMessage == "expected closing fence")
+      assert(scan.getMessage.startsWith("Markdown scan failed at offset 0"))
     }
   }

--- a/morphir/langkit/markdown/test/src/morphir/langkit/markdown/ParserTests.scala
+++ b/morphir/langkit/markdown/test/src/morphir/langkit/markdown/ParserTests.scala
@@ -8,6 +8,42 @@ import morphir.langkit.core.scanner.*
 class ParserTests extends Test[Any]:
 
   "Parser.parse" - {
+    "preserves exact documents across the existing block subset" in {
+      val cases = Chunk(
+        "" -> Document(Chunk.empty, Span.zero),
+        "# Title" -> Document(Chunk(Block.Heading(1, "Title", Span(0, 7))), Span(0, 7)),
+        "alpha\nbeta" -> Document(Chunk(Block.Paragraph("alpha\nbeta", Span(0, 10))), Span(0, 10)),
+        "```scala\none\n\ntwo\n```" -> Document(
+          Chunk(Block.FencedCode(FenceInfo.parse("scala"), "one\n\ntwo\n", Span(0, 21))),
+          Span(0, 21)
+        ),
+        "```\ncode" -> Document(
+          Chunk(Block.FencedCode(FenceInfo.empty, "code", Span(0, 8))),
+          Span(0, 8)
+        ),
+        "```\ncode\n" -> Document(
+          Chunk(Block.FencedCode(FenceInfo.empty, "code\n", Span(0, 9))),
+          Span(0, 9)
+        ),
+        "- alpha\n- beta" -> Document(
+          Chunk(Block.UnorderedList(Chunk("alpha", "beta"), Span(0, 14))),
+          Span(0, 14)
+        ),
+        "---" -> Document(Chunk(Block.ThematicBreak(Span(0, 3))), Span(0, 3)),
+        "# A\n\nB" -> Document(
+          Chunk(Block.Heading(1, "A", Span(0, 3)), Block.Paragraph("B", Span(5, 1))),
+          Span(0, 6)
+        ),
+        "# A\r\n\r\nB" -> Document(
+          Chunk(Block.Heading(1, "A", Span(0, 3)), Block.Paragraph("B", Span(7, 1))),
+          Span(0, 8)
+        )
+      )
+
+      cases.foreach { case (source, expected) =>
+        assert(Parser.parse(source) == Result.succeed(expected))
+      }
+    }
     "maps an input-size ceiling to an exact typed scanner failure" in {
       val budget = ScanBudget.limited(
         maxInputLength = InputSize.codeUnits(4L),
@@ -30,7 +66,7 @@ class ParserTests extends Test[Any]:
           )
         case _ => assert(false)
     }
-    "reports aggregate output exhaustion at the temporary scanner start offset" in {
+    "reports incremental output exhaustion at the consumed heading end" in {
       val budget = ScanBudget.limited(
         maxInputLength = InputSize.codeUnits(100L),
         maxWork = WorkUnits(100L),
@@ -43,14 +79,52 @@ class ParserTests extends Test[Any]:
           assert(
             error == ScanFailure(
               exceeded = ScanLimitExceeded.OutputNodes(limit = NodeCount.one, attempted = NodeCount(2L)),
-              // Task 5 parses remaining.text without advancing; Task 6 moves this to the scanner-backed parser.
-              offset = SourceOffset.start,
+              offset = SourceOffset(7),
               phase = Some(ScanPhase("markdown.blocks"))
             )
           )
         case _ => assert(false)
     }
-    "accepts the exact aggregate output ceiling and preserves the default result" in {
+    "charges deterministic work for scanner movement and line-local inspection" in {
+      val budget = ScanBudget.limited(
+        maxInputLength = InputSize.codeUnits(100L),
+        maxWork = WorkUnits(8L),
+        maxNestingDepth = NestingDepth(10),
+        maxOutputNodes = NodeCount(10L)
+      )
+
+      Parser.parse("x", budget) match
+        case Result.Failure(ParseError.Scan(error)) =>
+          assert(
+            error == ScanFailure(
+              exceeded = ScanLimitExceeded.Work(limit = WorkUnits(8L), attempted = WorkUnits(9L)),
+              offset = SourceOffset(1),
+              phase = Some(ScanPhase("markdown.blocks"))
+            )
+          )
+        case _ => assert(false)
+    }
+    "does not refund speculative paragraph lookahead work" in {
+      val budget = ScanBudget.limited(
+        maxInputLength = InputSize.codeUnits(100L),
+        maxWork = WorkUnits(30L),
+        maxNestingDepth = NestingDepth(10),
+        maxOutputNodes = NodeCount(10L)
+      )
+
+      assert(Parser.parse("# h", budget) == Parser.parse("# h"))
+      Parser.parse("x\n# h", budget) match
+        case Result.Failure(ParseError.Scan(error)) =>
+          assert(
+            error == ScanFailure(
+              exceeded = ScanLimitExceeded.Work(limit = WorkUnits(30L), attempted = WorkUnits(31L)),
+              offset = SourceOffset(2),
+              phase = Some(ScanPhase("markdown.blocks"))
+            )
+          )
+        case _ => assert(false)
+    }
+    "accepts the exact incremental output ceiling and preserves the default result" in {
       val budget = ScanBudget.limited(
         maxInputLength = InputSize.codeUnits(100L),
         maxWork = WorkUnits(100L),
@@ -59,6 +133,16 @@ class ParserTests extends Test[Any]:
       )
 
       assert(Parser.parse("# Title", budget) == Parser.parse("# Title"))
+    }
+    "charges exactly one output node for an empty document" in {
+      val exact = ScanBudget.limited(
+        maxInputLength = InputSize.codeUnits(1L),
+        maxWork = WorkUnits(1L),
+        maxNestingDepth = NestingDepth(1),
+        maxOutputNodes = NodeCount.one
+      )
+
+      assert(Parser.parse("", exact) == Result.succeed(Document(Chunk.empty, Span.zero)))
     }
     "accepts an explicitly unsafe unbounded budget" in {
       Parser.parse("# Title", ScanBudget.UnsafeUnbounded) match
@@ -128,6 +212,15 @@ class ParserTests extends Test[Any]:
               assert(span.length == "Hello".length)
             case _ => assert(false)
         case _ => assert(false)
+    }
+    "keeps a lone carriage return as paragraph text in the original span" in {
+      val source = "alpha\rbeta"
+
+      assert(
+        Parser.parse(source) == Result.succeed(
+          Document(Chunk(Block.Paragraph(source, Span(0, source.length))), Span(0, source.length))
+        )
+      )
     }
     "accepts an empty document" in {
       Parser.parse("") match

--- a/morphir/langkit/markdown/test/src/morphir/langkit/markdown/ParserTests.scala
+++ b/morphir/langkit/markdown/test/src/morphir/langkit/markdown/ParserTests.scala
@@ -7,12 +7,70 @@ import morphir.langkit.core.scanner.*
 
 class ParserTests extends Test[Any]:
 
+  private def parseMetrics(source: String): ScanMetrics =
+    Parser.parseWithMetrics(source, ScanBudget.UnsafeUnbounded) match
+      case Result.Success((_, metrics)) => metrics
+      case _                            => throw new AssertionError("unbounded parse unexpectedly failed")
+
+  private def assertLinearWork(name: String, input: Int => String)(using AssertScope): Unit =
+    val smallerSource = input(1024)
+    assert(smallerSource.length == 1024, s"$name fixture must be exactly 1,024 UTF-16 code units")
+    val smaller = parseMetrics(smallerSource).work.toLong
+
+    val largerSource = input(2048)
+    assert(largerSource.length == 2048, s"$name fixture must be exactly 2,048 UTF-16 code units")
+    val larger = parseMetrics(largerSource).work.toLong
+
+    val bound =
+      if smaller > (Long.MaxValue - 64L) / 3L then Long.MaxValue
+      else smaller * 3L + 64L
+    assert(larger <= bound, s"$name work grew from $smaller to $larger (bound $bound)")
+
+  private def tightWorkBudget(inputLength: Int): ScanBudget.Limited =
+    ScanBudget.limited(
+      maxInputLength = InputSize.codeUnits(inputLength.toLong),
+      maxWork = WorkUnits(32L),
+      maxNestingDepth = NestingDepth(16),
+      maxOutputNodes = NodeCount(16L)
+    )
+
+  private def assertWorkExhausted(source: String)(using AssertScope): Unit =
+    val result    = Parser.parse(source, tightWorkBudget(source.length))
+    val exhausted = result match
+      case Result.Failure(ParseError.Scan(ScanFailure(ScanLimitExceeded.Work(_, _), _, _))) => true
+      case _                                                                                => false
+    assert(exhausted, s"expected typed work exhaustion, got $result")
+
   "Parser.parse" - {
+    "has deterministic near-linear work growth for representative block inputs" in {
+      val inputs = Chunk[(String, Int => String)](
+        "paragraph"        -> (size => "a" * size),
+        "fence"            -> (size => "```\n" + ("a" * (size - 8)) + "\n```"),
+        "list"             -> (size => "- a\n" * (size / 4)),
+        "ambiguous prefix" -> (size => "#######\n" * (size / 8))
+      )
+
+      inputs.foreach { case (name, input) => assertLinearWork(name, input) }
+    }
+    "terminates hostile inputs through typed work exhaustion" in {
+      val hostile = Chunk(
+        "`" * 100000,
+        "~" * 100000,
+        "   - " * 20000,
+        "a\r\n" * 30000,
+        "\uD83D\uDE00" * 50000
+      )
+
+      hostile.foreach { source =>
+        assert(source.length.toLong < ScanBudget.default.maxInputLength.toLong)
+        assertWorkExhausted(source)
+      }
+    }
     "preserves exact documents across the existing block subset" in {
       val cases = Chunk(
-        "" -> Document(Chunk.empty, Span.zero),
-        "# Title" -> Document(Chunk(Block.Heading(1, "Title", Span(0, 7))), Span(0, 7)),
-        "alpha\nbeta" -> Document(Chunk(Block.Paragraph("alpha\nbeta", Span(0, 10))), Span(0, 10)),
+        ""                          -> Document(Chunk.empty, Span.zero),
+        "# Title"                   -> Document(Chunk(Block.Heading(1, "Title", Span(0, 7))), Span(0, 7)),
+        "alpha\nbeta"               -> Document(Chunk(Block.Paragraph("alpha\nbeta", Span(0, 10))), Span(0, 10)),
         "```scala\none\n\ntwo\n```" -> Document(
           Chunk(Block.FencedCode(FenceInfo.parse("scala"), "one\n\ntwo\n", Span(0, 21))),
           Span(0, 21)
@@ -29,7 +87,7 @@ class ParserTests extends Test[Any]:
           Chunk(Block.UnorderedList(Chunk("alpha", "beta"), Span(0, 14))),
           Span(0, 14)
         ),
-        "---" -> Document(Chunk(Block.ThematicBreak(Span(0, 3))), Span(0, 3)),
+        "---"      -> Document(Chunk(Block.ThematicBreak(Span(0, 3))), Span(0, 3)),
         "# A\n\nB" -> Document(
           Chunk(Block.Heading(1, "A", Span(0, 3)), Block.Paragraph("B", Span(5, 1))),
           Span(0, 6)


### PR DESCRIPTION
## Summary

- add a cross-platform `SourceScanner` with typed input, work, nesting, and output budgets plus explicit `UnsafeUnbounded` opt-out
- migrate the existing Markdown block parser to scanner-backed sequential parsing while preserving UTF-16 spans, CRLF handling, and fenced-code behavior
- add deterministic metrics, adversarial scaling coverage, allocation-aware fence metadata accounting, and scanner safety documentation

## Security model

- exhaustion is typed, sticky, and owned by one scanner session
- checkpoints restore offsets without refunding speculative work
- progress checks require strict forward movement
- fence metadata reserves work and output budget before token materialization
- scanner sessions are single-owner and non-thread-safe

## Test plan

- [x] `./mill morphir.langkit.core.jvm.test`
- [x] `./mill morphir.langkit.core.js.test`
- [x] `./mill morphir.langkit.core.native.test`
- [x] `./mill morphir.langkit.markdown.jvm.test`
- [x] `./mill morphir.langkit.markdown.js.test`
- [x] `./mill morphir.langkit.markdown.native.test`
- [x] `./mill --ticker false -i ci.lint`

Core: 74 tests per platform. Markdown: 42 tests per platform.