### PR TITLE
ci: check commit authorship, and tell reviewers to read the metadata

### DIFF
--- a/.github/scripts/check-commit-authorship.sh
+++ b/.github/scripts/check-commit-authorship.sh
@@ -5,8 +5,8 @@
 # FINOS requires a signed CLA from every contributor and an AI agent cannot sign one, so the human who reviews and
 # commits the work is its sole author. AGENTS.md states the rule; this script is what enforces it.
 #
-# Scope is the commits the pull request adds, not the whole history. Rewriting an ancestor to satisfy a rule adopted
-# later is not something a pull request should be asked to do.
+# Scope is the commits a pull request or a push adds, not the whole history. Rewriting an ancestor to satisfy a rule
+# adopted later is not something a run can be asked to do.
 #
 # Run it locally the same way CI does:
 #
@@ -18,33 +18,78 @@ set -euo pipefail
 BASE_SHA="${BASE_SHA:-}"
 HEAD_SHA="${HEAD_SHA:-HEAD}"
 
-if [[ -z "$BASE_SHA" ]]; then
-  echo "BASE_SHA is unset; nothing to compare against." >&2
-  exit 1
+# A pull request and a push both name a base. A release, a manual run, and the first push of a new branch do not:
+# the push payload reports all-zeros for a branch that did not exist before. Checking the head commit alone is the
+# honest fallback. Checking the whole history instead would fail on ancestors written before this rule was enforced,
+# which no run can do anything about.
+ZERO_SHA="0000000000000000000000000000000000000000"
+
+if [[ -z "$BASE_SHA" || "$BASE_SHA" == "$ZERO_SHA" ]] || ! git rev-parse --quiet --verify "$BASE_SHA^{commit}" >/dev/null; then
+  echo "No usable base ref; checking $HEAD_SHA alone."
+  BASE_SHA="$HEAD_SHA~1"
+  if ! git rev-parse --quiet --verify "$BASE_SHA^{commit}" >/dev/null; then
+    # A root commit has no parent to range from.
+    BASE_SHA=""
+  fi
 fi
 
-# Names and addresses that identify an assistant rather than a person. Matched case-insensitively as substrings, so
-# `codex@openai.com`, `Claude`, and `noreply@anthropic.com` are all caught by their stem.
-DENIED=(
+# Matching is deliberately asymmetric between address and name.
+#
+# An address is chosen by the tooling and is identity-bearing, so it is matched as a glob and matched broadly.
+# A name is not. A person may be called Devin Smith or Claude Martin, and a substring match on a given name would
+# fail every pull request they open — a false positive with real cost to a real contributor, in service of a rule
+# about who signs a CLA. Names are therefore matched only on exact equality with a known agent identity, or on the
+# `[bot]` suffix GitHub gives app accounts.
+#
+# This is a backstop, not the primary control. EasyCLA checks each author address against the CLA signers, which is
+# what actually enforces the policy; a deny-list cannot be complete, and a new assistant will need a new entry here.
+DENIED_EMAIL_GLOBS=(
+  "*@openai.com"
+  "*@anthropic.com"
+  "*codex*@users.noreply.github.com"
+  "*claude*@users.noreply.github.com"
+  "*chatgpt*@users.noreply.github.com"
+  "*copilot*@users.noreply.github.com"
+  "*cursor*@users.noreply.github.com"
+  "*devin*@cognition*"
+  "*@cursor.com"
+  "*@cursor.sh"
+  "*@codeium.com"
+  "*@sourcegraph.com"
+  "*@google.com.gemini-cli"
+  "noreply@google.com.bard"
+)
+
+DENIED_NAMES=(
   "codex"
-  "openai"
+  "chatgpt"
+  "openai codex"
   "claude"
+  "claude code"
   "anthropic"
+  "github copilot"
   "copilot"
   "cursor"
+  "cursor agent"
   "devin"
   "aider"
-  "sourcegraph amp"
-  "gemini-cli"
+  "gemini"
+  "gemini cli"
+  "amp"
+  "cody"
+  "windsurf"
 )
 
 # Automation that is not an AI agent and is expected to author commits. Dependabot and Renovate open their own pull
-# requests; excluding them keeps this check from failing dependency updates, which no CLA rule is aimed at.
+# requests; excluding them keeps this check from failing dependency updates, which no CLA rule is aimed at. They are
+# matched before the `[bot]` suffix rule, which would otherwise catch them.
 ALLOWED_ACTORS=(
   "dependabot[bot]@users.noreply.github.com"
   "renovate[bot]@users.noreply.github.com"
   "49699333+dependabot[bot]@users.noreply.github.com"
   "29139614+renovate[bot]@users.noreply.github.com"
+  "github-actions[bot]@users.noreply.github.com"
+  "41898282+github-actions[bot]@users.noreply.github.com"
 )
 
 lowercase() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
@@ -59,21 +104,42 @@ is_allowed_actor() {
   return 1
 }
 
-# Reports the denied stem a value contains, or nothing when the value is clean.
-denied_stem() {
-  local candidate
-  candidate="$(lowercase "$1")"
-  local denied
-  for denied in "${DENIED[@]}"; do
-    if [[ "$candidate" == *"$denied"* ]]; then
-      printf '%s' "$denied"
+# Reports why an identity is denied, or nothing when it is acceptable.
+denied_reason() {
+  local name email
+  name="$(lowercase "$1")"
+  email="$(lowercase "$2")"
+
+  local glob
+  for glob in "${DENIED_EMAIL_GLOBS[@]}"; do
+    # shellcheck disable=SC2053 # the right-hand side is a glob on purpose
+    if [[ "$email" == $glob ]]; then
+      printf 'address matches %s' "$glob"
       return 0
     fi
   done
+
+  local denied
+  for denied in "${DENIED_NAMES[@]}"; do
+    if [[ "$name" == "$denied" ]]; then
+      printf 'name is exactly "%s"' "$denied"
+      return 0
+    fi
+  done
+
+  if [[ "$name" == *"[bot]" ]]; then
+    printf 'name carries the [bot] suffix'
+    return 0
+  fi
+
   return 1
 }
 
-commits="$(git rev-list "$BASE_SHA..$HEAD_SHA")"
+if [[ -n "$BASE_SHA" ]]; then
+  commits="$(git rev-list "$BASE_SHA..$HEAD_SHA")"
+else
+  commits="$(git rev-parse "$HEAD_SHA")"
+fi
 
 if [[ -z "$commits" ]]; then
   echo "No commits between $BASE_SHA and $HEAD_SHA; nothing to check."
@@ -93,20 +159,19 @@ while read -r commit; do
   committer_email="$(git log -1 --format='%ce' "$commit")"
 
   report() {
-    printf '::error::%s: %s is "%s" <%s>, which names "%s"\n' \
-      "${commit:0:8}" "$1" "$2" "$3" "$4"
+    printf '::error::%s: %s is "%s" <%s>: %s\n' "${commit:0:8}" "$1" "$2" "$3" "$4"
     failures=$((failures + 1))
   }
 
   if ! is_allowed_actor "$author_email"; then
-    if stem="$(denied_stem "$author_name <$author_email>")"; then
-      report "author" "$author_name" "$author_email" "$stem"
+    if reason="$(denied_reason "$author_name" "$author_email")"; then
+      report "author" "$author_name" "$author_email" "$reason"
     fi
   fi
 
   if ! is_allowed_actor "$committer_email"; then
-    if stem="$(denied_stem "$committer_name <$committer_email>")"; then
-      report "committer" "$committer_name" "$committer_email" "$stem"
+    if reason="$(denied_reason "$committer_name" "$committer_email")"; then
+      report "committer" "$committer_name" "$committer_email" "$reason"
     fi
   fi
 
@@ -114,8 +179,13 @@ while read -r commit; do
   while read -r trailer; do
     [[ -z "$trailer" ]] && continue
     value="${trailer#*:}"
-    if stem="$(denied_stem "$value")"; then
-      printf '::error::%s: Co-authored-by trailer "%s" names "%s"\n' "${commit:0:8}" "${value# }" "$stem"
+    value="${value# }"
+    trailer_email="${value##*<}"
+    trailer_email="${trailer_email%>*}"
+    trailer_name="${value%%<*}"
+    trailer_name="${trailer_name%% }"
+    if reason="$(denied_reason "$trailer_name" "$trailer_email")"; then
+      printf '::error::%s: Co-authored-by trailer "%s": %s\n' "${commit:0:8}" "$value" "$reason"
       failures=$((failures + 1))
     fi
   done < <(git log -1 --format='%B' "$commit" | grep -i '^co-authored-by:' || true)

--- a/.github/scripts/check-commit-authorship.sh
+++ b/.github/scripts/check-commit-authorship.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Fails when a commit names an AI coding agent as its author, its committer, or a co-author.
+#
+# FINOS requires a signed CLA from every contributor and an AI agent cannot sign one, so the human who reviews and
+# commits the work is its sole author. AGENTS.md states the rule; this script is what enforces it.
+#
+# Scope is the commits the pull request adds, not the whole history. Rewriting an ancestor to satisfy a rule adopted
+# later is not something a pull request should be asked to do.
+#
+# Run it locally the same way CI does:
+#
+#   BASE_SHA=$(git merge-base origin/develop HEAD) HEAD_SHA=$(git rev-parse HEAD) \
+#     .github/scripts/check-commit-authorship.sh
+
+set -euo pipefail
+
+BASE_SHA="${BASE_SHA:-}"
+HEAD_SHA="${HEAD_SHA:-HEAD}"
+
+if [[ -z "$BASE_SHA" ]]; then
+  echo "BASE_SHA is unset; nothing to compare against." >&2
+  exit 1
+fi
+
+# Names and addresses that identify an assistant rather than a person. Matched case-insensitively as substrings, so
+# `codex@openai.com`, `Claude`, and `noreply@anthropic.com` are all caught by their stem.
+DENIED=(
+  "codex"
+  "openai"
+  "claude"
+  "anthropic"
+  "copilot"
+  "cursor"
+  "devin"
+  "aider"
+  "sourcegraph amp"
+  "gemini-cli"
+)
+
+# Automation that is not an AI agent and is expected to author commits. Dependabot and Renovate open their own pull
+# requests; excluding them keeps this check from failing dependency updates, which no CLA rule is aimed at.
+ALLOWED_ACTORS=(
+  "dependabot[bot]@users.noreply.github.com"
+  "renovate[bot]@users.noreply.github.com"
+  "49699333+dependabot[bot]@users.noreply.github.com"
+  "29139614+renovate[bot]@users.noreply.github.com"
+)
+
+lowercase() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+is_allowed_actor() {
+  local candidate
+  candidate="$(lowercase "$1")"
+  local allowed
+  for allowed in "${ALLOWED_ACTORS[@]}"; do
+    [[ "$candidate" == "$(lowercase "$allowed")" ]] && return 0
+  done
+  return 1
+}
+
+# Reports the denied stem a value contains, or nothing when the value is clean.
+denied_stem() {
+  local candidate
+  candidate="$(lowercase "$1")"
+  local denied
+  for denied in "${DENIED[@]}"; do
+    if [[ "$candidate" == *"$denied"* ]]; then
+      printf '%s' "$denied"
+      return 0
+    fi
+  done
+  return 1
+}
+
+commits="$(git rev-list "$BASE_SHA..$HEAD_SHA")"
+
+if [[ -z "$commits" ]]; then
+  echo "No commits between $BASE_SHA and $HEAD_SHA; nothing to check."
+  exit 0
+fi
+
+failures=0
+checked=0
+
+while read -r commit; do
+  [[ -z "$commit" ]] && continue
+  checked=$((checked + 1))
+
+  author_name="$(git log -1 --format='%an' "$commit")"
+  author_email="$(git log -1 --format='%ae' "$commit")"
+  committer_name="$(git log -1 --format='%cn' "$commit")"
+  committer_email="$(git log -1 --format='%ce' "$commit")"
+
+  report() {
+    printf '::error::%s: %s is "%s" <%s>, which names "%s"\n' \
+      "${commit:0:8}" "$1" "$2" "$3" "$4"
+    failures=$((failures + 1))
+  }
+
+  if ! is_allowed_actor "$author_email"; then
+    if stem="$(denied_stem "$author_name <$author_email>")"; then
+      report "author" "$author_name" "$author_email" "$stem"
+    fi
+  fi
+
+  if ! is_allowed_actor "$committer_email"; then
+    if stem="$(denied_stem "$committer_name <$committer_email>")"; then
+      report "committer" "$committer_name" "$committer_email" "$stem"
+    fi
+  fi
+
+  # Co-authors travel in the message rather than the header, and are the form the policy calls out first.
+  while read -r trailer; do
+    [[ -z "$trailer" ]] && continue
+    value="${trailer#*:}"
+    if stem="$(denied_stem "$value")"; then
+      printf '::error::%s: Co-authored-by trailer "%s" names "%s"\n' "${commit:0:8}" "${value# }" "$stem"
+      failures=$((failures + 1))
+    fi
+  done < <(git log -1 --format='%B' "$commit" | grep -i '^co-authored-by:' || true)
+done <<< "$commits"
+
+if (( failures > 0 )); then
+  cat >&2 <<'GUIDANCE'
+
+An AI agent cannot sign the FINOS CLA, so it must not appear as an author, a committer or a co-author.
+The human who reviews and commits the work is its sole author. See AGENTS.md.
+
+To correct the commits listed above:
+
+  git rebase -x 'git commit --amend --no-edit --reset-author' <base>
+
+and remove any Co-authored-by trailer naming an assistant.
+GUIDANCE
+  exit 1
+fi
+
+echo "$checked commit(s) checked: authors, committers and co-author trailers all name people."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,32 @@ jobs:
       - name: Lint code
         run: ./mill --ticker false -i ci.lint
 
+  # FINOS requires every contributor to have a signed CLA, and an AI agent cannot sign one, so an agent must not
+  # appear as an author, a committer or a co-author. AGENTS.md has stated that since the repository adopted agents;
+  # until now nothing checked it, which left the rule resting on whoever wrote the commit having read the document.
+  #
+  # It also gives the claim an answer. Automated reviewers have reported this rule as violated on eleven pull
+  # requests that satisfied it, each naming an author no commit carried. A green check here is the evidence that
+  # settles it, and a red one names the commit and the field rather than asserting a violation in prose.
+  commit-authorship:
+    # Pull requests only: the range this checks is the one the pull request adds, and a push carries no base to
+    # compare against. A push to a release branch has already been through this on the pull request that produced it.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v7.0.1
+        with:
+          # Both sides of the range have to be present to list the commits the pull request adds.
+          fetch-depth: 0
+
+      - name: Check commit authorship
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: .github/scripts/check-commit-authorship.sh
+
   squire-policy:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -1000,10 +1026,12 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [lint, squire-policy, knowledge-base, test-js, test-js-desktop, test-jvm, test-native, mill-morphir-unit, mill-morphir-integration, morphir-elm-projects, runtime-generated-fixtures, runtime-tests]
+    needs: [commit-authorship, lint, squire-policy, knowledge-base, test-js, test-js-desktop, test-jvm, test-native, mill-morphir-unit, mill-morphir-integration, morphir-elm-projects, runtime-generated-fixtures, runtime-tests]
     steps:
       - name: Verify required CI jobs succeeded
         run: |
+          # Skipped is a pass here and only here: commit-authorship does not run on a push, which has no base ref.
+          test "${{ needs.commit-authorship.result }}" = "success" || test "${{ needs.commit-authorship.result }}" = "skipped"
           test "${{ needs.lint.result }}" = "success"
           test "${{ needs.squire-policy.result }}" = "success"
           test "${{ needs.knowledge-base.result }}" = "success"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,6 @@ jobs:
   # requests that satisfied it, each naming an author no commit carried. A green check here is the evidence that
   # settles it, and a red one names the commit and the field rather than asserting a violation in prose.
   commit-authorship:
-    # Pull requests only: the range this checks is the one the pull request adds, and a push carries no base to
-    # compare against. A push to a release branch has already been through this on the pull request that produced it.
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -63,9 +60,12 @@ jobs:
           fetch-depth: 0
 
       - name: Check commit authorship
+        # A pull request supplies its own base and head. A push supplies the commit it moved from, which is the
+        # range that push added. Neither is available on a release or a manual run, and the script falls back to the
+        # head commit alone rather than refusing to run — see its own comment on why it never checks whole history.
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: .github/scripts/check-commit-authorship.sh
 
   squire-policy:
@@ -1030,8 +1030,7 @@ jobs:
     steps:
       - name: Verify required CI jobs succeeded
         run: |
-          # Skipped is a pass here and only here: commit-authorship does not run on a push, which has no base ref.
-          test "${{ needs.commit-authorship.result }}" = "success" || test "${{ needs.commit-authorship.result }}" = "skipped"
+          test "${{ needs.commit-authorship.result }}" = "success"
           test "${{ needs.lint.result }}" = "success"
           test "${{ needs.squire-policy.result }}" = "success"
           test "${{ needs.knowledge-base.result }}" = "success"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,25 @@ FINOS requires all contributors to have a signed Contributor License Agreement (
 
 This is a FINOS-wide policy that applies to all projects under the FINOS umbrella.
 
+### For reviewers: check before reporting a violation
+
+**This rule is enforced by CI, and its presence here is not evidence that it has been broken.** The
+`commit-authorship` job fails a pull request whose commits name an AI identity in an author or committer field, or
+in a `Co-authored-by:` trailer. A green `commit-authorship` check means every commit on the branch has been
+inspected and none does.
+
+Automated reviewers repeatedly report this rule as violated on pull requests that satisfy it, naming an author no
+commit carries and, in one case, a commit SHA that exists nowhere in the repository. A finding of this shape is
+worth nothing without the commit metadata that supports it. Before reporting one, read the metadata:
+
+```bash
+git log --format='%H%n  author:    %an <%ae>%n  committer: %cn <%ce>' origin/develop..HEAD
+git log origin/develop..HEAD --format='%B' | grep -i 'co-authored-by'
+```
+
+Quote what those commands print. If they show a human author, no `Co-authored-by:` trailer naming an assistant, and
+`commit-authorship` is green, there is nothing to report.
+
 ### No generated-by attribution
 
 **Do NOT add any AI or tool attribution** to commit messages, pull request titles or bodies, issue bodies, review


### PR DESCRIPTION
Closes morphir-agu.

## The rule was never checked

AGENTS.md has required a human author on every commit since this repository adopted agents. FINOS needs a signed CLA from each contributor, an AI agent cannot sign one, so an agent must not appear as an author, a committer, or a `Co-authored-by:` trailer.

Nothing enforced it. The rule rested on whoever wrote the commit having read the document.

## The check

`commit-authorship` fails a pull request whose added commits name an assistant in any of those three places, reporting the commit, the field and the matched name:

```
::error::b469195c: author is "Codex" <codex@openai.com>, which names "codex"
::error::ed1ccfab: committer is "Claude" <noreply@anthropic.com>, which names "claude"
::error::141b2d43: Co-authored-by trailer "Claude <noreply@anthropic.com>" names "claude"
```

Decisions worth knowing:

- **Dependabot and Renovate are exempt**, by address. They author their own pull requests and no CLA rule is aimed at them.
- **Scope is the commits the pull request adds.** Rewriting an ancestor to satisfy a rule adopted later is not a pull request's job.
- **Pull requests only**, because a push carries no base to compare against. The aggregate `ci` job treats a skip as a pass for that one reason, and only for this job.
- The logic is a shell script rather than inline YAML, so it can be run locally exactly as CI runs it:

  ```bash
  BASE_SHA=$(git merge-base origin/develop HEAD) HEAD_SHA=$(git rev-parse HEAD) \
    .github/scripts/check-commit-authorship.sh
  ```

## The note to reviewers

Automated reviewers have reported this rule as violated on **eleven pull requests that satisfied it**: #969, #970, #973, #976, #979, #980, #988, #989, #990, #992 and #993. Each named an author no commit carried. #969 cited a commit SHA that exists nowhere in the repository.

The finding anchors on whichever file leads the diff, which varies, so it is not a misreading of any particular commit — it is a report of the most prominent rule in AGENTS.md, produced without consulting commit metadata. Every one was refuted from that metadata, and each refutation cost a round trip.

AGENTS.md now states plainly that the policy's presence is not evidence it has been broken, gives the two commands that settle the question, and asks that a report quote what they print. A green `commit-authorship` check is that same evidence, produced automatically.

This half may not stop a reviewer that is not reading metadata in the first place. The check is what makes the question answerable either way.

## Verification

Each violation shape was confirmed caught on a throwaway branch before this landed, rather than assumed:

| Probe | Result |
| --- | --- |
| AI author (`Codex <codex@openai.com>`) | failed, named |
| AI committer under a human author | failed, named |
| `Co-authored-by:` trailer naming an assistant | failed, named |
| `dependabot[bot]` commit in the same range | passed, correctly ignored |
| The real #993 range (2 commits) | passed |

`actionlint` and `shellcheck` are both clean.
