### PR TITLE
docs: set the libraries release line to 0.5.0-M05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,40 @@ the shape of the next release, and it is what CI stamps on every build. Dated he
 `## [Unreleased]` is optional and carries no build meaning; use it for entries not yet assigned to
 a release.
 
-## [0.6.0-M01]
+## [0.5.0-M05]
+
+The first release cut through the independent version streams, and the first since this changelog
+existed. It carries roughly seventy merged pull requests; the notable ones are below, and the GitHub
+release notes hold the full list, which release-drafter builds from the pull requests themselves.
 
 ### Added
+- The Morphir desktop application: an Electron shell hosting morphir-ui, with Scala.js in both
+  processes over a kyo-jsonrpc seam. It is packaged for macOS, Linux and Windows and published to a
+  GitHub Release and to Maven Central, each asset carrying a `.sha256` sidecar (#986, #987, #988).
+- A knowledge base under `kb/`, with the kb tooling, Decision Records as a third register, and an
+  intent lifecycle that CI checks (#936, #939, #942, #948).
+- Buildkit core: a Morphir-agnostic typed task graph with the outcome executor, alongside
+  morphir-prelude (#966, #971).
+- A GitHub connector, and the published library families (#983).
+- The Mill Morphir plugins, dogfooded by this repository (#955).
+- Mirrored Morphir IR sources, validated against the schemas (#945).
 - Independent version streams: the libraries, the Mill plugins and the desktop application each take
-  their version from their own changelog and tag stream.
+  their version from their own changelog and tag stream (#991).
+- A Kyo runtime data foundation, moving to kyo 1.0.0-RC6 (#950).
+- Elm port and effect module metadata, carried through lowering (#937).
+
+### Changed
+- Snapshot coordinates now count toward the release the changelog names next, rather than away from
+  the last one that shipped. `0.5.0-M05-12-SNAPSHOT` means twelve commits into work that will become
+  `0.5.0-M05` (#991).
+- SNAPSHOTs publish from `develop` as well as `main` (#970).
+- Squire's tooling is Scala rather than Python (#956).
+- Durable task tracking moved to beads (#941).
+
+### Fixed
+- Closure parameter patterns are retained in the model (#952).
+- Sonatype publishing is serialized, so it no longer crashes in SubstituteLogger (#958).
+- A breaking-change label no longer drafts a 1.0.0 release (#951).
 
 ## [0.5.0-M04] - 2026-04-22
 


### PR DESCRIPTION
Sets the libraries release line to `0.5.0-M05` and writes its notes, so the next milestone can be cut.

## Why the line changes

The undated heading read `0.6.0-M01`, so the build was heading toward a minor bump. The next libraries release is a milestone on the 0.5.0 line, which is what the tag stream has carried since M01: `v0.5.0-M01` … `v0.5.0-M04`.

`0.5.0-M05` clears the area's `0.5.0-M04` floor, so the changelog gate accepts it.

The last non-SNAPSHOT release on this line was **`v0.5.0-M04`, published 2026-04-22**.

## Why the notes grew

The section had a single bullet, for the version streams. This is the first release since April, and the first cut through the independent streams. It carries roughly seventy merged pull requests, so the notable ones are now listed:

- the desktop application and its publishing path (#986, #987, #988)
- the knowledge base and intent lifecycle (#936, #939, #942, #948)
- buildkit core (#966, #971)
- the GitHub connector and published library families (#983)
- the Mill Morphir plugins (#955)
- the mirrored Morphir IR sources and schema conformance (#945)
- independent version streams (#991)
- the Kyo runtime data foundation (#950)

The exhaustive list stays in the GitHub release notes, which release-drafter builds from the pull requests themselves, rather than being duplicated by hand here.

The changed snapshot direction is recorded under **Changed**, because a consumer reading `0.5.0-M05-12-SNAPSHOT` needs to know the number counts *toward* the release rather than away from the last one that shipped.

## Verification

```
$ .claude/skills/squire/squire changelog check
   libraries      release line 0.5.0-M05
   mill-plugins   release line 0.5.0-M05
   desktop        release line 0.1.0

3 area(s) OK

$ .claude/skills/squire/squire release status
   libraries      pending — next tag v0.5.0-M05
   mill-plugins   pending — next tag mill-plugins/v0.5.0-M05
   desktop        pending — next tag desktop/v0.1.0

release status: clean

$ ./mill --ticker false -i show morphir.jvm.streamVersion
"0.5.0-M05-release.0.5.0.m05.line.82.g538a88-SNAPSHOT"
```

## What this does not do

- **It does not tag anything.** Cutting `v0.5.0-M05` stays a human act, deliberately.
- **It does not date the heading.** `squire release prepare --area libraries` does that *after* the release, and opens the next undated heading.

## One thing worth deciding separately

The Mill plugin family also declares `0.5.0-M05`. There is no technical conflict, since the tags are `v0.5.0-M05` and `mill-plugins/v0.5.0-M05` in separate streams, but two areas sitting at an identical number partly undercuts the readability the split was for. The plugin family has never published on its own, so its first real release is a free choice of number.
