### PR TITLE
fix(deps): pin uuid to 11.1.1 in the Morphir Elm tool locks

### DIFF
--- a/mill-build/test/MorphirElmToolTests.scala
+++ b/mill-build/test/MorphirElmToolTests.scala
@@ -14,7 +14,7 @@ def assertEquals[A](actual: A, expected: A): Unit =
   assertEquals(MorphirElmTool.Version, "2.99.0")
   assertEquals(
     os.read(toolDirectory / "package.json").trim,
-    """{"name":"morphir-scala-morphir-elm-tool","private":true,"dependencies":{"morphir-elm":"2.99.0"}}"""
+    """{"name":"morphir-scala-morphir-elm-tool","private":true,"dependencies":{"morphir-elm":"2.99.0"},"overrides":{"uuid":"^11.1.1"}}"""
   )
   assertEquals(manifest("name").str, "morphir-scala-morphir-elm-tool")
   assert(manifest("private").bool)

--- a/mill-plugins/morphir/elm/test-tools/morphir-elm/package-lock.json
+++ b/mill-plugins/morphir/elm/test-tools/morphir-elm/package-lock.json
@@ -3643,20 +3643,6 @@
         "npm": "*"
       }
     },
-    "node_modules/morphir-elm/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/mill-plugins/morphir/elm/test-tools/morphir-elm/package.json
+++ b/mill-plugins/morphir/elm/test-tools/morphir-elm/package.json
@@ -1,1 +1,1 @@
-{"name":"morphir-scala-morphir-elm-tool","private":true,"dependencies":{"morphir-elm":"2.99.0"}}
+{"name":"morphir-scala-morphir-elm-tool","private":true,"dependencies":{"morphir-elm":"2.99.0"},"overrides":{"uuid":"^11.1.1"}}

--- a/mill-plugins/morphir/integration/resources/published-consumer/tool/package-lock.json
+++ b/mill-plugins/morphir/integration/resources/published-consumer/tool/package-lock.json
@@ -3643,20 +3643,6 @@
         "npm": "*"
       }
     },
-    "node_modules/morphir-elm/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/mill-plugins/morphir/integration/resources/published-consumer/tool/package.json
+++ b/mill-plugins/morphir/integration/resources/published-consumer/tool/package.json
@@ -1,1 +1,1 @@
-{"name":"morphir-scala-morphir-elm-tool","private":true,"dependencies":{"morphir-elm":"2.99.0"}}
+{"name":"morphir-scala-morphir-elm-tool","private":true,"dependencies":{"morphir-elm":"2.99.0"},"overrides":{"uuid":"^11.1.1"}}


### PR DESCRIPTION
Closes the two open `uuid` Dependabot alerts (#115, #116).

## What was vulnerable

Both committed Morphir Elm tool lockfiles carried a nested
`node_modules/morphir-elm/node_modules/uuid` at `9.0.1` — below the
`11.1.1` that fixes the missing buffer bounds check in `v3`/`v5`/`v6`
when a caller supplies `buf`.

- `mill-plugins/morphir/elm/test-tools/morphir-elm/`
- `mill-plugins/morphir/integration/resources/published-consumer/tool/`

## Why an override rather than a version bump

Upgrading `morphir-elm` does not clear it. **Both `2.99.0` and `2.100.0`
declare `uuid: ^9.0.1`**, so the nested copy survives any bump available
to us — and `renovate.json` currently blocks `2.100.0` anyway for the
fatal `EBADF` regression (bead `morphir-qki`). An npm `overrides` entry
is the only route.

The v11 pin is safe here:

- No shipped `morphir-elm` JavaScript imports the `uuid` package. The
  `uuid` hits in its bundles are Elm-compiled pattern matches on the
  *Morphir* SDK module name, not the npm module.
- `vis-network`, the one real consumer, already accepts `^11.0.0` as a
  peer.

Regenerating both locks drops the nested `9.0.1` and leaves a single
`uuid` at `11.1.1`.

`MorphirElmLock.validate` still accepts both locks — `overrides` sits on
the root package entry, which the validator does not constrain.
`MorphirElmToolTests` compares the manifest byte for byte, so its
expected string moves with the manifest.

## The third alert

Alert #163 (`extract-zip` ≤ 2.0.1, high, CVE-2026-56876) is **not**
addressed here because it is already fixed on `main` by #1008: Electron
40+ replaced the unmaintained `extract-zip` with its own
`@electron-internal/extract-zip` fork. Worth recording that `extract-zip`
itself has no patched release — `2.0.1` is still latest on npm — so
upgrading Electron was the only route. That fix reached `develop` in the
`main`→`develop` fast-forward that precedes this branch.

## Verification

| Check | Result |
| --- | --- |
| `mill-build/test/MorphirElmToolTests.scala` | pass |
| `mill-plugins.morphir.{toolchain,javascript,elm-tooling,core,elm}.__.test` | 669 tasks SUCCESS |
| `mill-plugins.morphir.integration.test` | 3 tests pass |
| `ci.lint` | clean |
| `npm ci` + `npm audit` in both tool trees | 0 vulnerabilities |

The integration and elm plugin tests perform a real `npm ci` and invoke
the `morphir-elm` CLI, so the regenerated locks are exercised end to end
rather than only parsed.