### PR TITLE
fix(ci): scope the native build-output cache key to the ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,7 +494,20 @@ jobs:
           #
           # What remains is reuse across re-runs of the same commit, which is exactly the case that
           # follows a timeout or an infrastructure flake. Cold runs stay cold; see bead morphir-dru.
-          key: ${{ runner.os }}-mill-native-${{ matrix.java }}-${{ github.sha }}
+          #
+          # `github.ref_name` is part of the key because the commit alone does not identify a run.
+          # GitHub lets any branch read a cache written on the default branch, and a fast-forward
+          # `main`-to-`develop` sync leaves both branches on one commit — so `develop`'s *first*
+          # run restored `main`'s entry on a fresh runner and failed exactly as the reverted
+          # cross-commit restore did: the same 11 GithubClientTests assertions, this time
+          # `SnapshotNotFound`, because `out/morphir/**/native/` carries the task metadata that
+          # tells Mill the work is done while the no-daemon sandbox holding the blessed snapshots
+          # is not cached. Proven at f83f27b4 on 2026-08-19: `main` cold gave 81 passed / 0 failed,
+          # `develop` restoring that entry gave 70 / 11, and a cold re-run gave 81 / 0 again. The
+          # ref keeps the two apart while a re-run still hits its own entry. See bead morphir-8qz;
+          # the other Mill build-output caches in this file share the unscoped shape and have not
+          # yet been changed.
+          key: ${{ runner.os }}-mill-native-${{ matrix.java }}-${{ github.ref_name }}-${{ github.sha }}
 
       - name: Run Native tests
         # Kept in step with .config/mise/tasks/test/native for the selectors, but `-j 2` rather than


### PR DESCRIPTION
Found while syncing `main` into `develop` today. `develop`'s CI failed
`test-native` with 11 `GithubClientTests` failures on a tree that `main`
had just passed clean.

## The commit alone does not identify a run

The key was `${{ runner.os }}-mill-native-${{ matrix.java }}-${{ github.sha }}`,
justified in-file as limiting reuse to "re-runs of the same commit".

GitHub lets any branch read a cache written on the default branch, and a
fast-forward `main`→`develop` sync leaves both branches on one commit. So
`develop`'s **first** run restored `main`'s entry on a fresh runner. That
is a cross-*run* restore, not a re-run, and it fails the way the
cross-commit restore reverted in #990 failed — the same 11 assertions,
here `SnapshotNotFound`.

The cached `out/morphir/**/native/` carries the task metadata that tells
Mill the work is done, while the no-daemon sandbox the snapshot lookup
resolves against (`out/mill-no-daemon/<hash>/mill-workspace/…`) is not
cached. The blessed snapshots are committed; the restored run simply
could not see them, so it wrote proposed ones and failed.

## Measured

Same tree (`f83f27b4`), same job, same Java. The restore is the only
variable:

| Run | Native cache | `GithubClientTests` |
| --- | --- | --- |
| `main` 15:57 | `Cache not found` — cold | **81 passed, 0 failed** → saved the entry 16:12 |
| `develop` 16:16 | `Cache restored from key: Linux-mill-native-25-f83f27b4…` (959 MB) | **70 passed, 11 failed** |
| `develop` re-run 16:49 | `Cache not found` — cold (entry had been evicted) | **81 passed, 0 failed** |

## The change

Adds `github.ref_name` to the key. The two branches can no longer share
an entry, while a re-run still hits its own — so the reuse this cache
was added for in #990 is unaffected.

No legitimate hit is lost. The key already pins the commit, so two
branches could only ever share an entry when they shared a commit, which
is exactly the case that is unsafe.

## Deliberately not swept

Every other Mill build-output cache in `ci.yml` has the same unscoped
shape (`mill-jvm`, `mill-js-platform`, `mill-js-desktop`,
`mill-morphir-unit`, `mill-morphir-projects`, `mill-runtime-generated`).
None has manifested this, because the sandbox interaction is specific to
the native snapshot tests, and `test-js`/`test-jvm` passed on `develop`
in the very run where `test-native` failed. Widening a shared workflow on
a theoretical hazard is a separate decision — noted in bead `morphir-8qz`
rather than folded in here.

## Verification

`ci.yml` parses and the job resolves the intended key:

```
key -> ${{ runner.os }}-mill-native-${{ matrix.java }}-${{ github.ref_name }}-${{ github.sha }}
```

The real proof is this PR's own `test-native`: it writes under the new
key shape and must pass cold.