### PR TITLE
chore: back-migrate main to develop

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -5,7 +5,7 @@
 # Run `mise tasks` to see available tasks
 
 [tools]
-bun = "1.3.14"
+bun = "1.4.0"
 node = "24.19.0"
 "scala-cli" = "1.16.0"
 


### PR DESCRIPTION
Brings `main` back into `develop` ahead of the
`mill-github-dependency-graph` 0.3.0 upgrade. The branches have diverged,
so this is a real merge rather than the fast-forward we could use last
time.

## ⚠️ Must be merged with a **merge commit**, not squashed or rebased

Same reason as #999. A squash records the content but not the parentage,
so the merge base for the next `develop`-to-`main` promote would stay at
`f83f27b4` and every add/add conflict would come back. A rebase would
rewrite the SHAs and do the same damage.

After this merge commit, `git merge-base --is-ancestor origin/main HEAD`
succeeds — verified locally.

## What diverged

`main` had one commit `develop` never received:

```
d767caf7 chore(deps): update dependency bun to v1.4.0 (#1016)
```

`develop` has three `main` does not, which a later promote will carry up:

```
99c80789 feat(markdown): complete CommonMark conformance and the two-writer compile path (#1017)
629947f6 fix(deps): pin uuid to 11.1.1 in the Morphir Elm tool locks (#1010)
da03d29b fix(ci): scope the native build-output cache key to the ref (#1013)
```

## Resolution

No conflicts. The merge touches a single line:

```diff
 [tools]
-bun = "1.3.14"
+bun = "1.4.0"
```

Nothing on the `develop` side competes with it, so there was no judgement
to make here — unlike #999, where 31 paths conflicted and only two lines
were genuine divergence.