### PR TITLE
chore: retire develop and move to trunk-based development

### DIFF
--- a/.claude/skills/squire/SquireTests.scala
+++ b/.claude/skills/squire/SquireTests.scala
@@ -41,12 +41,11 @@ object SquireLauncherFixtures:
     if !path.toFile.setExecutable(true) then throw new AssertionError(s"could not make $path executable")
 
 object SquireCiPolicy:
-  val SupportedBranches = List("main", "0.4.x", "develop")
+  val SupportedBranches = List("main", "0.4.x")
   val PublishPredicate  =
     "github.repository == 'finos/morphir-scala' && " +
       "(github.ref == 'refs/heads/main' || " +
       "github.ref == 'refs/heads/0.4.x' || " +
-      "github.ref == 'refs/heads/develop' || " +
       "startsWith(github.ref, 'refs/tags/v'))"
   val PublishPluginsPredicate =
     "github.repository == 'finos/morphir-scala' && startsWith(github.ref, 'refs/tags/mill-plugins/v')"
@@ -58,7 +57,6 @@ object SquireCiPolicy:
   val CachePredicate =
     "github.ref == 'refs/heads/main' || " +
       "github.ref == 'refs/heads/0.4.x' || " +
-      "github.ref == 'refs/heads/develop' || " +
       "startsWith(github.ref, 'refs/tags/')"
   val SnapshotCommands = List(
     "echo \"MORPHIR_PUBLISH_MODE=snapshot\" >> \"$GITHUB_ENV\"",
@@ -344,8 +342,8 @@ object SquireCiPolicy:
     val publish  = publishBlock(workflow)
     val snapshot = indentedBlock(publish, "- name: Configure snapshot version", 6)
     expect(
-      scalar(snapshot, "if") == "github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'",
-      "snapshot step must run only on main and develop"
+      scalar(snapshot, "if") == "github.ref == 'refs/heads/main'",
+      "snapshot step must run only on main"
     )
     val lines    = snapshot.linesIterator.toList
     val runIndex = lines.indexWhere(_.trim == "run: |")
@@ -994,12 +992,12 @@ class SquireCliSpec extends Test[Any]:
       val json       = new StringBuilder
       for
         textExit <- SquireCli.runBranch(
-          BranchRefreshOpts(dryRun = true),
+          BranchRefreshOpts(target = "develop", dryRun = true),
           textRunner,
           value => text.append(value)
         )
         jsonExit <- SquireCli.runBranch(
-          BranchRefreshOpts(dryRun = true, json = true),
+          BranchRefreshOpts(target = "develop", dryRun = true, json = true),
           jsonRunner,
           value => json.append(value)
         )
@@ -1642,7 +1640,7 @@ class SquireCiPolicySpec extends Test[Any]:
         assert(scala.util.Try(assertPublishTargetInventory(withoutPlugin)).isFailure)
     }
 
-    "scopes the exact snapshot configuration to main and develop" in {
+    "scopes the exact snapshot configuration to main" in {
       assertSnapshotPolicy(workflow)
       assert(true)
     }
@@ -2018,13 +2016,13 @@ class SquireCiPolicySpec extends Test[Any]:
     "rejects representative branch snapshot and publish regressions" in {
       val pushWithExtraBranch = replaceOnce(
         workflow,
-        "  push:\n    branches: [\"main\", \"0.4.x\", \"develop\"]",
-        "  push:\n    branches: [\"main\", \"0.4.x\", \"develop\", \"feature\"]"
+        "  push:\n    branches: [\"main\", \"0.4.x\"]",
+        "  push:\n    branches: [\"main\", \"0.4.x\", \"feature\"]"
       )
       val broadSnapshotCondition = replaceOnce(
         workflow,
-        "        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'\n        run: |",
-        "        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/feature'\n        run: |"
+        "        if: github.ref == 'refs/heads/main'\n        run: |",
+        "        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature'\n        run: |"
       )
       val extraSnapshotWrite = replaceOnce(
         workflow,
@@ -2064,7 +2062,6 @@ class SquireCiPolicySpec extends Test[Any]:
       val predicates = List(
         "github.ref == 'refs/heads/main'",
         "github.ref == 'refs/heads/0.4.x'",
-        "github.ref == 'refs/heads/develop'",
         "startsWith(github.ref, 'refs/tags/')"
       )
       val mutations =
@@ -2558,27 +2555,22 @@ class SquireBranchSpec extends Test[Any]:
   import SquireBranchFixtures.*
 
   "CLI options" - {
-    "default to develop without dry-run or JSON" in {
+    // `--target` has no default. It defaulted to `develop` while that branch existed; with the
+    // repository on trunk-based development there is no branch it would be right to assume, so the
+    // caller names one.
+    "require a target rather than assuming one" in {
       val parsed = Parser[BranchRefreshOpts].parse(Seq.empty)
-      assert(parsed == Right((BranchRefreshOpts(), Seq.empty)))
+      assert(parsed.isLeft, s"a bare refresh must not parse, got $parsed")
     }
 
+    // A bare positional is refused at parse time now that `--target` carries no default. It used to
+    // parse — the default supplied the target and the positional fell through to a later check — so
+    // the refusal moved earlier rather than away, and still happens before any process runs.
     "accept a named target and reject a bare positional target before any process" in {
       val named      = Parser[BranchRefreshOpts].parse(Seq("--target", "release-line"))
       val positional = SquireApp.BranchRefreshCmd.parser.detailedParse(Seq("release-line"))
-      positional match
-        case Left(_)                     => assert(false)
-        case Right((options, remaining)) =>
-          val runner = BranchRecordingRunner(Map.empty)
-          Abort.run[SquireError](
-            SquireCli.runBranch(options, remaining.all, runner, _ => ())
-          ).map { outcome =>
-            assert(
-              named == Right((BranchRefreshOpts(target = "release-line"), Seq.empty)) &&
-                failureContains(outcome, "unexpected positional arguments", "release-line") &&
-                runner.requests.isEmpty
-            )
-          }
+      assert(named == Right((BranchRefreshOpts(target = "release-line"), Seq.empty)))
+      assert(positional.isLeft, s"a bare positional target must not parse, got $positional")
     }
   }
 

--- a/.claude/skills/squire/squire.scala
+++ b/.claude/skills/squire/squire.scala
@@ -62,7 +62,7 @@ final case class ReferenceRepoRemoveOpts(
 )
 
 final case class BranchRefreshOpts(
-    @HelpMessage("Target branch to refresh") target: String = "develop",
+    @HelpMessage("Target branch to refresh, for example a release line") target: String,
     @HelpMessage("Report the update without writing") dryRun: Boolean = false,
     @HelpMessage("Output the typed result as JSON") json: Boolean = false
 )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ env:
 
 on:
   pull_request:
-    branches: ["main", "0.4.x", "develop"]
+    branches: ["main", "0.4.x"]
   push:
-    branches: ["main", "0.4.x", "develop"]
+    branches: ["main", "0.4.x"]
   release:
     types:
       - published
@@ -326,7 +326,7 @@ jobs:
     # under 15 minutes and has also exceeded 30 on the same branch with no JS sources changed, and a
     # timed-out job is reported as *cancelled*, which reads like an unrelated failure. Pull requests
     # always pay a cold build here: the JS build cache is keyed by the exact commit SHA and is only
-    # saved on main, develop, 0.4.x and tags, so a PR can never restore it.
+    # saved on main, 0.4.x and tags, so a PR can never restore it.
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -371,7 +371,7 @@ jobs:
 
       - name: Cache JS build output
         # when in master repo: all commits to main branch and all additional tags
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.4.x' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/')
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.4.x' || startsWith(github.ref, 'refs/tags/')
         uses: actions/cache/save@v6
         with:
           path: |
@@ -427,7 +427,7 @@ jobs:
 
       - name: Cache JS build output
         # when in master repo: all commits to main branch and all additional tags
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.4.x' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/')
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.4.x' || startsWith(github.ref, 'refs/tags/')
         uses: actions/cache/save@v6
         with:
           path: |
@@ -497,14 +497,16 @@ jobs:
           #
           # `github.ref_name` is part of the key because the commit alone does not identify a run.
           # GitHub lets any branch read a cache written on the default branch, and a fast-forward
-          # `main`-to-`develop` sync leaves both branches on one commit — so `develop`'s *first*
+          # `main`-to-`develop` sync left both branches on one commit — so `develop`'s *first*
           # run restored `main`'s entry on a fresh runner and failed exactly as the reverted
           # cross-commit restore did: the same 11 GithubClientTests assertions, this time
           # `SnapshotNotFound`, because `out/morphir/**/native/` carries the task metadata that
           # tells Mill the work is done while the no-daemon sandbox holding the blessed snapshots
           # is not cached. Proven at f83f27b4 on 2026-08-19: `main` cold gave 81 passed / 0 failed,
-          # `develop` restoring that entry gave 70 / 11, and a cold re-run gave 81 / 0 again. The
-          # ref keeps the two apart while a re-run still hits its own entry. See bead morphir-8qz;
+          # `develop` restoring that entry gave 70 / 11, and a cold re-run gave 81 / 0 again.
+          # `develop` has since been retired, but the reason holds for any two refs sharing one
+          # commit — a release branch cut from `main`, or a re-run of the same SHA. The ref keeps
+          # them apart while a re-run still hits its own entry. See bead morphir-8qz;
           # the other Mill build-output caches in this file share the unscoped shape and have not
           # yet been changed.
           key: ${{ runner.os }}-mill-native-${{ matrix.java }}-${{ github.ref_name }}-${{ github.sha }}
@@ -550,7 +552,7 @@ jobs:
 
       - name: Cache JVM build output
         # when in master repo: all commits to main branch and all additional tags
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.4.x' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/')
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.4.x' || startsWith(github.ref, 'refs/tags/')
         uses: actions/cache/save@v6
         with:
           path: |
@@ -562,7 +564,7 @@ jobs:
   desktop-matrix:
     # A desktop/v* tag or the desktop release it came from always packages all five platforms,
     # ignoring the switch below — turning off ordinary-CI packaging must never weaken a real
-    # release. A push to main, develop or 0.4.x also packages all five; everything else (a pull
+    # release. A push to main or 0.4.x also packages all five; everything else (a pull
     # request, or a v*/mill-plugins/v* release, which are not this job's business) packages the
     # three-leg smoke matrix, one per operating system. This job just computes which;
     # desktop-package and desktop-verify consume its outputs.
@@ -600,7 +602,7 @@ jobs:
           # "$GITHUB_EVENT_NAME" == "release" test would start all five packaging runners for one.
           # The ref carries the tag on a release event too, so this covers a bare tag push and the
           # release cut from it alike.
-          if [[ "$GITHUB_REF" == refs/tags/desktop/v* || "$GITHUB_REF" == "refs/heads/main" || "$GITHUB_REF" == "refs/heads/develop" || "$GITHUB_REF" == "refs/heads/0.4.x" ]]; then
+          if [[ "$GITHUB_REF" == refs/tags/desktop/v* || "$GITHUB_REF" == "refs/heads/main" || "$GITHUB_REF" == "refs/heads/0.4.x" ]]; then
             MATRIX='{"include":[{"token":"mac-aarch64","runner":"macos-14"},{"token":"mac-amd64","runner":"macos-15-intel"},{"token":"linux-amd64","runner":"ubuntu-24.04"},{"token":"linux-aarch64","runner":"ubuntu-24.04-arm"},{"token":"win-amd64","runner":"windows-latest"}]}'
             PLATFORMS="mac-aarch64,mac-amd64,linux-amd64,linux-aarch64,win-amd64"
           else
@@ -878,7 +880,7 @@ jobs:
     # plugin family releases through the sibling publish-plugins job below, gated on
     # refs/tags/mill-plugins/v*; the desktop application ships through desktop-release, gated on
     # refs/tags/desktop/v*.
-    if: github.repository == 'finos/morphir-scala' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.4.x' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v'))
+    if: github.repository == 'finos/morphir-scala' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.4.x' || startsWith(github.ref, 'refs/tags/v'))
     needs: [ci]
 
     # Without this the job inherits GitHub's six-hour default. An `apt-get update` wedged against
@@ -941,7 +943,7 @@ jobs:
           key: ${{ runner.os }}-mill-js-desktop-25-${{ github.sha }}
 
       - name: Configure snapshot version
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo "MORPHIR_PUBLISH_MODE=snapshot" >> "$GITHUB_ENV"
           echo "MORPHIR_PUBLISH_BRANCH=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
@@ -965,7 +967,7 @@ jobs:
           # shellcheck disable=SC1090
           source "$envfile"
           set +a
-          # Branch pushes (main, develop, 0.4.x) are the snapshot case and keep publishing every
+          # Branch pushes (main, 0.4.x) are the snapshot case and keep publishing every
           # area — libraries and plugins — each stamped from its own changelog, via ci.publish.
           # A refs/tags/v* release is the routed case: this job's guard above already limits the
           # tag path to that one namespace, so ci.sonatype.libraries is the only kind-specific
@@ -982,7 +984,7 @@ jobs:
     # bare v* library tag or a desktop/v* tag — both continue the ref differently ('refs/tags/v...'
     # and 'refs/tags/d...' respectively) — so this job and `publish` above can never both claim
     # the same tag. Unlike `publish`, this job has no branch case: the plugin family's snapshot
-    # publishing already happens from the `publish` job's ci.publish call on main/develop/0.4.x;
+    # publishing already happens from the `publish` job's ci.publish call on main/0.4.x;
     # only the release path is routed separately.
     if: github.repository == 'finos/morphir-scala' && startsWith(github.ref, 'refs/tags/mill-plugins/v')
     needs: [ci]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ commit carries and, in one case, a commit SHA that exists nowhere in the reposit
 worth nothing without the commit metadata that supports it. Before reporting one, read the metadata:
 
 ```bash
-git log --format='%H%n  author:    %an <%ae>%n  committer: %cn <%ce>' origin/develop..HEAD
-git log origin/develop..HEAD --format='%B' | grep -i 'co-authored-by'
+git log --format='%H%n  author:    %an <%ae>%n  committer: %cn <%ce>' origin/main..HEAD
+git log origin/main..HEAD --format='%B' | grep -i 'co-authored-by'
 ```
 
 Quote what those commands print. If they show a human author, no `Co-authored-by:` trailer naming an assistant, and
@@ -372,9 +372,10 @@ The project uses GitHub Actions for CI:
 - `test-jvm` - JVM tests, including `langkit.itest`
 - `test-js` - ScalaJS tests, including the wasm link variants
 - `test-native` - Scala Native tests
-- `publish` - SNAPSHOTs from `main` and `develop`; milestones/releases from `0.4.x` and tags, via `./mill --ticker false -i ci.publish`
+- `publish` - SNAPSHOTs from `main`; milestones/releases from `0.4.x` and tags, via `./mill --ticker false -i ci.publish`
 
-CI runs on pull requests targeting and pushes to `main`, `0.4.x`, and `develop`, plus releases and manual triggers.
+CI runs on pull requests targeting and pushes to `main` and `0.4.x`, plus releases and manual triggers. `main` is
+the trunk: pull requests target it directly.
 
 ## Pull Request & CI Protocol
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ the shape of the next release, and it is what CI stamps on every build. Dated he
 `## [Unreleased]` is optional and carries no build meaning; use it for entries not yet assigned to
 a release.
 
+## [Unreleased]
+
+### Changed
+- The repository moved to trunk-based development. Pull requests target `main` and merge into it; the `develop`
+  integration branch, its promotion pull request and its back-migration are retired. Snapshots publish from `main`
+  alone, and `squire branch refresh` now requires `--target`. See decision 0014.
+
 ## [0.5.0-M05]
 
 The first release cut through the independent version streams, and the first since this changelog

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ NOTE: All contributors must have a contributor license agreement (CLA) on file w
 
 ## Development and snapshot releases
 
-Feature and contributor pull requests target `develop`. Pull-request events run the validation jobs, but never
-publish artifacts. After a pull request is merged, a successful push to `main` or `develop` runs the full aggregate
+Feature and contributor pull requests target `main`. Pull-request events run the validation jobs, but never
+publish artifacts. After a pull request is merged, a successful push to `main` runs the full aggregate
 CI gate and then automatically publishes a traceable snapshot from the canonical `finos/morphir-scala` repository.
 Publication credentials remain in that repository's CI environment; contributors neither need nor receive them
 locally.
@@ -28,15 +28,15 @@ Each snapshot uses an exact coordinate. On `main`, the coordinate is `$releaseLi
 0.5.0-57-SNAPSHOT
 ```
 
-On `develop`, the coordinate is `$releaseLine-$branch.$distance.g$abbrev-SNAPSHOT`, for example:
+On any other publishing branch, the coordinate is `$releaseLine-$branch.$distance.g$abbrev-SNAPSHOT`, for example:
 
 ```text
-0.5.0-M04-develop.57.gbd4cd2-SNAPSHOT
-0.5.0-develop.57.gbd4cd2-SNAPSHOT
+0.5.0-M04-0.4.x.57.gbd4cd2-SNAPSHOT
+0.5.0-0.4.x.57.gbd4cd2-SNAPSHOT
 ```
 
-The release line may include a qualifier (`M04`). On `develop`, the coordinate also records the branch (`develop`),
-the commit distance from the nearest version tag (`57`), and a `g` followed by the first six hexadecimal characters
+The release line may include a qualifier (`M04`). Off `main`, the coordinate also records the branch, the commit
+distance from the nearest version tag (`57`), and a `g` followed by the first six hexadecimal characters
 of the Git revision (`bd4cd2`), before the terminal `SNAPSHOT` marker. Consumers must add the Sonatype snapshot
 repository and depend on the exact coordinate they intend to test:
 
@@ -80,14 +80,15 @@ The focused CI jobs are:
 
 The cache changes performance only. A disabled or empty cache must not change build results.
 
-### Promoting `develop` to `main`
+### Refreshing a long-lived branch from `main`
 
-Maintainers open a `develop`-to-`main` release pull request and **MUST squash-merge it**. Confirming the squash merge
-in GitHub is an operator precondition: the refresh script can prove the merged pull request and its ancestry, but it
-cannot determine which merge method GitHub used.
+`main` is the trunk: pull requests target it and merge into it, and there is no integration branch in front of it.
+See [decision 0014](kb/bundles/morphir/morphir-scala/decisions/0014-trunk-based-development-on-main.md) for why the
+`develop` branch was retired.
 
-After the squash merge is visible on `origin/main`, verify that `origin` is the intended canonical repository and that
-the GitHub CLI is authenticated and resolves the same repository:
+A long-lived branch that is *behind* `main` — a release line such as `0.4.x`, say — can be refreshed from it, once
+the branch's own pull request into `main` has been squash-merged and is visible on `origin/main`. First verify that
+`origin` is the intended canonical repository and that the GitHub CLI is authenticated and resolves the same one:
 
 ```bash
 git remote get-url origin
@@ -96,20 +97,20 @@ gh repo view --json nameWithOwner --jq .nameWithOwner
 ```
 
 Stop if the remote is not the canonical `finos/morphir-scala` repository or the final command does not print
-`finos/morphir-scala`. Then prove the default `develop` refresh without pushing, review the reported branch and SHAs,
-and perform it:
+`finos/morphir-scala`. Then prove the refresh without pushing, review the reported branch and SHAs, and perform it:
 
 ```bash
-.claude/skills/squire/squire branch refresh --dry-run
-.claude/skills/squire/squire branch refresh
+.claude/skills/squire/squire branch refresh --target <branch> --dry-run
+.claude/skills/squire/squire branch refresh --target <branch>
 ```
 
-The equivalent assisted workflow is `/squire branch refresh`. The command defaults to `develop`; for a different
-integration branch, pass `--target <branch>` to both invocations. It fetches remote-tracking refs but does not
-check out a branch or mutate the working tree. Before updating the remote target, it requires the target SHA to match
-the merged pull request's exact head and requires that pull request's merge commit to be an ancestor of
-`origin/main`. It therefore refuses to refresh if `develop` advanced after the matching pull request. The only remote
-update it can make is protected by `--force-with-lease`; it never uses or recommends unconditional force.
+The equivalent assisted workflow is `/squire branch refresh --target <branch>`. `--target` is required and has no
+default; it defaulted to `develop` while that branch existed, and there is now no branch it would be right to assume.
+The command fetches remote-tracking refs but does not check out a branch or mutate the working tree. Before updating
+the remote target, it requires the target SHA to match the merged pull request's exact head and requires that pull
+request's merge commit to be an ancestor of `origin/main`. It therefore refuses to refresh if the target advanced
+after the matching pull request. The only remote update it can make is protected by `--force-with-lease`; it never
+uses or recommends unconditional force.
 
 ## Benchmarking
 

--- a/kb/bundles/morphir/morphir-scala/continuous-integration.md
+++ b/kb/bundles/morphir/morphir-scala/continuous-integration.md
@@ -22,7 +22,7 @@ branches.
 | `test-js` | ScalaJS tests, including the WebAssembly link variants, for every JS/Wasm module except the desktop/UI subset (see `test-js-desktop`) |
 | `test-js-desktop` | The same ScalaJS/WebAssembly workload as `test-js`, scoped to `morphir.ui`, `morphir.desktop` and `morphir.appkit.electron`. Split into its own runner because linking that subset alongside the rest of the JS tree in one Mill daemon exceeded the 8 GB heap in `.mill-jvm-opts`; `ci.testJs`/`ci.testJsWasmLink` (`ci/MorphirCi.mill`) resolve the shared wildcard once and partition it with `millbuild.JsTestSelectors`, so the two jobs' targets are exhaustive and disjoint by construction. |
 | `test-native` | Scala Native tests |
-| `publish` | Sonatype publication via Mill `ci.publish`. Branch snapshots on `main` and `develop`; VCS milestones and releases on `0.4.x` and tags. The publish set is whatever Mill resolves for `__.publishSonatypeCentral`, including the Mill Morphir plugin family (`org.finos.morphir.mill`); the test-only `integration` module is not a publish module and is not uploaded. Destination tasks live under `ci.sonatype.*`. |
+| `publish` | Sonatype publication via Mill `ci.publish`. Branch snapshots on `main`; VCS milestones and releases on `0.4.x` and tags. The publish set is whatever Mill resolves for `__.publishSonatypeCentral`, including the Mill Morphir plugin family (`org.finos.morphir.mill`); the test-only `integration` module is not a publish module and is not uploaded. Destination tasks live under `ci.sonatype.*`. |
 | `desktop-package` | Matrix job, one runner per platform token (`mac-aarch64`, `mac-amd64`, `linux-amd64`, `linux-aarch64`, `win-amd64`). Links Scala.js with `fullLinkJS` and runs `electron-builder`, then uploads the raw output as a workflow artifact. Runs only when a GitHub Release publishes or the ref is a tag. |
 | `desktop-release` | One Linux runner. Canonicalizes the staged assets, signs `checksums.txt`, verifies, then uploads to the GitHub Release and to Sonatype Central as one bundle. Destination tasks live under `ci.desktop.*`. Same trigger scope as `desktop-package`, and needs it to finish first. |
 | `ci` | Aggregate gate, depending on lint, knowledge-base and all four test jobs |
@@ -31,23 +31,23 @@ See [Packaging and Release](/packaging-and-release.md) for what `publish`, `desk
 `desktop-release` actually ship, the ordered steps each one runs, and the signing keys involved. This page is
 the job inventory; that one is the release story.
 
-CI runs on pull requests into `main`, `0.4.x`, and `develop`; pushes to those same branches; published releases; and
+CI runs on pull requests into `main` and `0.4.x`; pushes to those same branches; published releases; and
 manual dispatch. Older runs of the same pull request are cancelled automatically. Hosted mill invocations pass
 `--ticker false`. That includes the workflow, the local `lint` mise wrapper, and `test:jvm-platform`. The GitHub
 log is then a linear task trace rather than a replayed progress ticker.
 
 The Release step runs `ci.sonatype.writeMillEnv` first, with Morphir `GPG_*` and `SONATYPE_*` names in that mill.
 It sources the written file and then starts `./mill --ticker false -i ci.publish`. Mill snapshots `Task.env` at process start, so
-conversion has to happen in an earlier mill. Live Central upload is the first `develop` publish job after merge.
+conversion has to happen in an earlier mill. Live Central upload is the first `main` publish job after merge.
 
 ## Branch snapshots
 
-A push or merge to `main` or `develop` must pass the full aggregate `ci` gate before publishing. On `main`, the
+A push or merge to `main` must pass the full aggregate `ci` gate before publishing. On `main`, the
 exact coordinate is `$releaseLine-$distance-SNAPSHOT`, for example `0.5.0-M04-57-SNAPSHOT` or `0.5.0-57-SNAPSHOT`.
-On `develop`, the coordinate is `$releaseLine-$branch.$distance.g$abbrev-SNAPSHOT`, for example
-`0.5.0-M04-develop.57.gbd4cd2-SNAPSHOT` or `0.5.0-develop.57.gbd4cd2-SNAPSHOT`: the release line may have a
-qualifier, and the coordinate records `develop`, the distance from the nearest version tag, and a six-character Git
-abbreviation before the terminal `SNAPSHOT` marker.
+On any other publishing branch, the coordinate is `$releaseLine-$branch.$distance.g$abbrev-SNAPSHOT`, for example
+`0.5.0-M04-0.4.x.57.gbd4cd2-SNAPSHOT`: the release line may have a qualifier, and the coordinate records the branch,
+the distance from the nearest version tag, and a six-character Git abbreviation before the terminal `SNAPSHOT`
+marker.
 
 Only non-PR runs in the canonical `finos/morphir-scala` repository can reach publication and its credentials. Pull
 requests validate without publishing, and contributors do not receive publication credentials locally. Consumers

--- a/kb/bundles/morphir/morphir-scala/decisions/0014-trunk-based-development-on-main.md
+++ b/kb/bundles/morphir/morphir-scala/decisions/0014-trunk-based-development-on-main.md
@@ -1,0 +1,80 @@
+---
+type: Decision Record
+title: "Trunk-based development on main; the develop branch is retired"
+description: "Pull requests target main and merge into it. The develop integration branch and its promotion ritual are removed, because the second branch cost more than it returned."
+state: Accepted
+decided: 2026-08-21
+tags: [ci, release, branching, process]
+status: stable
+---
+
+# 0014 — Trunk-based development on `main`; the `develop` branch is retired
+
+`main` is the trunk. Contributor and maintainer pull requests target it and merge into it. There is no integration
+branch in front of it, and the `develop` branch has been deleted.
+
+```mermaid
+flowchart LR
+  subgraph before [Before]
+    pr1["pull request"] --> dev["develop"]
+    dev --> promote["promotion PR"] --> main1["main"]
+    main1 -->|"back-migrate PR"| dev
+  end
+  subgraph after [After]
+    pr2["pull request"] --> main2["main"]
+  end
+```
+
+**Figure 1:** the loop that came out. `develop` needed promoting forward and back-migrating back, and both directions
+were pull requests a person had to open, merge and then repair when they drifted.
+
+## Why
+
+The two-branch flow asked for four things that a one-branch flow does not.
+
+A **promotion pull request** from `develop` to `main` for every release, which had to be squash-merged, and which
+CONTRIBUTING had to explain because GitHub cannot report which merge method was used.
+
+A **back-migration** the other way, because `main` also received commits directly — dependency bumps landed there —
+so the two branches diverged in both directions at once. The final state before this decision had `develop` three
+commits ahead of `main` and `main` one commit ahead of `develop`, with an open back-migration pull request to repair
+it.
+
+A **refresh command** — `squire branch refresh` — built to move `develop` forward safely after a promotion, with SHA
+and ancestry proofs, because doing it by hand risked losing commits.
+
+A **branch in every predicate**. `develop` appeared in the CI triggers, the publish predicate, the snapshot
+configuration step, three cache-save conditions, the desktop packaging matrix, and the squire policy tests that hold
+all of those in place.
+
+What it returned was a staging area for `main` — which the pull-request gate already provides. Every pull request
+runs the full aggregate CI gate before it can merge, so `develop` was not catching anything `main` would not have
+caught. It was a second place for the same commits to sit.
+
+## What this changes
+
+Snapshots publish from `main` alone. The branch-qualified snapshot coordinate
+(`0.5.0-M04-develop.57.gbd4cd2-SNAPSHOT`) is still produced for any publishing branch that is not `main`, so a
+release line keeps its own coordinate; `main` keeps the shorter `0.5.0-M04-57-SNAPSHOT` form.
+
+`squire branch refresh` survives, and `--target` is now required. It defaulted to `develop`, and with that branch
+gone there is no branch it would be right to assume. The command is still the safe way to move a long-lived branch —
+a release line such as `0.4.x` — forward from `main`.
+
+`0.4.x` is untouched. Retiring `develop` is not a statement about release lines, which exist to diverge from the
+trunk deliberately and are not integration branches.
+
+## Alternatives
+
+**Keep `develop` and automate the back-migration.** This treats the symptom. The divergence came from commits landing
+on both branches, and automation would have made the repair quieter rather than unnecessary.
+
+**Keep `develop` and forbid direct commits to `main`.** This would have removed the back-migration but not the
+promotion, and it would have meant routing dependency-bump automation through the integration branch as well —
+more configuration, for a staging area the pull-request gate already covers.
+
+## Revisit when
+
+Pull requests start merging into `main` in a state that the gate did not catch and an integration branch would have —
+a batch that only fails when several changes meet. That would be evidence the gate is measuring the wrong thing, and
+the answer might be an integration branch again, or might be a better gate.

--- a/kb/bundles/morphir/morphir-scala/decisions/index.md
+++ b/kb/bundles/morphir/morphir-scala/decisions/index.md
@@ -34,6 +34,7 @@ past-tense and answers *why is it shaped this way*. See
 ## Build and tooling
 
 * [Keep compiling Mill Morphir plugins into the metabuild](/decisions/0012-keep-source-metabuild-for-mill-morphir-plugins.md) - Normal builds continue to compile mill-plugins/morphir sources into the metabuild; pinned Central artifacts are deferred until bootstrap experience is measured.
+* [Trunk-based development on main; the develop branch is retired](/decisions/0014-trunk-based-development-on-main.md) - Pull requests target main and merge into it. The develop integration branch and its promotion ritual are removed, because the second branch cost more than it returned.
 
 ## Published libraries
 

--- a/kb/bundles/morphir/morphir-scala/log.md
+++ b/kb/bundles/morphir/morphir-scala/log.md
@@ -1,5 +1,14 @@
 # Log
 
+## 2026-08-21
+
+* **Decision**: Recorded [Trunk-based development on main](/decisions/0014-trunk-based-development-on-main.md).
+  The `develop` branch is retired: pull requests target `main` and merge into it, snapshots publish from `main`
+  alone, and `squire branch refresh` now requires `--target`. Earlier entries on this page that describe a
+  `develop` publish or a `main`-to-`develop` sync record what was true then and are left as written.
+* **Update**: [Packaging and Release](/packaging-and-release.md) now names `main` and `0.4.x` as the trigger and
+  publish branches.
+
 ## 2026-08-17
 
 * **Creation**: Added [Packaging and Release](/packaging-and-release.md), covering the destinations, triggers,

--- a/kb/bundles/morphir/morphir-scala/packaging-and-release.md
+++ b/kb/bundles/morphir/morphir-scala/packaging-and-release.md
@@ -33,7 +33,7 @@ shows every path, end to end.
 ```mermaid
 flowchart TD
     PR[Pull request] --> Gate[ci gate: lint, tests, kb checks]
-    Push[Push to main, 0.4.x or develop] --> Gate
+    Push[Push to main or 0.4.x] --> Gate
     Rel[GitHub Release published] --> Gate
     Dispatch[Manual dispatch] --> Gate
 
@@ -73,8 +73,8 @@ cut from it, and signing comes before verification, which comes before either up
 
 | Event | GitHub Actions trigger | Condition | What runs |
 | --- | --- | --- | --- |
-| Pull request | `pull_request` | into `main`, `0.4.x`, `develop` | `ci` gate; nothing publishes. Desktop packaging also runs, `linux-amd64` alone, unless the switch below turns it off |
-| Push | `push` | to `main`, `0.4.x`, `develop` | `ci` gate, then `publish` (`ci.publish`, every area) once it passes. Desktop packaging also runs, all five platforms, unless the switch below turns it off |
+| Pull request | `pull_request` | into `main`, `0.4.x` | `ci` gate; nothing publishes. Desktop packaging also runs, `linux-amd64` alone, unless the switch below turns it off |
+| Push | `push` | to `main`, `0.4.x` | `ci` gate, then `publish` (`ci.publish`, every area) once it passes. Desktop packaging also runs, all five platforms, unless the switch below turns it off |
 | Release published | `release`, `types: [published]` | not scoped to a branch | `ci` gate, then whichever of `publish`, `publish-plugins` or `desktop-release` the tag's namespace routes to; see [Release routing](#release-routing). Desktop packaging (all five platforms) always runs alongside it, since a release's `github.ref` carries a tag and `desktop-matrix` treats any tag as the full-platform case |
 | Manual dispatch | `workflow_dispatch` | whichever ref is chosen | the same jobs that ref would otherwise trigger |
 
@@ -103,7 +103,7 @@ unnamespaced library stream, a check that also rejects `refs/tags/desktop/v...` 
 guards are mutually exclusive by construction. A single tag can only ever start one of `refs/tags/v`,
 `refs/tags/desktop/v` or `refs/tags/mill-plugins/v`, so a release never triggers two publish paths at
 once. Snapshot and milestone publishing from a branch push is unaffected by this table: `publish`
-still runs `ci.publish` on `main`, `develop` and `0.4.x`, publishing every area together, each stamped
+still runs `ci.publish` on `main` and `0.4.x`, publishing every area together, each stamped
 from its own changelog. Only the release path routes by tag.
 
 ### Desktop packaging in ordinary CI
@@ -114,7 +114,7 @@ rather than at release time. Four jobs carry this:
 
 | Job | Does |
 | --- | --- |
-| `desktop-matrix` | Computes the platform set: all five tokens on a tag, a published release, or a push to `main`, `develop` or `0.4.x`; `linux-amd64` alone everywhere else (a pull request). Outputs both the matrix JSON and the same set as a comma-separated token list. |
+| `desktop-matrix` | Computes the platform set: all five tokens on a tag, a published release, or a push to `main` or `0.4.x`; `linux-amd64` alone everywhere else (a pull request). Outputs both the matrix JSON and the same set as a comma-separated token list. |
 | `desktop-package` | The same packaging matrix described below, now sized from `desktop-matrix`'s output instead of always covering all five. |
 | `desktop-verify` | Downloads the packaged artifacts, normalizes staging the way `desktop-release` does, then runs `ci.desktop.canonicalize` and `ci.desktop.verify` over exactly that subset, with the signature check relaxed because nothing signs `checksums.txt` here and a pull request carries no GPG secret. No signing and no upload happen in this job, or anywhere in ordinary CI. |
 | `packaging` | Aggregates the three above, the way `ci` aggregates lint and the test jobs. It reads `desktop-matrix` first, because a skip on its own is ambiguous: `desktop-package` also skips when `ci` fails upstream. If `desktop-matrix` was skipped the switch is off and every member must be skipped together; if it ran, packaging was expected to run and only success will do. |
@@ -138,8 +138,8 @@ packaging must never weaken a real release. `desktop-release` depends on `packag
 
 `excludedModuleSubstrings` in `ci/package.mill.yaml` drops `.integration.` (test-only) and
 `.desktop.dist.`: the desktop archives publish through the separate `ci.desktop` destination described
-below, because there is no archive to publish on an ordinary snapshot run. Snapshots publish from `main`
-and `develop`; milestones and releases publish from `0.4.x` and tags. See
+below, because there is no archive to publish on an ordinary snapshot run. Snapshots publish from `main`;
+milestones and releases publish from `0.4.x` and tags. See
 [Continuous Integration](/continuous-integration.md) for the exact coordinate formats, which this page
 reuses rather than restating.
 


### PR DESCRIPTION
Retires `develop` and moves the repository to trunk-based development, as decided in [0014](kb/bundles/morphir/morphir-scala/decisions/0014-trunk-based-development-on-main.md).

Pull requests target `main` and merge into it. The promotion pull request, the back-migration, and the `develop` branch itself are gone.

## Why

The two-branch flow asked for four things a one-branch flow does not:

- a **promotion pull request** for every release, which had to be squash-merged and which CONTRIBUTING had to explain, because GitHub cannot report which merge method was used;
- a **back-migration** the other way, because `main` also received commits directly — dependency bumps landed there — so the branches diverged in both directions at once. The state before this change had `develop` three commits ahead of `main`, `main` one ahead of `develop`, and an open back-migration PR to repair it;
- a **refresh command** built to move `develop` forward safely afterwards;
- a **branch in every predicate** — CI triggers, the publish predicate, the snapshot step, three cache-save conditions, the desktop packaging matrix, and the squire policy holding all of those in place.

What it returned was a staging area for `main` that the pull-request gate already provides. Every PR runs the full aggregate gate before it can merge.

## What changes

`develop` comes out of the CI triggers and every predicate that named it, and out of the squire policy that pins them. Snapshots publish from `main` alone; the branch-qualified coordinate still exists for any other publishing branch, so a release line keeps its own.

`squire branch refresh` survives with `--target` now **required** — it defaulted to `develop`, and there is no branch left it would be right to assume. A bare positional target is refused at parse time rather than a step later: the same refusal, moved earlier.

`0.4.x` is untouched. This says nothing about release lines, which exist to diverge from the trunk deliberately.

## Historical text left as written

The native cache-key comment keeps its `main`-to-`develop` measurement — that evidence is why the key is scoped by ref, and the reason holds for any two refs sharing one commit. Decision 0012 and the dated `0.5.0-M05` changelog entry are superseded rather than edited, per the Decision Record convention.

## Verified

`squire` suite green (it is what enforces the CI branch policy), `ci.lint` clean, `squire changelog check` passes with the new `[Unreleased]` heading, `mise run kb:check` reports 0 errors.

## After merge

The ruleset **`20530189 "Protect develop from deletion"`** has to be removed and the branch deleted. Doing that before this merges would leave CI referencing a branch that no longer exists.
