### PR TITLE
fix(deps): expect uuid v14 in the Morphir Elm tool manifest test

### DIFF
--- a/mill-build/test/MorphirElmToolTests.scala
+++ b/mill-build/test/MorphirElmToolTests.scala
@@ -14,7 +14,7 @@ def assertEquals[A](actual: A, expected: A): Unit =
   assertEquals(MorphirElmTool.Version, "2.99.0")
   assertEquals(
     os.read(toolDirectory / "package.json").trim,
-    """{"name":"morphir-scala-morphir-elm-tool","private":true,"dependencies":{"morphir-elm":"2.99.0"},"overrides":{"uuid":"^11.1.1"}}"""
+    """{"name":"morphir-scala-morphir-elm-tool","private":true,"dependencies":{"morphir-elm":"2.99.0"},"overrides":{"uuid":"^14.0.0"}}"""
   )
   assertEquals(manifest("name").str, "morphir-scala-morphir-elm-tool")
   assert(manifest("private").bool)


### PR DESCRIPTION
`main` has been red since #1020.

Renovate bumped the npm `overrides` entry in both Morphir Elm tool manifests from `^11.1.1` to `^14.0.0` and did not update `MorphirElmToolTests.scala`, which still asserted the old value:

```
Expected …"overrides":{"uuid":"^11.1.1"}, got …"overrides":{"uuid":"^14.0.0"}
```

Not a security question: the override exists to clear two Dependabot alerts on a nested `uuid@9.0.1` inside morphir-elm (#1010), and v14 clears them exactly as v11.1.1 did.

What *was* worth checking is whether morphir-elm still runs, because the override forces v14 onto a package that declares `uuid: ^9.0.1` — five majors up. It does:

- `examples.morphir-elm-projects.__.morphirIR` — IR generated for every project, exit 0
- `mill-plugins.morphir.{toolchain,javascript,elm-tooling,core,elm}.__.test` — all suites pass
- `mill-plugins.morphir.integration.test` — passes; this is the one that resolves the second manifest

So the bump stands and only the expectation moves.