### PR TITLE
build: update mill-github-dependency-graph to 0.3.1

### DIFF
--- a/.github/workflows/github-dependency-graph.yml
+++ b/.github/workflows/github-dependency-graph.yml
@@ -9,6 +9,8 @@ jobs:
   submit-dependency-graph:
     if: github.repository == 'finos/morphir-scala' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     
       - uses: actions/checkout@v7.0.1
@@ -25,6 +27,9 @@ jobs:
       # Generate and submit the dependency graph to GitHub's Dependency Submission API.
       # Uses the Eleven19 fork of mill-github-dependency-graph (the original
       # ckipp01/mill-github-dependency-graph is archived and does not support Mill 1.x).
+      # From 0.3.0 the plugin reports test-module dependencies as `development`
+      # rather than `runtime`, and includes dependencies reached through internal
+      # moduleDeps. The plugin version is pinned in the `//|` header of build.mill.
       - name: Submit dependency graph
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.mill
+++ b/build.mill
@@ -7,7 +7,7 @@
 //| - org.scala-js:scalajs-js-envs_2.13:1.4.0
 //| - com.carlosedp::mill-aliases::1.1.0
 //| - com.github.lolgab::mill-mima::0.2.0
-//| - io.eleven19.mill-github-dependency-graph::mill-github-dependency-graph:0.0.2
+//| - io.eleven19.mill-github-dependency-graph::mill-github-dependency-graph::0.3.1
 //| - org.apache.commons:commons-compress:1.28.0
 
 package build


### PR DESCRIPTION
The build was pinned to `0.0.2`. The artifact id changed in `0.1.0`: releases through `0.0.2` were published as `mill-github-dependency-graph_3`, with no Mill platform suffix, so a version bump alone would not have resolved. The coordinate now carries the platform suffix and resolves to `mill-github-dependency-graph_mill1_3`.

## What 0.3.1 brings

Two `0.3.0` behaviours matter for this build:

- **Test dependencies are reported as `development`.** A test-only dependency used to be indistinguishable from one that ships. On a build this size that is a large share of the manifests, and it made Dependabot treat build-time-only libraries as shipping ones.
- **Dependencies reached through internal `moduleDeps` are included**, marked *indirect*. Releases through `0.2.0` left them out of the manifest entirely, so reading a module's manifest understated what it actually puts on the classpath.

The submit command stays flagless: the default covers every module at runtime scope.

## Workflow permissions

`permissions: contents: write` is now declared on the submit job. GitHub's dependency submission endpoint writes to the repository, and the default `GITHUB_TOKEN` is read-only in many organisations, which returns a `403`.

## Verification

Run locally against this branch:

- `./mill resolve 'io.eleven19.mill.github.dependency.graph.Graph/__'` lists `generate`, `report` and `submit`. `report` exists only from `0.2.0`, so the new coordinate is the one being resolved.
- `Graph/generate --modules 'morphir.prelude.jvm.test'` — 14 dependencies, every one at `scope: development`.
- `Graph/generate --modules 'morphir.prelude.jvm'` — all `runtime`, with `indirect` entries present, confirming module deps are now covered.
- The build resolves 176 modules.

`Graph/submit` is not exercised locally; it reads the run identity from the environment GitHub Actions sets, so it runs on `main` after merge.