### PR TITLE
Add read support for GitHub gists

### DIFF
--- a/morphir/connector/README.md
+++ b/morphir/connector/README.md
@@ -10,7 +10,7 @@ libraries Morphir builds on) and out of feature modules, where it otherwise accu
 
 | Connector | Artifact | For |
 | --- | --- | --- |
-| [`github`](./github) | `morphir-connector-github` | The GitHub GraphQL API (issues, pull requests, discussions) |
+| [`github`](./github) | `morphir-connector-github` | The GitHub GraphQL API (issues, pull requests, discussions, gists) |
 
 ## What belongs in a connector
 

--- a/morphir/connector/github/README.md
+++ b/morphir/connector/github/README.md
@@ -1,6 +1,6 @@
 # morphir-connector-github
 
-A Kyo GitHub GraphQL client for issues, pull requests, and discussions. No Morphir types, no OKF types.
+A Kyo GitHub GraphQL client for issues, pull requests, discussions, and gists. No Morphir types, no OKF types.
 
 Listing includes author, UTC `createdAt` / `updatedAt` as `Maybe[java.time.Instant]`, labels, and comments.
 Discussions include upvote count, an accepted answer, and nested comment replies. `listDiscussions` takes a
@@ -18,6 +18,13 @@ Cursors are `Cursor`. A discussion comment node id is
 Public models and `GitHubException` have `Render` instances so logs and snapshots print opaque numbers and ids as
 `issue:975`, `pr:3`, `discussion:100`, `cursor:c1`, and `dc:DC_1`. Issue and pull request comments have no upvote count and no
 reply tree.
+
+Gist reads are user-scoped rather than repository-scoped. `listGists` lists a named user's public gists, while
+`listMyGists` lists the authenticated viewer's gists with an `All`, `Public`, or `Secret` privacy filter. Lists return
+lightweight `GistSummary` values without file contents or comments. `getGist` and `getMyGist` return a full `Gist`
+with up to three hundred files and the first comment page. A file's text is absent for binary content and may be partial
+when `isTruncated` is true. `listGistComments` pages further comments. User logins and gist names are opaque
+`GithubLogin` and `GistName` values.
 
 `Token` does not print the secret. Long GitHub tokens show a type prefix and the last four characters
 (`Token(ghp_...abcd)`). Short values print `Token(redacted)`. `GithubClient.live(token)` still takes a parsed
@@ -51,7 +58,7 @@ Native artifact links kqueue. See the published-library-families Design Note.
 
 Listing methods return `ConnectionPage[A] < (Abort[GitHubException] & Async)`. Pass `after` and a positive
 `PageSize` as `first` to page.
-`getIssue`, `getPullRequest`, and `getDiscussion` return `Maybe[A]`. Nested comments use the same page type;
+`getIssue`, `getPullRequest`, `getDiscussion`, `getGist`, and `getMyGist` return `Maybe[A]`. Nested comments use the same page type;
 `listIssueComments`, `listPullRequestComments`, `listDiscussionComments`, and `listDiscussionReplies` page further:
 
 ```scala

--- a/morphir/connector/github/js-jvm/src/morphir/connector/github/internal/PlatformLive.scala
+++ b/morphir/connector/github/js-jvm/src/morphir/connector/github/internal/PlatformLive.scala
@@ -36,6 +36,39 @@ private[github] object PlatformLive:
         env =>
           GithubClient.lift(GraphQl.discussionsFrom(env))
       )
+    def listGists(
+        user: GithubLogin,
+        after: Maybe[Cursor],
+        first: PageSize
+    ): ConnectionPage[GistSummary] < (Abort[GitHubException] & Async) =
+      post[GraphQl.GistsEnvelope](GraphQl.listGistsDocument(user, after, first)).map(env =>
+        GithubClient.lift(GraphQl.gistsFrom(env))
+      )
+    def listMyGists(
+        privacy: GistPrivacy,
+        after: Maybe[Cursor],
+        first: PageSize
+    ): ConnectionPage[GistSummary] < (Abort[GitHubException] & Async) =
+      post[GraphQl.ViewerGistsEnvelope](GraphQl.listMyGistsDocument(privacy, after, first)).map(env =>
+        GithubClient.lift(GraphQl.myGistsFrom(env))
+      )
+    def getGist(user: GithubLogin, name: GistName): Maybe[Gist] < (Abort[GitHubException] & Async) =
+      post[GraphQl.SingleGistEnvelope](GraphQl.getGistDocument(user, name)).map(env =>
+        GithubClient.lift(GraphQl.gistFrom(env))
+      )
+    def getMyGist(name: GistName): Maybe[Gist] < (Abort[GitHubException] & Async) =
+      post[GraphQl.ViewerSingleGistEnvelope](GraphQl.getMyGistDocument(name)).map(env =>
+        GithubClient.lift(GraphQl.myGistFrom(env))
+      )
+    def listGistComments(
+        user: GithubLogin,
+        name: GistName,
+        after: Maybe[Cursor],
+        first: PageSize
+    ): ConnectionPage[GistComment] < (Abort[GitHubException] & Async) =
+      post[GraphQl.GistCommentsEnvelope](GraphQl.listGistCommentsDocument(user, name, after, first)).map(env =>
+        GithubClient.lift(GraphQl.gistCommentsFrom(env))
+      )
     def listDiscussionReplies(
         commentId: DiscussionCommentId,
         after: Maybe[Cursor],
@@ -97,6 +130,15 @@ private[github] object PlatformLive:
       postBody(request)
 
     private def post[A: Schema](request: GraphQl.NodeReplyRequest): A < (Abort[GitHubException] & Async) =
+      postBody(request)
+
+    private def post[A: Schema](request: GraphQl.UserRequest): A < (Abort[GitHubException] & Async) =
+      postBody(request)
+
+    private def post[A: Schema](request: GraphQl.ViewerGistsRequest): A < (Abort[GitHubException] & Async) =
+      postBody(request)
+
+    private def post[A: Schema](request: GraphQl.ViewerGistRequest): A < (Abort[GitHubException] & Async) =
       postBody(request)
 
     private def postBody[A: Schema, B: Schema](body: B): A < (Abort[GitHubException] & Async) =

--- a/morphir/connector/github/native/src/morphir/connector/github/internal/PlatformLive.scala
+++ b/morphir/connector/github/native/src/morphir/connector/github/internal/PlatformLive.scala
@@ -39,6 +39,29 @@ private[github] object PlatformLive:
         replyDepth: ReplyDepth
     ): ConnectionPage[Discussion] < (Abort[GitHubException] & Async) =
       Abort.fail(GitHubException.Transport(detail))
+    def listGists(
+        user: GithubLogin,
+        after: Maybe[Cursor],
+        first: PageSize
+    ): ConnectionPage[GistSummary] < (Abort[GitHubException] & Async) =
+      Abort.fail(GitHubException.Transport(detail))
+    def listMyGists(
+        privacy: GistPrivacy,
+        after: Maybe[Cursor],
+        first: PageSize
+    ): ConnectionPage[GistSummary] < (Abort[GitHubException] & Async) =
+      Abort.fail(GitHubException.Transport(detail))
+    def getGist(user: GithubLogin, name: GistName): Maybe[Gist] < (Abort[GitHubException] & Async) =
+      Abort.fail(GitHubException.Transport(detail))
+    def getMyGist(name: GistName): Maybe[Gist] < (Abort[GitHubException] & Async) =
+      Abort.fail(GitHubException.Transport(detail))
+    def listGistComments(
+        user: GithubLogin,
+        name: GistName,
+        after: Maybe[Cursor],
+        first: PageSize
+    ): ConnectionPage[GistComment] < (Abort[GitHubException] & Async) =
+      Abort.fail(GitHubException.Transport(detail))
     def listDiscussionReplies(
         commentId: DiscussionCommentId,
         after: Maybe[Cursor],

--- a/morphir/connector/github/schema/github-subset.graphql
+++ b/morphir/connector/github/schema/github-subset.graphql
@@ -19,6 +19,20 @@ interface Node {
 type Query {
   repository(owner: String!, name: String!): Repository
   node(id: ID!): Node
+  user(login: String!): User
+  viewer: User!
+}
+
+interface RepositoryOwner {
+  login: String!
+  url: URI!
+}
+
+type User implements RepositoryOwner {
+  login: String!
+  url: URI!
+  gist(name: String!): Gist
+  gists(first: Int, after: String, privacy: GistPrivacy): GistConnection!
 }
 
 type Repository {
@@ -33,6 +47,60 @@ type Repository {
 type Actor {
   login: String!
   url: URI!
+}
+
+enum GistPrivacy {
+  ALL
+  PUBLIC
+  SECRET
+}
+
+type GistConnection {
+  nodes: [Gist]
+  pageInfo: PageInfo!
+}
+
+type Gist {
+  comments(first: Int, after: String): GistCommentConnection!
+  createdAt: DateTime!
+  description: String
+  files(limit: Int): [GistFile]
+  id: ID!
+  isFork: Boolean!
+  isPublic: Boolean!
+  name: String!
+  owner: RepositoryOwner
+  pushedAt: DateTime
+  stargazerCount: Int!
+  updatedAt: DateTime!
+  url: URI!
+}
+
+type GistFile {
+  encoding: String
+  extension: String
+  isImage: Boolean!
+  isTruncated: Boolean!
+  language: Language
+  name: String
+  size: Int
+  text(truncate: Int): String
+}
+
+type Language {
+  name: String!
+}
+
+type GistComment {
+  author: Actor
+  body: String!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+}
+
+type GistCommentConnection {
+  nodes: [GistComment]
+  pageInfo: PageInfo!
 }
 
 type Label {

--- a/morphir/connector/github/src/morphir/connector/github/GithubClient.scala
+++ b/morphir/connector/github/src/morphir/connector/github/GithubClient.scala
@@ -5,13 +5,15 @@ import morphir.connector.github.internal.GraphQl
 import morphir.connector.github.internal.PlatformLive
 
 /**
- * Lists issues, pull requests, and discussions for a repository, and looks up one of those objects by number.
+ * Reads repository issues, pull requests, and discussions, plus public and authenticated-viewer gists.
  *
- * List methods return [[ConnectionPage]] and accept `after` / `first` so a caller can page. [[GithubClient.recorded]]
- * replays GraphQL JSON envelopes. [[GithubClient.fixture]] replays already-decoded values. [[GithubClient.live]] posts
- * to GitHub over `kyo-http` on the JVM and on Node.js. Pass a [[Token]] or take [[TokenProvider]] from [[kyo.Env]]. On
- * Scala Native, listing fails with [[GitHubException.Transport]] because the published kyo-net Native artifact at
- * 1.0.0-RC6 does not link kqueue on macOS. Tests use recorded or fixture clients and do not call `api.github.com`.
+ * List methods return [[ConnectionPage]] and accept `after` / `first` so a caller can page. Gist lists return
+ * [[GistSummary]] values; [[getGist]] and [[getMyGist]] load files and the first comment page.
+ * [[GithubClient.recorded]] replays GraphQL JSON envelopes. [[GithubClient.fixture]] replays already-decoded values.
+ * [[GithubClient.live]] posts to GitHub over `kyo-http` on the JVM and on Node.js. Pass a [[Token]] or take
+ * [[TokenProvider]] from [[kyo.Env]]. On Scala Native, reads fail with [[GitHubException.Transport]] because the
+ * published kyo-net Native artifact at 1.0.0-RC6 does not link kqueue on macOS. Tests use recorded or fixture clients
+ * and do not call `api.github.com`.
  */
 trait GithubClient:
   def listIssues(
@@ -30,6 +32,24 @@ trait GithubClient:
       first: PageSize = PageSize.default,
       replyDepth: ReplyDepth = ReplyDepth.one
   ): ConnectionPage[Discussion] < (Abort[GitHubException] & Async)
+  def listGists(
+      user: GithubLogin,
+      after: Maybe[Cursor] = Absent,
+      first: PageSize = PageSize.default
+  ): ConnectionPage[GistSummary] < (Abort[GitHubException] & Async)
+  def listMyGists(
+      privacy: GistPrivacy = GistPrivacy.All,
+      after: Maybe[Cursor] = Absent,
+      first: PageSize = PageSize.default
+  ): ConnectionPage[GistSummary] < (Abort[GitHubException] & Async)
+  def getGist(user: GithubLogin, name: GistName): Maybe[Gist] < (Abort[GitHubException] & Async)
+  def getMyGist(name: GistName): Maybe[Gist] < (Abort[GitHubException] & Async)
+  def listGistComments(
+      user: GithubLogin,
+      name: GistName,
+      after: Maybe[Cursor] = Absent,
+      first: PageSize = PageSize.default
+  ): ConnectionPage[GistComment] < (Abort[GitHubException] & Async)
   def listDiscussionReplies(
       commentId: DiscussionCommentId,
       after: Maybe[Cursor] = Absent,
@@ -78,12 +98,22 @@ object GithubClient:
       discussionComments: ConnectionPage[DiscussionComment] = ConnectionPage(),
       issue: Maybe[Issue] = Absent,
       pullRequest: Maybe[PullRequest] = Absent,
-      discussion: Maybe[Discussion] = Absent
+      discussion: Maybe[Discussion] = Absent,
+      gists: Chunk[GistSummary] = Chunk.empty,
+      myGists: Chunk[GistSummary] = Chunk.empty,
+      gist: Maybe[Gist] = Absent,
+      myGist: Maybe[Gist] = Absent,
+      gistComments: ConnectionPage[GistComment] = ConnectionPage()
   ): GithubClient =
     FixtureClient(
       issues,
       pullRequests,
       discussions,
+      gists,
+      myGists,
+      gist,
+      myGist,
+      gistComments,
       discussionReplies,
       issueComments,
       pullRequestComments,
@@ -103,12 +133,22 @@ object GithubClient:
       discussionComments: String = GraphQl.emptyDiscussionComments,
       issue: String = GraphQl.emptyIssue,
       pullRequest: String = GraphQl.emptyPullRequest,
-      discussion: String = GraphQl.emptyDiscussion
+      discussion: String = GraphQl.emptyDiscussion,
+      gists: String = GraphQl.emptyGists,
+      myGists: String = GraphQl.emptyMyGists,
+      gist: String = GraphQl.emptyGist,
+      myGist: String = GraphQl.emptyMyGist,
+      gistComments: String = GraphQl.emptyGistComments
   ): GithubClient =
     RecordedClient(
       issues,
       pullRequests,
       discussions,
+      gists,
+      myGists,
+      gist,
+      myGist,
+      gistComments,
       discussionReplies,
       issueComments,
       pullRequestComments,
@@ -134,6 +174,11 @@ object GithubClient:
       issues: Chunk[Issue],
       pullRequests: Chunk[PullRequest],
       discussions: Chunk[Discussion],
+      gists: Chunk[GistSummary],
+      myGists: Chunk[GistSummary],
+      gist: Maybe[Gist],
+      myGist: Maybe[Gist],
+      gistComments: ConnectionPage[GistComment],
       discussionReplies: ConnectionPage[DiscussionComment],
       issueComments: ConnectionPage[IssueComment],
       pullRequestComments: ConnectionPage[IssueComment],
@@ -161,6 +206,29 @@ object GithubClient:
         replyDepth: ReplyDepth
     ): ConnectionPage[Discussion] < (Abort[GitHubException] & Async) =
       ConnectionPage(nodes = discussions)
+    def listGists(
+        user: GithubLogin,
+        after: Maybe[Cursor],
+        first: PageSize
+    ): ConnectionPage[GistSummary] < (Abort[GitHubException] & Async) =
+      ConnectionPage(nodes = gists)
+    def listMyGists(
+        privacy: GistPrivacy,
+        after: Maybe[Cursor],
+        first: PageSize
+    ): ConnectionPage[GistSummary] < (Abort[GitHubException] & Async) =
+      ConnectionPage(nodes = myGists)
+    def getGist(user: GithubLogin, name: GistName): Maybe[Gist] < (Abort[GitHubException] & Async) =
+      gist
+    def getMyGist(name: GistName): Maybe[Gist] < (Abort[GitHubException] & Async) =
+      myGist
+    def listGistComments(
+        user: GithubLogin,
+        name: GistName,
+        after: Maybe[Cursor],
+        first: PageSize
+    ): ConnectionPage[GistComment] < (Abort[GitHubException] & Async) =
+      gistComments
     def listDiscussionReplies(
         commentId: DiscussionCommentId,
         after: Maybe[Cursor],
@@ -208,6 +276,11 @@ object GithubClient:
       issuesJson: String,
       pullRequestsJson: String,
       discussionsJson: String,
+      gistsJson: String,
+      myGistsJson: String,
+      gistJson: String,
+      myGistJson: String,
+      gistCommentsJson: String,
       discussionRepliesJson: String,
       issueCommentsJson: String,
       pullRequestCommentsJson: String,
@@ -235,6 +308,29 @@ object GithubClient:
         replyDepth: ReplyDepth
     ): ConnectionPage[Discussion] < (Abort[GitHubException] & Async) =
       lift(GraphQl.decodeDiscussions(discussionsJson))
+    def listGists(
+        user: GithubLogin,
+        after: Maybe[Cursor],
+        first: PageSize
+    ): ConnectionPage[GistSummary] < (Abort[GitHubException] & Async) =
+      lift(GraphQl.decodeGists(gistsJson))
+    def listMyGists(
+        privacy: GistPrivacy,
+        after: Maybe[Cursor],
+        first: PageSize
+    ): ConnectionPage[GistSummary] < (Abort[GitHubException] & Async) =
+      lift(GraphQl.decodeMyGists(myGistsJson))
+    def getGist(user: GithubLogin, name: GistName): Maybe[Gist] < (Abort[GitHubException] & Async) =
+      lift(GraphQl.decodeGist(gistJson))
+    def getMyGist(name: GistName): Maybe[Gist] < (Abort[GitHubException] & Async) =
+      lift(GraphQl.decodeMyGist(myGistJson))
+    def listGistComments(
+        user: GithubLogin,
+        name: GistName,
+        after: Maybe[Cursor],
+        first: PageSize
+    ): ConnectionPage[GistComment] < (Abort[GitHubException] & Async) =
+      lift(GraphQl.decodeGistComments(gistCommentsJson))
     def listDiscussionReplies(
         commentId: DiscussionCommentId,
         after: Maybe[Cursor],

--- a/morphir/connector/github/src/morphir/connector/github/internal/Client.scala
+++ b/morphir/connector/github/src/morphir/connector/github/internal/Client.scala
@@ -1,13 +1,72 @@
 package morphir.connector.github.internal
 
+import caliban.client.CalibanClientError.DecodingError
 import caliban.client.FieldBuilder._
 import caliban.client._
+import caliban.client.__Value._
 
 object Client {
+
+  sealed trait GistPrivacy extends scala.Product with scala.Serializable { def value: String }
+  object GistPrivacy {
+    case object ALL    extends GistPrivacy { val value: String = "ALL"    }
+    case object PUBLIC extends GistPrivacy { val value: String = "PUBLIC" }
+    case object SECRET extends GistPrivacy { val value: String = "SECRET" }
+
+    implicit val decoder: ScalarDecoder[GistPrivacy] = {
+      case __StringValue("ALL")    => Right(GistPrivacy.ALL)
+      case __StringValue("PUBLIC") => Right(GistPrivacy.PUBLIC)
+      case __StringValue("SECRET") => Right(GistPrivacy.SECRET)
+      case other                   => Left(DecodingError(s"Can't build GistPrivacy from input $other"))
+    }
+    implicit val encoder: ArgEncoder[GistPrivacy] = {
+      case GistPrivacy.ALL    => __EnumValue("ALL")
+      case GistPrivacy.PUBLIC => __EnumValue("PUBLIC")
+      case GistPrivacy.SECRET => __EnumValue("SECRET")
+    }
+
+    val values: scala.collection.immutable.Vector[GistPrivacy] = scala.collection.immutable.Vector(ALL, PUBLIC, SECRET)
+  }
 
   type Node
   object Node {
     def id: SelectionBuilder[Node, String] = _root_.caliban.client.SelectionBuilder.Field("id", Scalar())
+  }
+
+  type RepositoryOwner
+  object RepositoryOwner {
+    def login: SelectionBuilder[RepositoryOwner, String] =
+      _root_.caliban.client.SelectionBuilder.Field("login", Scalar())
+    def url: SelectionBuilder[RepositoryOwner, String] = _root_.caliban.client.SelectionBuilder.Field("url", Scalar())
+  }
+
+  type User
+  object User {
+    def login: SelectionBuilder[User, String] = _root_.caliban.client.SelectionBuilder.Field("login", Scalar())
+    def url: SelectionBuilder[User, String]   = _root_.caliban.client.SelectionBuilder.Field("url", Scalar())
+    def gist[A](name: String)(innerSelection: SelectionBuilder[Gist, A])(implicit
+        encoder0: ArgEncoder[String]
+    ): SelectionBuilder[User, scala.Option[A]] = _root_.caliban.client.SelectionBuilder.Field(
+      "gist",
+      OptionOf(Obj(innerSelection)),
+      arguments = List(Argument("name", name, "String!"))
+    )
+    def gists[A](
+        first: scala.Option[Int] = None,
+        after: scala.Option[String] = None,
+        privacy: scala.Option[GistPrivacy] = None
+    )(innerSelection: SelectionBuilder[GistConnection, A])(implicit
+        encoder0: ArgEncoder[scala.Option[Int]],
+        encoder1: ArgEncoder[scala.Option[String]]
+    ): SelectionBuilder[User, A] = _root_.caliban.client.SelectionBuilder.Field(
+      "gists",
+      Obj(innerSelection),
+      arguments = List(
+        Argument("first", first, "Int"),
+        Argument("after", after, "String"),
+        Argument("privacy", privacy, "GistPrivacy")
+      )
+    )
   }
 
   type Repository
@@ -72,6 +131,108 @@ object Client {
   object Actor {
     def login: SelectionBuilder[Actor, String] = _root_.caliban.client.SelectionBuilder.Field("login", Scalar())
     def url: SelectionBuilder[Actor, String]   = _root_.caliban.client.SelectionBuilder.Field("url", Scalar())
+  }
+
+  type GistConnection
+  object GistConnection {
+    def nodes[A](innerSelection: SelectionBuilder[Gist, A])
+        : SelectionBuilder[GistConnection, scala.Option[List[scala.Option[A]]]] =
+      _root_.caliban.client.SelectionBuilder.Field("nodes", OptionOf(ListOf(OptionOf(Obj(innerSelection)))))
+    def pageInfo[A](innerSelection: SelectionBuilder[PageInfo, A]): SelectionBuilder[GistConnection, A] =
+      _root_.caliban.client.SelectionBuilder.Field("pageInfo", Obj(innerSelection))
+  }
+
+  type Gist
+  object Gist {
+    def comments[A](
+        first: scala.Option[Int] = None,
+        after: scala.Option[String] = None
+    )(innerSelection: SelectionBuilder[GistCommentConnection, A])(implicit
+        encoder0: ArgEncoder[scala.Option[Int]],
+        encoder1: ArgEncoder[scala.Option[String]]
+    ): SelectionBuilder[Gist, A] = _root_.caliban.client.SelectionBuilder.Field(
+      "comments",
+      Obj(innerSelection),
+      arguments = List(Argument("first", first, "Int"), Argument("after", after, "String"))
+    )
+    def createdAt: SelectionBuilder[Gist, String] = _root_.caliban.client.SelectionBuilder.Field("createdAt", Scalar())
+    def description: SelectionBuilder[Gist, scala.Option[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("description", OptionOf(Scalar()))
+    def files[A](limit: scala.Option[Int] = None)(innerSelection: SelectionBuilder[GistFile, A])(implicit
+        encoder0: ArgEncoder[scala.Option[Int]]
+    ): SelectionBuilder[Gist, scala.Option[List[scala.Option[A]]]] = _root_.caliban.client.SelectionBuilder.Field(
+      "files",
+      OptionOf(ListOf(OptionOf(Obj(innerSelection)))),
+      arguments = List(Argument("limit", limit, "Int"))
+    )
+    def id: SelectionBuilder[Gist, String]        = _root_.caliban.client.SelectionBuilder.Field("id", Scalar())
+    def isFork: SelectionBuilder[Gist, Boolean]   = _root_.caliban.client.SelectionBuilder.Field("isFork", Scalar())
+    def isPublic: SelectionBuilder[Gist, Boolean] = _root_.caliban.client.SelectionBuilder.Field("isPublic", Scalar())
+    def name: SelectionBuilder[Gist, String]      = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
+    def owner[A](onUser: SelectionBuilder[User, A]): SelectionBuilder[Gist, scala.Option[A]] =
+      _root_.caliban.client.SelectionBuilder.Field("owner", OptionOf(ChoiceOf(Map("User" -> Obj(onUser)))))
+    def pushedAt: SelectionBuilder[Gist, scala.Option[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("pushedAt", OptionOf(Scalar()))
+    def stargazerCount: SelectionBuilder[Gist, Int] =
+      _root_.caliban.client.SelectionBuilder.Field("stargazerCount", Scalar())
+    def updatedAt: SelectionBuilder[Gist, String] = _root_.caliban.client.SelectionBuilder.Field("updatedAt", Scalar())
+    def url: SelectionBuilder[Gist, String]       = _root_.caliban.client.SelectionBuilder.Field("url", Scalar())
+    def ownerOption[A](onUser: scala.Option[SelectionBuilder[User, A]] =
+      None): SelectionBuilder[Gist, scala.Option[scala.Option[A]]] = _root_.caliban.client.SelectionBuilder.Field(
+      "owner",
+      OptionOf(ChoiceOf(Map("User" -> onUser.fold[FieldBuilder[scala.Option[A]]](NullField)(a => OptionOf(Obj(a))))))
+    )
+    def ownerInterface[A](owner: SelectionBuilder[RepositoryOwner, A]): SelectionBuilder[Gist, scala.Option[A]] =
+      _root_.caliban.client.SelectionBuilder.Field("owner", OptionOf(Obj(owner)))
+  }
+
+  type GistFile
+  object GistFile {
+    def encoding: SelectionBuilder[GistFile, scala.Option[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("encoding", OptionOf(Scalar()))
+    def `extension`: SelectionBuilder[GistFile, scala.Option[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("extension", OptionOf(Scalar()))
+    def isImage: SelectionBuilder[GistFile, Boolean] = _root_.caliban.client.SelectionBuilder.Field("isImage", Scalar())
+    def isTruncated: SelectionBuilder[GistFile, Boolean] =
+      _root_.caliban.client.SelectionBuilder.Field("isTruncated", Scalar())
+    def language[A](innerSelection: SelectionBuilder[Language, A]): SelectionBuilder[GistFile, scala.Option[A]] =
+      _root_.caliban.client.SelectionBuilder.Field("language", OptionOf(Obj(innerSelection)))
+    def name: SelectionBuilder[GistFile, scala.Option[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("name", OptionOf(Scalar()))
+    def size: SelectionBuilder[GistFile, scala.Option[Int]] =
+      _root_.caliban.client.SelectionBuilder.Field("size", OptionOf(Scalar()))
+    def text(truncate: scala.Option[Int] = None)(implicit
+        encoder0: ArgEncoder[scala.Option[Int]]
+    ): SelectionBuilder[GistFile, scala.Option[String]] = _root_.caliban.client.SelectionBuilder.Field(
+      "text",
+      OptionOf(Scalar()),
+      arguments = List(Argument("truncate", truncate, "Int"))
+    )
+  }
+
+  type Language
+  object Language {
+    def name: SelectionBuilder[Language, String] = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
+  }
+
+  type GistComment
+  object GistComment {
+    def author[A](innerSelection: SelectionBuilder[Actor, A]): SelectionBuilder[GistComment, scala.Option[A]] =
+      _root_.caliban.client.SelectionBuilder.Field("author", OptionOf(Obj(innerSelection)))
+    def body: SelectionBuilder[GistComment, String] = _root_.caliban.client.SelectionBuilder.Field("body", Scalar())
+    def createdAt: SelectionBuilder[GistComment, String] =
+      _root_.caliban.client.SelectionBuilder.Field("createdAt", Scalar())
+    def updatedAt: SelectionBuilder[GistComment, String] =
+      _root_.caliban.client.SelectionBuilder.Field("updatedAt", Scalar())
+  }
+
+  type GistCommentConnection
+  object GistCommentConnection {
+    def nodes[A](innerSelection: SelectionBuilder[GistComment, A])
+        : SelectionBuilder[GistCommentConnection, scala.Option[List[scala.Option[A]]]] =
+      _root_.caliban.client.SelectionBuilder.Field("nodes", OptionOf(ListOf(OptionOf(Obj(innerSelection)))))
+    def pageInfo[A](innerSelection: SelectionBuilder[PageInfo, A]): SelectionBuilder[GistCommentConnection, A] =
+      _root_.caliban.client.SelectionBuilder.Field("pageInfo", Obj(innerSelection))
   }
 
   type Label
@@ -305,6 +466,17 @@ object Client {
           onDiscussionComment.fold[FieldBuilder[scala.Option[A]]](NullField)(a => OptionOf(Obj(a)))))),
         arguments = List(Argument("id", id, "ID!"))
       )
+    def user[A](login: String)(innerSelection: SelectionBuilder[User, A])(implicit
+        encoder0: ArgEncoder[String]
+    ): SelectionBuilder[_root_.caliban.client.Operations.RootQuery, scala.Option[A]] =
+      _root_.caliban.client.SelectionBuilder.Field(
+        "user",
+        OptionOf(Obj(innerSelection)),
+        arguments = List(Argument("login", login, "String!"))
+      )
+    def viewer[A](innerSelection: SelectionBuilder[User, A])
+        : SelectionBuilder[_root_.caliban.client.Operations.RootQuery, A] =
+      _root_.caliban.client.SelectionBuilder.Field("viewer", Obj(innerSelection))
   }
 
 }

--- a/morphir/connector/github/src/morphir/connector/github/internal/GraphQl.scala
+++ b/morphir/connector/github/src/morphir/connector/github/internal/GraphQl.scala
@@ -15,6 +15,11 @@ private[github] object GraphQl:
 
   final case class Nodes[A](nodes: Chunk[A], pageInfo: Maybe[PageInfo] = Absent) derives Schema
 
+  final case class GistNodes[A](
+      nodes: Maybe[Chunk[Maybe[A]]] = Absent,
+      pageInfo: Maybe[PageInfo] = Absent
+  ) derives Schema
+
   final case class WireIssueComment(
       author: Maybe[Actor] = Absent,
       body: Maybe[String] = Absent,
@@ -55,8 +60,80 @@ private[github] object GraphQl:
   final case class PullRequestsEnvelope(data: Maybe[PullRequestsData], errors: Maybe[Chunk[Error]] = Absent)
       derives Schema
 
+  final case class WireGistSummary(
+      name: String,
+      description: Maybe[String],
+      url: String,
+      owner: Maybe[Actor] = Absent,
+      isPublic: Boolean = false,
+      isFork: Boolean = false,
+      stargazerCount: Int = 0,
+      createdAt: Maybe[Instant] = Absent,
+      updatedAt: Maybe[Instant] = Absent,
+      pushedAt: Maybe[Instant] = Absent
+  ) derives Schema
+
+  final case class GistsUser(gists: GistNodes[WireGistSummary]) derives Schema
+  final case class GistsData(user: Maybe[GistsUser]) derives Schema
+  final case class GistsEnvelope(data: Maybe[GistsData], errors: Maybe[Chunk[Error]] = Absent) derives Schema
+  final case class ViewerGistsData(viewer: Maybe[GistsUser]) derives Schema
+  final case class ViewerGistsEnvelope(data: Maybe[ViewerGistsData], errors: Maybe[Chunk[Error]] = Absent)
+      derives Schema
+
+  final case class WireLanguage(name: String) derives Schema
+  final case class WireGistFile(
+      name: Maybe[String] = Absent,
+      encoding: Maybe[String] = Absent,
+      extension: Maybe[String] = Absent,
+      language: Maybe[WireLanguage] = Absent,
+      size: Maybe[Int] = Absent,
+      isImage: Boolean = false,
+      isTruncated: Boolean = false,
+      text: Maybe[String] = Absent
+  ) derives Schema
+  final case class WireGistComment(
+      author: Maybe[Actor] = Absent,
+      body: String,
+      createdAt: Maybe[Instant] = Absent,
+      updatedAt: Maybe[Instant] = Absent
+  ) derives Schema
+  final case class WireGist(
+      name: String,
+      description: Maybe[String],
+      url: String,
+      owner: Maybe[Actor] = Absent,
+      isPublic: Boolean = false,
+      isFork: Boolean = false,
+      stargazerCount: Int = 0,
+      createdAt: Maybe[Instant] = Absent,
+      updatedAt: Maybe[Instant] = Absent,
+      pushedAt: Maybe[Instant] = Absent,
+      files: Maybe[Chunk[Maybe[WireGistFile]]] = Absent,
+      comments: Maybe[GistNodes[WireGistComment]] = Absent
+  ) derives Schema
+  final case class SingleGistUser(gist: Maybe[WireGist] = Absent) derives Schema
+  final case class SingleGistData(user: Maybe[SingleGistUser]) derives Schema
+  final case class SingleGistEnvelope(data: Maybe[SingleGistData], errors: Maybe[Chunk[Error]] = Absent) derives Schema
+  final case class ViewerSingleGistData(viewer: Maybe[SingleGistUser]) derives Schema
+  final case class ViewerSingleGistEnvelope(
+      data: Maybe[ViewerSingleGistData],
+      errors: Maybe[Chunk[Error]] = Absent
+  ) derives Schema
+  final case class GistCommentsNode(comments: Maybe[GistNodes[WireGistComment]] = Absent) derives Schema
+  final case class GistCommentsUser(gist: Maybe[GistCommentsNode] = Absent) derives Schema
+  final case class GistCommentsData(user: Maybe[GistCommentsUser]) derives Schema
+  final case class GistCommentsEnvelope(data: Maybe[GistCommentsData], errors: Maybe[Chunk[Error]] = Absent)
+      derives Schema
+
   final case class RepositoryVars(owner: String, name: String) derives Schema
   final case class Request(query: String, variables: RepositoryVars) derives Schema
+
+  final case class UserVars(login: String) derives Schema
+  final case class UserRequest(query: String, variables: UserVars) derives Schema
+  final case class ViewerGistsVars(privacy: String) derives Schema
+  final case class ViewerGistsRequest(query: String, variables: ViewerGistsVars) derives Schema
+  final case class GistNameVars(name: String) derives Schema
+  final case class ViewerGistRequest(query: String, variables: GistNameVars) derives Schema
 
   final case class NodeReplyVars(id: String, first: Int, after: Maybe[String] = Absent) derives Schema
   final case class NodeReplyRequest(query: String, variables: NodeReplyVars) derives Schema
@@ -135,6 +212,11 @@ private[github] object GraphQl:
   val emptyIssues: String            = """{"data":{"repository":{"issues":{"nodes":[]}}}}"""
   val emptyPullRequests: String      = """{"data":{"repository":{"pullRequests":{"nodes":[]}}}}"""
   val emptyDiscussions: String       = """{"data":{"repository":{"discussions":{"nodes":[]}}}}"""
+  val emptyGists: String             = """{"data":{"user":{"gists":{"nodes":[]}}}}"""
+  val emptyMyGists: String           = """{"data":{"viewer":{"gists":{"nodes":[]}}}}"""
+  val emptyGist: String              = """{"data":{"user":{"gist":null}}}"""
+  val emptyMyGist: String            = """{"data":{"viewer":{"gist":null}}}"""
+  val emptyGistComments: String      = """{"data":{"user":{"gist":{"comments":{"nodes":[]}}}}}"""
   val emptyDiscussionReplies: String =
     """{"data":{"node":{"replies":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}"""
   val emptyIssueComments: String =
@@ -186,6 +268,61 @@ private[github] object GraphQl:
           Client.DiscussionConnection.nodes(discussionSelection(replyDepth.normalized))
       )
     )
+
+  def listGistsDocument(
+      user: GithubLogin,
+      after: Maybe[Cursor] = Absent,
+      first: PageSize = PageSize.default
+  ): UserRequest =
+    val document = Client.Query.user(user.asString)(
+      Client.User.gists(Some(first.toInt), cursorArg(after), Some(Client.GistPrivacy.PUBLIC))(
+        Client.GistConnection.pageInfo(pageInfoSelection) ~
+          Client.GistConnection.nodes(gistSummarySelection)
+      )
+    ).toGraphQL()
+    UserRequest(document.query, UserVars(user.asString))
+
+  def listMyGistsDocument(
+      privacy: GistPrivacy = GistPrivacy.All,
+      after: Maybe[Cursor] = Absent,
+      first: PageSize = PageSize.default
+  ): ViewerGistsRequest =
+    val wirePrivacy = privacy match
+      case GistPrivacy.All    => Client.GistPrivacy.ALL
+      case GistPrivacy.Public => Client.GistPrivacy.PUBLIC
+      case GistPrivacy.Secret => Client.GistPrivacy.SECRET
+    val document = Client.Query.viewer(
+      Client.User.gists(Some(first.toInt), cursorArg(after), Some(wirePrivacy))(
+        Client.GistConnection.pageInfo(pageInfoSelection) ~
+          Client.GistConnection.nodes(gistSummarySelection)
+      )
+    ).toGraphQL()
+    ViewerGistsRequest(document.query, ViewerGistsVars(wirePrivacy.value))
+
+  def getGistDocument(user: GithubLogin, name: GistName): UserRequest =
+    val document = Client.Query.user(user.asString)(
+      Client.User.gist(name.asString)(gistSelection)
+    ).toGraphQL()
+    UserRequest(document.query, UserVars(user.asString))
+
+  def getMyGistDocument(name: GistName): ViewerGistRequest =
+    val document = Client.Query.viewer(
+      Client.User.gist(name.asString)(gistSelection)
+    ).toGraphQL()
+    ViewerGistRequest(document.query, GistNameVars(name.asString))
+
+  def listGistCommentsDocument(
+      user: GithubLogin,
+      name: GistName,
+      after: Maybe[Cursor] = Absent,
+      first: PageSize = PageSize.default
+  ): UserRequest =
+    val document = Client.Query.user(user.asString)(
+      Client.User.gist(name.asString)(
+        Client.Gist.comments(Some(first.toInt), cursorArg(after))(gistCommentsSelection)
+      )
+    ).toGraphQL()
+    UserRequest(document.query, UserVars(user.asString))
 
   def listDiscussionRepliesDocument(
       commentId: DiscussionCommentId,
@@ -276,6 +413,33 @@ private[github] object GraphQl:
       envelope.data.flatMap(_.repository).map(repo => page(repo.discussions, toDiscussion)).getOrElse(ConnectionPage())
     }
 
+  def decodeGists(json: String): Result[GitHubException, ConnectionPage[GistSummary]] =
+    decodeEnvelopeValue(json, summon[Schema[GistsEnvelope]], _.errors) { envelope =>
+      envelope.data.flatMap(_.user).map(user => page(user.gists, toGistSummary)).getOrElse(ConnectionPage())
+    }
+
+  def decodeMyGists(json: String): Result[GitHubException, ConnectionPage[GistSummary]] =
+    decodeEnvelopeValue(json, summon[Schema[ViewerGistsEnvelope]], _.errors) { envelope =>
+      envelope.data.flatMap(_.viewer).map(user => page(user.gists, toGistSummary)).getOrElse(ConnectionPage())
+    }
+
+  def decodeGist(json: String): Result[GitHubException, Maybe[Gist]] =
+    decodeEnvelopeValue(json, summon[Schema[SingleGistEnvelope]], _.errors) { envelope =>
+      envelope.data.flatMap(_.user).flatMap(_.gist).map(toGist)
+    }
+
+  def decodeMyGist(json: String): Result[GitHubException, Maybe[Gist]] =
+    decodeEnvelopeValue(json, summon[Schema[ViewerSingleGistEnvelope]], _.errors) { envelope =>
+      envelope.data.flatMap(_.viewer).flatMap(_.gist).map(toGist)
+    }
+
+  def decodeGistComments(json: String): Result[GitHubException, ConnectionPage[GistComment]] =
+    decodeEnvelopeValue(json, summon[Schema[GistCommentsEnvelope]], _.errors) { envelope =>
+      envelope.data.flatMap(_.user).flatMap(_.gist).flatMap(_.comments).map(page(_, toGistComment)).getOrElse(
+        ConnectionPage()
+      )
+    }
+
   def decodeDiscussionReplies(json: String): Result[GitHubException, ConnectionPage[DiscussionComment]] =
     decodeEnvelopeValue(json, summon[Schema[NodeRepliesEnvelope]], _.errors) { envelope =>
       envelope.data.flatMap(_.node).flatMap(_.replies).map(toConnectionPage).getOrElse(ConnectionPage())
@@ -337,6 +501,32 @@ private[github] object GraphQl:
       envelope.data.flatMap(_.repository).map(repo => page(repo.discussions, toDiscussion)).getOrElse(ConnectionPage())
     )
 
+  def gistsFrom(envelope: GistsEnvelope): Result[GitHubException, ConnectionPage[GistSummary]] =
+    fromErrors(
+      envelope.errors,
+      envelope.data.flatMap(_.user).map(user => page(user.gists, toGistSummary)).getOrElse(ConnectionPage())
+    )
+
+  def myGistsFrom(envelope: ViewerGistsEnvelope): Result[GitHubException, ConnectionPage[GistSummary]] =
+    fromErrors(
+      envelope.errors,
+      envelope.data.flatMap(_.viewer).map(user => page(user.gists, toGistSummary)).getOrElse(ConnectionPage())
+    )
+
+  def gistFrom(envelope: SingleGistEnvelope): Result[GitHubException, Maybe[Gist]] =
+    fromErrors(envelope.errors, envelope.data.flatMap(_.user).flatMap(_.gist).map(toGist))
+
+  def myGistFrom(envelope: ViewerSingleGistEnvelope): Result[GitHubException, Maybe[Gist]] =
+    fromErrors(envelope.errors, envelope.data.flatMap(_.viewer).flatMap(_.gist).map(toGist))
+
+  def gistCommentsFrom(envelope: GistCommentsEnvelope): Result[GitHubException, ConnectionPage[GistComment]] =
+    fromErrors(
+      envelope.errors,
+      envelope.data.flatMap(_.user).flatMap(_.gist).flatMap(_.comments).map(page(_, toGistComment)).getOrElse(
+        ConnectionPage()
+      )
+    )
+
   def discussionRepliesFrom(envelope: NodeRepliesEnvelope): Result[GitHubException, ConnectionPage[DiscussionComment]] =
     fromErrors(
       envelope.errors,
@@ -380,14 +570,53 @@ private[github] object GraphQl:
 
   private val actorSelection = Client.Actor.login ~ Client.Actor.url
 
+  private val repositoryOwnerSelection = Client.RepositoryOwner.login ~ Client.RepositoryOwner.url
+
+  private val pageInfoSelection =
+    Client.PageInfo.hasNextPage ~ Client.PageInfo.endCursor
+
+  private val gistSummarySelection =
+    Client.Gist.name ~
+      Client.Gist.description ~
+      Client.Gist.url ~
+      Client.Gist.ownerInterface(repositoryOwnerSelection) ~
+      Client.Gist.isPublic ~
+      Client.Gist.isFork ~
+      Client.Gist.stargazerCount ~
+      Client.Gist.createdAt ~
+      Client.Gist.updatedAt ~
+      Client.Gist.pushedAt
+
+  private val gistFileSelection =
+    Client.GistFile.name ~
+      Client.GistFile.encoding ~
+      Client.GistFile.`extension` ~
+      Client.GistFile.language(Client.Language.name) ~
+      Client.GistFile.size ~
+      Client.GistFile.isImage ~
+      Client.GistFile.isTruncated ~
+      Client.GistFile.text()
+
+  private val gistCommentSelection =
+    Client.GistComment.author(actorSelection) ~
+      Client.GistComment.body ~
+      Client.GistComment.createdAt ~
+      Client.GistComment.updatedAt
+
+  private val gistCommentsSelection =
+    Client.GistCommentConnection.pageInfo(pageInfoSelection) ~
+      Client.GistCommentConnection.nodes(gistCommentSelection)
+
+  private val gistSelection =
+    gistSummarySelection ~
+      Client.Gist.files(Some(300))(gistFileSelection) ~
+      Client.Gist.comments(Some(100))(gistCommentsSelection)
+
   private val issueCommentSelection =
     Client.IssueComment.author(actorSelection) ~
       Client.IssueComment.body ~
       Client.IssueComment.createdAt ~
       Client.IssueComment.updatedAt
-
-  private val pageInfoSelection =
-    Client.PageInfo.hasNextPage ~ Client.PageInfo.endCursor
 
   private val issueCommentsSelection =
     Client.IssueCommentConnection.pageInfo(pageInfoSelection) ~
@@ -510,12 +739,71 @@ private[github] object GraphQl:
       replies = wire.replies.map(toConnectionPage).getOrElse(ConnectionPage())
     )
 
+  private def toGistSummary(wire: WireGistSummary): GistSummary =
+    GistSummary(
+      name = GistName.fromWire(wire.name),
+      description = wire.description,
+      url = wire.url,
+      owner = wire.owner,
+      isPublic = wire.isPublic,
+      isFork = wire.isFork,
+      stargazerCount = wire.stargazerCount,
+      createdAt = wire.createdAt,
+      updatedAt = wire.updatedAt,
+      pushedAt = wire.pushedAt
+    )
+
+  private def toGist(wire: WireGist): Gist =
+    Gist(
+      summary = GistSummary(
+        name = GistName.fromWire(wire.name),
+        description = wire.description,
+        url = wire.url,
+        owner = wire.owner,
+        isPublic = wire.isPublic,
+        isFork = wire.isFork,
+        stargazerCount = wire.stargazerCount,
+        createdAt = wire.createdAt,
+        updatedAt = wire.updatedAt,
+        pushedAt = wire.pushedAt
+      ),
+      files = wire.files.map(_.flatMap(_.map(toGistFile).toList)).getOrElse(Chunk.empty),
+      comments = wire.comments.map(page(_, toGistComment)).getOrElse(ConnectionPage())
+    )
+
+  private def toGistFile(wire: WireGistFile): GistFile =
+    GistFile(
+      name = wire.name,
+      encoding = wire.encoding,
+      extension = wire.extension,
+      language = wire.language.map(_.name),
+      size = wire.size,
+      isImage = wire.isImage,
+      isTruncated = wire.isTruncated,
+      text = wire.text
+    )
+
+  private def toGistComment(wire: WireGistComment): GistComment =
+    GistComment(
+      author = wire.author,
+      body = wire.body,
+      createdAt = wire.createdAt,
+      updatedAt = wire.updatedAt
+    )
+
   private def toConnectionPage(conn: Nodes[WireDiscussionComment]): ConnectionPage[DiscussionComment] =
     page(conn, toDiscussionComment)
 
   private def page[A, B](conn: Nodes[A], toValue: A => B): ConnectionPage[B] =
     ConnectionPage(
       nodes = conn.nodes.map(toValue),
+      hasNextPage = conn.pageInfo.map(_.hasNextPage).getOrElse(false),
+      endCursor = conn.pageInfo.flatMap(_.endCursor).flatMap(Cursor.parse)
+    )
+
+  private def page[A, B](conn: GistNodes[A], toValue: A => B): ConnectionPage[B] =
+    ConnectionPage(
+      nodes = conn.nodes.map(_.flatMap(_.map(toValue).toList)).getOrElse(Chunk.empty),
       hasNextPage = conn.pageInfo.map(_.hasNextPage).getOrElse(false),
       endCursor = conn.pageInfo.flatMap(_.endCursor).flatMap(Cursor.parse)
     )

--- a/morphir/connector/github/src/morphir/connector/github/model.scala
+++ b/morphir/connector/github/src/morphir/connector/github/model.scala
@@ -156,6 +156,55 @@ object GithubNumber:
   ): A =
     discussion(number)
 
+/** A GitHub user login used to list and look up gists. */
+opaque type GithubLogin = String
+
+object GithubLogin:
+  given CanEqual[GithubLogin, GithubLogin] = CanEqual.derived
+  given Schema[GithubLogin]                = GithubOpaqueSchemas.string
+  given Render[GithubLogin]                = Render.from(show)
+
+  def parse(raw: String): Maybe[GithubLogin] =
+    val trimmed = raw.trim
+    if isValid(trimmed) then Present(trimmed) else Absent
+
+  def show(login: GithubLogin): String = s"login:${login.asString}"
+
+  private[github] def fromWire(raw: String): GithubLogin = raw
+
+  extension (login: GithubLogin) def asString: String = login
+
+  private def isValid(login: String): Boolean =
+    login.nonEmpty &&
+      login.length <= 39 &&
+      isAsciiAlphaNumeric(login.head) &&
+      isAsciiAlphaNumeric(login.last) &&
+      !login.contains("--") &&
+      login.forall(char => isAsciiAlphaNumeric(char) || char == '-')
+
+  private def isAsciiAlphaNumeric(char: Char): Boolean =
+    (char >= 'a' && char <= 'z') ||
+      (char >= 'A' && char <= 'Z') ||
+      (char >= '0' && char <= '9')
+
+/** The opaque name GitHub uses to address a gist within its owner's account. */
+opaque type GistName = String
+
+object GistName:
+  given CanEqual[GistName, GistName] = CanEqual.derived
+  given Schema[GistName]             = GithubOpaqueSchemas.string
+  given Render[GistName]             = Render.from(show)
+
+  def parse(raw: String): Maybe[GistName] =
+    val trimmed = raw.trim
+    if trimmed.isEmpty then Absent else Present(trimmed)
+
+  def show(name: GistName): String = s"gist:${name.asString}"
+
+  private[github] def fromWire(raw: String): GistName = raw
+
+  extension (name: GistName) def asString: String = name
+
 /** GraphQL global node id of a `DiscussionComment`. Used to page replies; not a connection cursor. */
 opaque type DiscussionCommentId = String
 
@@ -215,6 +264,51 @@ final case class DiscussionComment(
     updatedAt: Maybe[Instant] = Absent,
     upvoteCount: Int = 0,
     replies: ConnectionPage[DiscussionComment] = ConnectionPage()
+) derives CanEqual, Schema
+
+/** Privacy filter for the authenticated viewer's gists. */
+enum GistPrivacy derives CanEqual, Schema:
+  case All, Public, Secret
+
+/** Gist metadata returned by list operations. Files and comments are loaded by [[GithubClient.getGist]]. */
+final case class GistSummary(
+    name: GistName,
+    description: Maybe[String],
+    url: String,
+    owner: Maybe[Actor] = Absent,
+    isPublic: Boolean = false,
+    isFork: Boolean = false,
+    stargazerCount: Int = 0,
+    createdAt: Maybe[Instant] = Absent,
+    updatedAt: Maybe[Instant] = Absent,
+    pushedAt: Maybe[Instant] = Absent
+) derives CanEqual, Schema
+
+/** One file in a gist. `text` is absent for binary files and may be partial when `isTruncated` is true. */
+final case class GistFile(
+    name: Maybe[String] = Absent,
+    encoding: Maybe[String] = Absent,
+    extension: Maybe[String] = Absent,
+    language: Maybe[String] = Absent,
+    size: Maybe[Int] = Absent,
+    isImage: Boolean = false,
+    isTruncated: Boolean = false,
+    text: Maybe[String] = Absent
+) derives CanEqual, Schema
+
+/** A comment on a gist. */
+final case class GistComment(
+    author: Maybe[Actor] = Absent,
+    body: String,
+    createdAt: Maybe[Instant] = Absent,
+    updatedAt: Maybe[Instant] = Absent
+) derives CanEqual, Schema
+
+/** A gist with files and its first page of comments. */
+final case class Gist(
+    summary: GistSummary,
+    files: Chunk[GistFile] = Chunk.empty,
+    comments: ConnectionPage[GistComment] = ConnectionPage()
 ) derives CanEqual, Schema
 
 /** A GitHub issue. Field names follow GitHub's GraphQL `Issue` type, not OKF. */

--- a/morphir/connector/github/test-snapshots/GithubClientTests/get-gist.snap
+++ b/morphir/connector/github/test-snapshots/GithubClientTests/get-gist.snap
@@ -1,0 +1,1 @@
+query{user(login:"octocat"){gist(name:"gist1"){name description url owner{login url} isPublic isFork stargazerCount createdAt updatedAt pushedAt files(limit:300){name encoding extension language{name} size isImage isTruncated text} comments(first:100){pageInfo{hasNextPage endCursor} nodes{author{login url} body createdAt updatedAt}}}}}

--- a/morphir/connector/github/test-snapshots/GithubClientTests/get-my-gist.snap
+++ b/morphir/connector/github/test-snapshots/GithubClientTests/get-my-gist.snap
@@ -1,0 +1,1 @@
+query{viewer{gist(name:"gist1"){name description url owner{login url} isPublic isFork stargazerCount createdAt updatedAt pushedAt files(limit:300){name encoding extension language{name} size isImage isTruncated text} comments(first:100){pageInfo{hasNextPage endCursor} nodes{author{login url} body createdAt updatedAt}}}}}

--- a/morphir/connector/github/test-snapshots/GithubClientTests/list-gist-comments.snap
+++ b/morphir/connector/github/test-snapshots/GithubClientTests/list-gist-comments.snap
@@ -1,0 +1,1 @@
+query{user(login:"octocat"){gist(name:"gist1"){comments(first:20,after:"gc1"){pageInfo{hasNextPage endCursor} nodes{author{login url} body createdAt updatedAt}}}}}

--- a/morphir/connector/github/test-snapshots/GithubClientTests/list-gists.snap
+++ b/morphir/connector/github/test-snapshots/GithubClientTests/list-gists.snap
@@ -1,0 +1,1 @@
+query{user(login:"octocat"){gists(first:100,privacy:PUBLIC){pageInfo{hasNextPage endCursor} nodes{name description url owner{login url} isPublic isFork stargazerCount createdAt updatedAt pushedAt}}}}

--- a/morphir/connector/github/test-snapshots/GithubClientTests/list-my-gists.snap
+++ b/morphir/connector/github/test-snapshots/GithubClientTests/list-my-gists.snap
@@ -1,0 +1,1 @@
+query{viewer{gists(first:100,privacy:SECRET){pageInfo{hasNextPage endCursor} nodes{name description url owner{login url} isPublic isFork stargazerCount createdAt updatedAt pushedAt}}}}

--- a/morphir/connector/github/test/src/morphir/connector/github/GithubClientTests.scala
+++ b/morphir/connector/github/test/src/morphir/connector/github/GithubClientTests.scala
@@ -27,6 +27,8 @@ class GithubClientTests extends SnapshotTest[Any]:
   private def discNo(n: Int): DiscussionNumber                 = DiscussionNumber.fromWire(n)
   private def cursor(s: String): Cursor                        = Cursor.fromWire(s)
   private def commentId(s: String): DiscussionCommentId        = DiscussionCommentId.fromWire(s)
+  private def login(s: String): GithubLogin                    = GithubLogin.fromWire(s)
+  private def gistName(s: String): GistName                    = GistName.fromWire(s)
   private def pageSize(n: Int): PageSize                       = PageSize.fromWire(n)
   private def repo(owner: String, name: String): RepositoryRef =
     RepositoryRef.parse(owner, name) match
@@ -68,6 +70,31 @@ class GithubClientTests extends SnapshotTest[Any]:
     }
     "trims owner and name" in
       assert(RepositoryRef.parse("  owner  ", "  repo  ") == Present(repo("owner", "repo")))
+  }
+
+  "GithubLogin" - {
+    "rejects a blank string" in
+      assert(GithubLogin.parse("  ").isEmpty)
+    "rejects malformed GitHub logins" in {
+      assert(GithubLogin.parse("octo cat").isEmpty)
+      assert(GithubLogin.parse("-octocat").isEmpty)
+      assert(GithubLogin.parse("octocat-").isEmpty)
+      assert(GithubLogin.parse("octo--cat").isEmpty)
+      assert(GithubLogin.parse("octo_cat").isEmpty)
+      assert(GithubLogin.parse("øctocat").isEmpty)
+      assert(GithubLogin.parse("a" * 40).isEmpty)
+    }
+    "stores trimmed valid logins" in {
+      assert(GithubLogin.parse("  Octo-Cat42  ") == Present(login("Octo-Cat42")))
+      assert(GithubLogin.parse("a" * 39) == Present(login("a" * 39)))
+    }
+  }
+
+  "GistName" - {
+    "rejects a blank string" in
+      assert(GistName.parse("  ").isEmpty)
+    "stores a trimmed name" in
+      assert(GistName.parse("  aa5a315d61ae9438b18d  ") == Present(gistName("aa5a315d61ae9438b18d")))
   }
 
   "Token" - {
@@ -236,6 +263,143 @@ class GithubClientTests extends SnapshotTest[Any]:
   }
 
   "GithubClient.recorded" - {
+    "decodes a lightweight page of public gists" in {
+      val json =
+        """{"data":{"user":{"gists":{"pageInfo":{"hasNextPage":true,"endCursor":"g2"},"nodes":[{
+          |"name":"aa5a315d61ae9438b18d","description":"examples","url":"https://gist.github.com/aa5a315d61ae9438b18d",
+          |"owner":{"login":"octocat","url":"https://github.com/octocat"},
+          |"isPublic":true,"isFork":false,"stargazerCount":3,
+          |"createdAt":"2026-01-02T03:04:05Z","updatedAt":"2026-01-03T04:05:06Z","pushedAt":null
+        }]}}}}""".stripMargin.replaceAll("\n", "")
+      run(GithubClient.recorded(gists = json).listGists(login("octocat"))).map {
+        case Result.Success(page) =>
+          assert(page.hasNextPage)
+          assert(page.endCursor == Present(cursor("g2")))
+          assert(
+            page.nodes == Chunk(
+              GistSummary(
+                name = gistName("aa5a315d61ae9438b18d"),
+                description = Present("examples"),
+                url = "https://gist.github.com/aa5a315d61ae9438b18d",
+                owner = Present(Actor("octocat", "https://github.com/octocat")),
+                isPublic = true,
+                isFork = false,
+                stargazerCount = 3,
+                createdAt = Present(java.time.Instant.parse("2026-01-02T03:04:05Z")),
+                updatedAt = Present(java.time.Instant.parse("2026-01-03T04:05:06Z")),
+                pushedAt = Absent
+              )
+            )
+          )
+        case _ => assert(false)
+      }
+    }
+    "decodes the authenticated viewer's gists" in {
+      val json =
+        """{"data":{"viewer":{"gists":{"nodes":[{
+          |"name":"secret1","description":null,"url":"https://gist.github.com/secret1",
+          |"owner":{"login":"octocat","url":"https://github.com/octocat"},
+          |"isPublic":false,"isFork":false,"stargazerCount":0,
+          |"createdAt":"2026-01-02T03:04:05Z","updatedAt":"2026-01-03T04:05:06Z","pushedAt":null
+        }]}}}}""".stripMargin.replaceAll("\n", "")
+      run(GithubClient.recorded(myGists = json).listMyGists(GistPrivacy.Secret)).map {
+        case Result.Success(page) =>
+          assert(page.nodes.map(_.name) == Chunk(gistName("secret1")))
+          assert(!page.nodes.head.isPublic)
+        case _ => assert(false)
+      }
+    }
+    "treats nullable gist connection nodes as an empty page" in {
+      val json = """{"data":{"user":{"gists":{"nodes":null}}}}"""
+      run(GithubClient.recorded(gists = json).listGists(login("octocat"))).map {
+        case Result.Success(page) => assert(page.nodes.isEmpty)
+        case _                    => assert(false)
+      }
+    }
+    "discards null gist, file, and comment nodes" in {
+      val json =
+        """{"data":{"user":{"gist":{
+          |"name":"gist1","description":null,"url":"https://gist.github.com/gist1",
+          |"files":[null,{"name":"hello.txt","isImage":false,"isTruncated":false}],
+          |"comments":{"nodes":[null,{"author":null,"body":"hello"}]}
+          |}}}}""".stripMargin.replaceAll("\n", "")
+      run(GithubClient.recorded(gist = json).getGist(login("octocat"), gistName("gist1"))).map {
+        case Result.Success(Present(gist)) =>
+          assert(gist.files.map(_.name) == Chunk(Present("hello.txt")))
+          assert(gist.comments.nodes.map(_.body) == Chunk("hello"))
+        case _ => assert(false)
+      }
+    }
+    "decodes a gist with files and its first comment page" in {
+      val json =
+        """{"data":{"user":{"gist":{
+          |"name":"aa5a315d61ae9438b18d","description":"examples","url":"https://gist.github.com/aa5a315d61ae9438b18d",
+          |"owner":{"login":"octocat","url":"https://github.com/octocat"},
+          |"isPublic":true,"isFork":false,"stargazerCount":3,
+          |"createdAt":"2026-01-02T03:04:05Z","updatedAt":"2026-01-03T04:05:06Z","pushedAt":"2026-01-03T05:00:00Z",
+          |"files":[
+          |{"name":"hello.scala","encoding":"utf-8","extension":".scala","language":{"name":"Scala"},"size":12,"isImage":false,"isTruncated":true,"text":"object Main"},
+          |{"name":"logo.png","encoding":null,"extension":".png","language":null,"size":42,"isImage":true,"isTruncated":false,"text":null}
+          |],
+          |"comments":{"pageInfo":{"hasNextPage":true,"endCursor":"gc2"},"nodes":[{
+          |"author":{"login":"hubot","url":"https://github.com/hubot"},"body":"nice gist",
+          |"createdAt":"2026-01-04T03:04:05Z","updatedAt":"2026-01-04T03:04:05Z"
+          |}]}
+        }}}}""".stripMargin.replaceAll("\n", "")
+      run(GithubClient.recorded(gist = json).getGist(login("octocat"), gistName("aa5a315d61ae9438b18d"))).map {
+        case Result.Success(Present(gist)) =>
+          assert(
+            gist.files == Chunk(
+              GistFile(
+                name = Present("hello.scala"),
+                encoding = Present("utf-8"),
+                extension = Present(".scala"),
+                language = Present("Scala"),
+                size = Present(12),
+                isTruncated = true,
+                text = Present("object Main")
+              ),
+              GistFile(
+                name = Present("logo.png"),
+                extension = Present(".png"),
+                size = Present(42),
+                isImage = true
+              )
+            )
+          )
+          assert(gist.comments.hasNextPage)
+          assert(gist.comments.endCursor == Present(cursor("gc2")))
+          assert(gist.comments.nodes.map(_.body) == Chunk("nice gist"))
+        case _ => assert(false)
+      }
+    }
+    "looks up the authenticated viewer's gist without a login" in {
+      val json =
+        """{"data":{"viewer":{"gist":{
+          |"name":"secret1","description":null,"url":"https://gist.github.com/secret1","owner":null,
+          |"isPublic":false,"isFork":false,"stargazerCount":0,
+          |"createdAt":"2026-01-02T03:04:05Z","updatedAt":"2026-01-03T04:05:06Z","pushedAt":null,
+          |"files":[],"comments":{"nodes":[]}
+        }}}}""".stripMargin.replaceAll("\n", "")
+      run(GithubClient.recorded(myGist = json).getMyGist(gistName("secret1"))).map {
+        case Result.Success(Present(gist)) => assert(gist.summary.name == gistName("secret1"))
+        case _                             => assert(false)
+      }
+    }
+    "decodes another page of gist comments" in {
+      val json =
+        """{"data":{"user":{"gist":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{
+          |"author":null,"body":"next page","createdAt":"2026-01-05T03:04:05Z","updatedAt":"2026-01-05T03:04:05Z"
+          |}]}}}}}""".stripMargin.replaceAll("\n", "")
+      run(
+        GithubClient
+          .recorded(gistComments = json)
+          .listGistComments(login("octocat"), gistName("aa5a315d61ae9438b18d"), Present(cursor("gc2")))
+      ).map {
+        case Result.Success(page) => assert(page.nodes.map(_.body) == Chunk("next page"))
+        case _                    => assert(false)
+      }
+    }
     "decodes issues from a GraphQL envelope" in {
       val json =
         """{"data":{"repository":{"issues":{"nodes":[{"number":1,"title":"title","body":"body","url":"https://example.test/1"}]}}}}"""
@@ -682,6 +846,60 @@ class GithubClientTests extends SnapshotTest[Any]:
     "matches the blessed get-discussion snapshot" in {
       val request = GraphQl.getDiscussionDocument(repo("acme", "widgets"), discNo(4))
       assertSnapshot(request.query, "get-discussion")
+    }
+  }
+
+  "GraphQl.listGistsDocument" - {
+    "matches the public gist-list snapshot" in {
+      val request = GraphQl.listGistsDocument(login("octocat"))
+      assert(request.variables.login == "octocat")
+      assertSnapshot(request.query, "list-gists")
+    }
+    "passes paging and forces public privacy" in {
+      val request = GraphQl.listGistsDocument(login("octocat"), Present(cursor("g1")), pageSize(25))
+      assert(request.query.contains("first:25"))
+      assert(request.query.contains("after:\"g1\""))
+      assert(request.query.contains("privacy:PUBLIC"))
+    }
+  }
+
+  "GraphQl.listMyGistsDocument" - {
+    "matches the secret viewer gist-list snapshot" in {
+      val request = GraphQl.listMyGistsDocument(GistPrivacy.Secret)
+      assert(request.variables.privacy == "SECRET")
+      assertSnapshot(request.query, "list-my-gists")
+    }
+  }
+
+  "GraphQl.getGistDocument" - {
+    "matches the full gist snapshot" in {
+      val request = GraphQl.getGistDocument(login("octocat"), gistName("gist1"))
+      assert(request.variables.login == "octocat")
+      assertSnapshot(request.query, "get-gist")
+    }
+    "requests GitHub's complete returned file set" in {
+      val request = GraphQl.getGistDocument(login("octocat"), gistName("gist1"))
+      assert(request.query.contains("files(limit:300)"))
+    }
+  }
+
+  "GraphQl.getMyGistDocument" - {
+    "matches the viewer gist snapshot" in {
+      val request = GraphQl.getMyGistDocument(gistName("gist1"))
+      assert(request.variables.name == "gist1")
+      assertSnapshot(request.query, "get-my-gist")
+    }
+  }
+
+  "GraphQl.listGistCommentsDocument" - {
+    "matches the paged gist-comment snapshot" in {
+      val request = GraphQl.listGistCommentsDocument(
+        login("octocat"),
+        gistName("gist1"),
+        Present(cursor("gc1")),
+        pageSize(20)
+      )
+      assertSnapshot(request.query, "list-gist-comments")
     }
   }
 


### PR DESCRIPTION
## Summary

- add typed, read-only gist models and APIs for named users and the authenticated viewer
- support lightweight paginated gist lists, full gist lookup with up to 300 files, and paginated gist comments
- extend GraphQL schema/code generation, live transports, fixtures, recorded clients, snapshots, and documentation
- tolerate nullable gist, file, and comment nodes returned by GitHub

## Testing

- `mise run lint`
- GitHub connector JVM: 99 passed
- GitHub connector Scala.js: 99 passed
- GitHub connector Scala Native: 99 passed
- repository JVM, JavaScript/Wasm, Native, lint, and Squire phases passed under a four-core CPU limit

## Local CI note

The remaining local `ci:local` failure is an unrelated GnuPG 2.4.8 fixture failure in `MillPublishEnvTests` while exporting a temporary secret key (`Bad secret key`). It reproduces in isolation and does not involve the connector changes.