### PR TITLE
docs(kb): integrate Morphir YAML configuration

### DIFF
--- a/kb/README.md
+++ b/kb/README.md
@@ -39,7 +39,7 @@ under `bundles/` or be grouped one level deeper by subject.
 | [`morphir/morphir-ir-v3`](./bundles/morphir/morphir-ir-v3/) | The Morphir Intermediate Representation at format version 3 — the current, active IR format. |
 | [`morphir/morphir-ir-v4-draft`](./bundles/morphir/morphir-ir-v4-draft/) | The draft specification for Morphir IR format version 4 — not yet active and subject to change. |
 | [`morphir/morphir-upstream`](./bundles/morphir/morphir-upstream/) | The IR specification, design and schema files mirrored from finos/morphir, worked on here and synced back. |
-| [`morphir/morphir-configuration`](./bundles/morphir/morphir-configuration/) | The `morphir.toml` workspace and project configuration format, and how layered configuration sources merge. |
+| [`morphir/morphir-configuration`](./bundles/morphir/morphir-configuration/) | The shared Morphir configuration model, its TOML and YAML serializations, and the implementation status of layered discovery and merging. |
 | [`intent`](./bundles/intent/) | Work this project means to do, is doing, or has done — with the reasoning behind it. |
 | [`programming-language-tooling`](./bundles/programming-language-tooling/) | Evidence-backed references and tutorials for syntax trees, traversal, interoperability, transformation pipelines, and toolchain design. |
 | [`morphir/morphir-scala`](./bundles/morphir/morphir-scala/) | Morphir-scala capabilities, decisions, design notes, and research. |

--- a/kb/bundles/morphir/README.md
+++ b/kb/bundles/morphir/README.md
@@ -9,18 +9,20 @@ self-contained OKF bundle.
 | [`morphir-ir-v3`](./morphir-ir-v3/) | [finos/morphir](https://github.com/finos/morphir) `docs/` | The Morphir IR specification at format version 3 — the current, active version. |
 | [`morphir-ir-v4-draft`](./morphir-ir-v4-draft/) | [finos/morphir](https://github.com/finos/morphir) `docs/spec/draft/` and `docs/design/draft/ir/` | The draft specification for Morphir IR format version 4, with the design rationale behind it. Not yet active; subject to change. |
 | [`morphir-upstream`](./morphir-upstream/) | [finos/morphir](https://github.com/finos/morphir), mirrored | The IR specification, design and schema files themselves, worked on here and synced back. Not a summary — upstream's own bytes. |
-| [`morphir-configuration`](./morphir-configuration/) | [finos/morphir](https://github.com/finos/morphir) `docs/spec/morphir-toml/` | The `morphir.toml` workspace and project configuration format, and how layered configuration sources merge. |
+| [`morphir-configuration`](./morphir-configuration/) | [finos/morphir](https://github.com/finos/morphir) configuration specifications and [finos/morphir-rust](https://github.com/finos/morphir-rust) implementation | The shared Morphir configuration model, its TOML and YAML serializations, and the implementation status of layered discovery and merging. |
 | [`morphir-scala`](./morphir-scala/) | this repository | Morphir-scala capabilities, decisions, design notes, and research. |
 | [`morphir-elm`](./morphir-elm/) | [finos/morphir-elm](https://github.com/finos/morphir-elm) | The Elm implementation of Morphir, which produces and consumes IR format version 3. |
 
 ## Source discipline
 
-These bundles were seeded from two upstream repositories at pinned commits:
+These bundles were seeded from three upstream repositories at pinned commits:
 
-- `finos/morphir` @ `4d5e5c06a7cf269c5f86b050a16a6f82bb5c29bc` (2026-07-27)
+- `finos/morphir` @ `4d5e5c06a7cf269c5f86b050a16a6f82bb5c29bc` (2026-07-27), with the YAML and
+  configuration-discovery update at `4d2a6d836da1c3a114241e911f1af0f38b97b453` (2026-08-24)
 - `finos/morphir-elm` @ `1956c36d3715851a2f215775a45395690746d801` (2026-05-28)
+- `finos/morphir-rust` @ `cdfa6c6323ab0f08a285b77a8a857eb9915a83fb` (2026-08-24)
 
-Two constraints apply to how those repositories may be used as sources:
+Three constraints apply to how those repositories may be used as sources:
 
 1. **`finos/morphir` — documentation, plus the artifacts the format is actually defined by.** `docs/` is
    authoritative for spec knowledge, and so are four things outside it that the original seeding missed:
@@ -30,6 +32,9 @@ Two constraints apply to how those repositories may be used as sources:
    repository remains experimental and must not be consulted for knowledge.
 2. **`finos/morphir-elm` — the v3 implementation.** Its source is authoritative for how format version 3 is actually
    implemented, and is the right place to verify v3 claims against working code.
+3. **`finos/morphir-rust`, the Rust configuration implementation.** Its source defines the implemented YAML
+   parser, configuration discovery, and merge subset. Compare it with the configuration specifications rather than
+   assuming that every normative layer is implemented.
 
 Every concept document records the file it came from in its `sources` frontmatter, with a commit-pinned URL.
 

--- a/kb/bundles/morphir/morphir-configuration/index.md
+++ b/kb/bundles/morphir/morphir-configuration/index.md
@@ -1,27 +1,35 @@
 ---
 okf_version: "0.2"
-title: "Morphir Configuration (morphir.toml)"
-description: "The morphir.toml workspace and project configuration format, and how layered configuration sources merge."
+title: "Morphir Configuration"
+description: "The shared Morphir configuration model, its TOML and YAML serializations, and the implementation status of layered discovery and merging."
 ---
 
 # Morphir Configuration
 
-Knowledge bundle for **`morphir.toml`**, the configuration format used by Morphir tooling for workspaces, projects,
-tasks, workflows, and toolchains. Seeded from `docs/spec/morphir-toml/` in
-[finos/morphir](https://github.com/finos/morphir) at commit `4d5e5c06`.
+Knowledge bundle for the Morphir tooling configuration model and its `morphir.toml` and `morphir.yaml`
+serializations. Existing TOML section references retain their original [finos/morphir](https://github.com/finos/morphir)
+pin at `4d5e5c06`. The YAML, discovery, overview, and merge updates use `4d2a6d83`. The Rust implementation reference
+uses [finos/morphir-rust](https://github.com/finos/morphir-rust) commit `cdfa6c63`.
 
-`morphir.toml` is orthogonal to the IR format version — it configures the tooling, not the IR. The older
+The configuration model is independent of its file serialization and of the IR format version. It configures the
+tooling, not the IR. The older
 `morphir.json` project file is a different, narrower thing; see
 [Relationship to morphir.json](/relationship-to-morphir-json.md).
 
-> **Status.** The upstream specification marks itself *Draft*, "versioned and intended to become the authoritative
-> reference". It describes configuration parsed into `pkg/config.Config`.
+> **Status.** The TOML specification remains draft. The YAML specification records Rust loader and CLI support.
+> The normative merge specification defines six layers. The Rust configuration context loader used by the CLI
+> currently loads the global user and selected project or workspace layers, with an optional workspace-member
+> project merge. The daemon loads each discovered file directly without those context merges.
 
 ## Orientation
 
-* [Configuration Overview](/overview.md) - How morphir.toml is discovered, how TOML maps to the internal object model, and what the top-level keys are.
+* [Configuration Overview](/overview.md) - How TOML and YAML represent one configuration model, how files are discovered, and where the specification and Rust implementation differ.
 * [Merge Rules](/merge-rules.md) - The six configuration sources, their precedence order, and the deterministic deep-merge algorithm.
-* [Relationship to morphir.json](/relationship-to-morphir-json.md) - How morphir.toml and the older morphir.json project file compare, and which tools read which.
+* [Relationship to morphir.json](/relationship-to-morphir-json.md) - How the TOML and YAML configuration model compares with the older morphir.json project file, and which tools read each.
+
+## Implementation references
+
+* [Morphir Rust configuration support at cdfa6c63](/morphir-rust-configuration-cdfa6c63.md) - Commit-pinned behavior of the Rust parser, discovery logic, merge subset, CLI, and daemon for TOML and YAML configuration.
 
 ## Sections
 

--- a/kb/bundles/morphir/morphir-configuration/log.md
+++ b/kb/bundles/morphir/morphir-configuration/log.md
@@ -1,6 +1,12 @@
 # Log
 
+## 2026-08-24
+
+* **Update**: Reframed the bundle around one configuration model with TOML and YAML serializations. The new YAML, discovery, overview, and merge material is pinned to `finos/morphir` commit `4d2a6d836da1c3a114241e911f1af0f38b97b453`; unchanged section references retain their original pin.
+* **Creation**: Added a Rust implementation reference pinned to `finos/morphir-rust` commit `cdfa6c6323ab0f08a285b77a8a857eb9915a83fb`, including discovery, platform paths, merge coverage, CLI and daemon use, and verified specification gaps.
+* **Update**: Updated the `morphir.json` comparison and bundle registries to describe the shared TOML and YAML model.
+
 ## 2026-07-28
 
-* **Creation**: Seeded from `docs/spec/morphir-toml/` in `finos/morphir` at commit `4d5e5c06a7cf269c5f86b050a16a6f82bb5c29bc` — the format specification and the merge rules document.
+* **Creation**: Seeded from `docs/spec/morphir-toml/` in `finos/morphir` at commit `4d5e5c06a7cf269c5f86b050a16a6f82bb5c29bc`, using the format specification and the merge rules document.
 * **Creation**: Split into its own bundle rather than folded into `morphir-ir-v3` or `morphir-ir-v4-draft`, because `morphir.toml` configures tooling and is not tied to an IR format version. The `morphir.json` concept remains in the `morphir-ir-v3` bundle, where it belongs as the configuration that v3-era tooling reads.

--- a/kb/bundles/morphir/morphir-configuration/merge-rules.md
+++ b/kb/bundles/morphir/morphir-configuration/merge-rules.md
@@ -2,12 +2,12 @@
 type: Specification Section
 title: Merge Rules
 description: The six configuration sources, their precedence order, and the deterministic deep-merge algorithm.
-tags: [morphir, configuration, morphir-toml, merge, precedence]
+tags: [morphir, configuration, morphir-toml, morphir-yaml, merge, precedence]
 status: draft
 sources:
   - id: merge-rules
-    resource: https://github.com/finos/morphir/blob/4d5e5c06a7cf269c5f86b050a16a6f82bb5c29bc/docs/spec/morphir-toml/morphir-toml-merge-rules.md
-    title: Morphir TOML Configuration Merge Rules
+    resource: https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-toml/morphir-toml-merge-rules.md
+    title: Morphir Configuration Merge Rules
 generated:
   by: process:kb-seed
   at: 2026-07-28T00:00:00Z
@@ -15,7 +15,16 @@ generated:
 
 # Merge Rules
 
-Morphir configuration is **layered**: several sources are loaded and merged into one **effective configuration**.
+Morphir configuration is layered. The normative specification loads six sources and merges them into one effective
+configuration. Each file source may use TOML or YAML. The algorithm starts after parsing, so serialization does not
+change precedence or merge behavior.
+
+## Baseline
+
+This reference uses the merge specification at `finos/morphir` commit
+`4d2a6d836da1c3a114241e911f1af0f38b97b453`. Re-read that pinned document and the TOML and YAML specifications when
+the pin moves. The [Rust implementation reference](/morphir-rust-configuration-cdfa6c63.md) tracks implemented
+coverage separately.
 
 ## Sources and precedence
 
@@ -24,16 +33,16 @@ Lowest to highest:
 | Priority | Source | Typical path |
 | -------- | ------ | ------------ |
 | 1 (lowest) | Built-in defaults | compiled in |
-| 2 | System config | `/etc/morphir/morphir.toml` |
-| 3 | Global user config | `~/.config/morphir/morphir.toml` |
-| 4 | Project config | `morphir.toml` |
-| 5 | User override | `.morphir/morphir.user.toml` |
+| 2 | System config | `/etc/morphir/morphir.toml` or `.yaml` |
+| 3 | Global user config | Platform config directory or home `.morphir` directory |
+| 4 | Project config | `morphir.toml` or `morphir.yaml` |
+| 5 | User override | `.morphir/morphir.user.toml` or `.yaml` |
 | 6 (highest) | Environment variables | `MORPHIR_*` |
 
-A hidden project config (`.morphir/morphir.toml`) may also be used by some commands; its merge semantics are
-identical.
+A hidden project config is an alternate project path, not another layer. The serialization and location ambiguity
+rules are summarized in [Configuration Overview](/overview.md).
 
-The user-override layer sitting *above* the project config is the notable choice — it lets a developer change
+The user-override layer sits above the project config. It lets a developer change
 behavior locally without editing a file that is under version control.
 
 ## The merge algorithm
@@ -58,31 +67,33 @@ Generally: **later maps take precedence over earlier maps.**
 
 | Rule | Behavior |
 | ---- | -------- |
-| 1 — Overlay wins | For a key in both maps, the overlay value takes precedence |
-| 2 — Maps merge recursively | Two maps under the same key are deep-merged |
-| 3 — **Arrays replace** | The overlay array replaces the base entirely; no concatenation |
-| 4 — `nil` overlay ignored | A `nil` overlay value does not override the base |
-| 5 — No mutation | The result is independent; inputs are unmodified |
+| 1. Overlay wins | For a key in both maps, the overlay value takes precedence |
+| 2. Maps merge recursively | Two maps under the same key are deep-merged |
+| 3. **Arrays replace** | The overlay array replaces the base entirely; no concatenation |
+| 4. `nil` overlay ignored | A `nil` overlay value does not override the base |
+| 5. No mutation | The result is independent; inputs are unmodified |
 
 Rule 3 is the one that surprises people: a project-level `codegen.targets` **replaces** the global list rather than
-adding to it. Note the contrast with the v4 design's decoration merge, which concatenates arrays — the two merge
-systems are unrelated and behave differently.
+adding to it. The v4 design's decoration merge concatenates arrays. That merge system is unrelated and behaves
+differently.
 
 Rule 4 means a key cannot be *unset* by a higher layer, only overwritten with another value.
 
-These rules are implemented by `pkg/config/internal/configloader.DeepMerge` and `MergeAll`.
+The specification attributes these rules to `pkg/config/internal/configloader.DeepMerge` and `MergeAll`. The pinned
+Rust implementation has a separate recursive merge with the same map and replacement behavior for the layers it
+loads. It does not implement all six layers. See the
+[Rust implementation reference](/morphir-rust-configuration-cdfa6c63.md).
 
 ## Environment variable mapping (informative)
 
 Variables prefixed `MORPHIR_` (the default prefix) become config keys.
 
-- **Double underscore** marks a nested object boundary:
-  `MORPHIR_CODEGEN__GO__PACKAGE=foo` → `codegen.go.package = "foo"`
-- **Single underscores are not split.** They stay part of the key name at that level:
-  `MORPHIR_IR_FORMAT_VERSION=3` → `ir_format_version = 3`, a single key in the env-derived map.
+| Syntax | Behavior | Example |
+| --- | --- | --- |
+| Double underscore | Starts a nested object boundary | `MORPHIR_CODEGEN__GO__PACKAGE=foo` becomes `codegen.go.package = "foo"` |
+| Single underscore | Remains part of the key at that level | `MORPHIR_IR_FORMAT_VERSION=3` becomes the single key `ir_format_version = 3` |
 
-The second bullet is a trap. `MORPHIR_IR_FORMAT_VERSION` does **not** set `ir.format_version`; it creates a key named
+The `MORPHIR_IR_FORMAT_VERSION` row is a trap. That variable does **not** set `ir.format_version`; it creates a key named
 `ir_format_version` that nothing reads. The correct form is `MORPHIR_IR__FORMAT_VERSION`.
 
-The specification is explicit that this is deliberate — the mapping is "intentionally mechanical; it does not attempt
-to guess dotted paths."
+The specification calls this mapping "intentionally mechanical" and says it does not guess dotted paths.

--- a/kb/bundles/morphir/morphir-configuration/morphir-rust-configuration-cdfa6c63.md
+++ b/kb/bundles/morphir/morphir-configuration/morphir-rust-configuration-cdfa6c63.md
@@ -1,0 +1,130 @@
+---
+type: Reference
+title: Morphir Rust configuration support at cdfa6c63
+description: Commit-pinned behavior of the Rust parser, discovery logic, merge subset, CLI, and daemon for TOML and YAML configuration.
+tags: [morphir, configuration, morphir-rust, morphir-toml, morphir-yaml, implementation]
+status: stable
+sources:
+  - id: parser
+    resource: https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir-common/src/config/mod.rs
+    title: Morphir Rust configuration parser
+  - id: discovery
+    resource: https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir-design/src/config.rs
+    title: Morphir Rust configuration discovery and context
+  - id: daemon
+    resource: https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir-daemon/src/workspace.rs
+    title: Morphir Rust daemon workspace loading
+  - id: compile-cli
+    resource: https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir/src/commands/compile.rs
+    title: Morphir Rust compile command
+  - id: generate-cli
+    resource: https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir/src/commands/generate.rs
+    title: Morphir Rust generate command
+generated:
+  by: process:kb-update
+  at: 2026-08-24T00:00:00Z
+---
+
+# Morphir Rust configuration support at cdfa6c63
+
+At commit `cdfa6c6323ab0f08a285b77a8a857eb9915a83fb`, Morphir Rust parses TOML and YAML with explicit profile checks
+into a shared JSON value. It discovers canonical project and global files and uses YAML in the CLI and daemon. Its
+layer loading is narrower than the normative six-layer [Merge Rules](/merge-rules.md). Configuration context loading
+merges a global user file below the selected project or workspace file. For a workspace, it then tries the
+`default_member` or first `members` value as a literal path and may merge that project file.
+[discovery](https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir-design/src/config.rs)
+
+## Baseline
+
+All claims on this page were verified against `finos/morphir-rust` commit
+`cdfa6c6323ab0f08a285b77a8a857eb9915a83fb`. Re-read the pinned files and update this reference when the commit pin
+moves. [Configuration Overview](/overview.md) provides the specification baseline and bundle orientation.
+
+## Parsing
+
+| Input | Selection | Normalization |
+| --- | --- | --- |
+| `.toml` | Explicit path or discovery | `toml::Value` to `serde_json::Value` |
+| `.yaml` | Explicit path or discovery | `serde_yaml::Value` to `serde_json::Value` after syntax and value checks |
+| `.yml` | Explicit path only | Same path as `.yaml` |
+| `.json` | Explicit path or legacy fallback during discovery | Legacy project model converted to `MorphirConfig` |
+
+The parser lowercases the extension before selection. It rejects unsupported extensions. File-read errors and the
+TOML or `serde_yaml` parse errors include the source path.
+[parser](https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir-common/src/config/mod.rs#L35-L72)
+
+The YAML checks reject nulls, non-string mapping keys, a non-mapping root, tags, anchors, aliases, and the `<<` merge
+key. Tests also pin rejection of duplicate keys and multiple documents. The Rust parser accepts `.yml` when passed
+as an explicit path, while discovery never lists it as a candidate.
+[parser](https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir-common/src/config/mod.rs#L75-L127)
+
+## Discovery
+
+| Scope | Candidates | Behavior |
+| --- | --- | --- |
+| Project or workspace | `morphir.toml`, `morphir.yaml`, `.morphir/morphir.toml`, `.morphir/morphir.yaml` | Returns one, reports every conflicting path, or falls back to `morphir.json` |
+| XDG global | `$XDG_CONFIG_HOME/morphir/` when absolute, otherwise `$HOME/.config/morphir/`; plus `$HOME/.morphir/` | Checks TOML and YAML across both roots as one candidate set |
+| macOS global | Absolute `$XDG_CONFIG_HOME`, otherwise Application Support; plus `$HOME/.morphir/` | Checks TOML and YAML across both roots as one candidate set |
+| Windows global | roaming application data; plus the profile's `.morphir` directory | Ignores XDG and checks TOML and YAML across both roots |
+
+Project discovery walks from the start directory toward the filesystem root. Exact-directory discovery is also
+public for workspace-member and daemon use. Any candidate set with more than one existing file fails with
+`Ambiguous Morphir configuration; found:` followed by the paths.
+[discovery](https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir-design/src/config.rs#L36-L93)
+
+The `config_root` function maps `.morphir/morphir.toml` and `.morphir/morphir.yaml` back to the directory above
+`.morphir`. Configuration context and relative path resolution use that root. A source directory such as `src`
+therefore resolves beside `.morphir`, not inside it.
+[discovery](https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir-design/src/config.rs#L162-L176)
+
+## Implemented merge sequence
+
+Figure 1 shows the values that the Rust context loader combines.
+
+```mermaid
+flowchart LR
+  base[Global user file or empty object] -->|base value| merge[Deep merge]
+  selected[Selected project or workspace file] -->|overlay value| merge
+  merge -->|decode merged value| decode[Decode MorphirConfig]
+  decode -->|workspace default or first member| member[Member project file]
+  member -->|merge as overlay| effective[Effective member configuration]
+  decode -->|use decoded value| effectiveProject[Effective project configuration]
+```
+
+**Figure 1:** The Rust context loader implements global, selected file, and optional workspace-member merging, not
+the specification's complete six-layer sequence.
+
+Objects merge recursively. Every other overlay value replaces the base value, which makes arrays replace rather
+than concatenate. The selected project or workspace file overrides global user values. A selected workspace member
+then overrides the decoded workspace value. The context loader does not expand a glob in that member value.
+[discovery](https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir-design/src/config.rs#L197-L278)
+
+The implementation does not load built-in defaults as a separate value layer, system configuration, user override
+files, or `MORPHIR_*` environment variables in this path. Rust struct defaults still apply during deserialization.
+That is not the same as loading the six normative sources.
+
+## CLI and daemon use
+
+The `compile` and `generate` commands accept an explicit configuration path. Without one, both call upward discovery
+and report that no `morphir.toml`, `morphir.yaml`, or `morphir.json` was found. Both load the resulting configuration
+through `load_config_context`, so they receive global-below-project merging and hidden-path root resolution.
+[compile-cli](https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir/src/commands/compile.rs#L48-L62)
+[generate-cli](https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir/src/commands/generate.rs#L25-L39)
+
+The daemon uses exact-directory discovery to open a workspace and load each project file directly. Member discovery
+only expands patterns ending in `/*` by listing that pattern's parent directory. It does not apply `workspace.exclude`
+or support other glob forms at this commit. Tests cover a single YAML project and YAML workspace members.
+[daemon](https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir-daemon/src/workspace.rs#L82-L156)
+
+## Verified gaps from the normative YAML specification
+
+The parser does not call the shared `morphir-config-v1` JSON Schema. It converts the parsed value to Rust
+`MorphirConfig`, which checks the fields represented by that type but is not schema validation. The source also has
+no explicit check for YAML 1.2 Core Schema scalar resolution or finite numeric values. These are implementation gaps
+relative to the [YAML specification](https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-yaml/morphir-yaml-specification.md#implementation-checklist), not claims that a known input currently parses incorrectly.
+[parser](https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir-common/src/config/mod.rs#L35-L127)
+
+The custom YAML validation helpers return messages without the source path, line, or column. The specification
+requires parse and validation diagnostics to include the source path and YAML location.
+[parser](https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir-common/src/config/mod.rs#L75-L127)
+[yaml-spec](https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-yaml/morphir-yaml-specification.md#implementation-checklist)

--- a/kb/bundles/morphir/morphir-configuration/overview.md
+++ b/kb/bundles/morphir/morphir-configuration/overview.md
@@ -1,14 +1,20 @@
 ---
 type: Format
 title: Configuration Overview
-description: How morphir.toml is discovered, how TOML maps to the internal object model, and what the top-level keys are.
+description: How TOML and YAML represent one configuration model, how files are discovered, and where the specification and Rust implementation differ.
 resource: https://morphir.finos.org/schemas/morphir-config-v1.yaml
-tags: [morphir, configuration, morphir-toml, workspace]
+tags: [morphir, configuration, morphir-toml, morphir-yaml, workspace]
 status: draft
 sources:
   - id: toml-spec
-    resource: https://github.com/finos/morphir/blob/4d5e5c06a7cf269c5f86b050a16a6f82bb5c29bc/docs/spec/morphir-toml/morphir-toml-specification.md
+    resource: https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-toml/morphir-toml-specification.md
     title: Morphir TOML Configuration Specification
+  - id: yaml-spec
+    resource: https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-yaml/morphir-yaml-specification.md
+    title: Morphir YAML Configuration Specification
+  - id: merge-spec
+    resource: https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-toml/morphir-toml-merge-rules.md
+    title: Morphir Configuration Merge Rules
 generated:
   by: process:kb-seed
   at: 2026-07-28T00:00:00Z
@@ -16,31 +22,98 @@ generated:
 
 # Configuration Overview
 
-`morphir.toml` configures Morphir tooling. Its scope is the workspace, projects, tasks, workflows, and toolchains —
-not the IR format, which is specified separately.
+`morphir.toml` and `morphir.yaml` serialize the same Morphir tooling configuration model. Equivalent files must
+produce the same nested value. Defaults, validation, path resolution, and merging operate on that value rather than
+on TOML or YAML syntax. The model covers workspaces, projects, tasks, workflows, and toolchains. It does not define
+the Morphir IR format. [toml-spec](https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-toml/morphir-toml-specification.md)
+[yaml-spec](https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-yaml/morphir-yaml-specification.md)
+
+## Baseline
+
+This reference uses `finos/morphir` commit `4d2a6d836da1c3a114241e911f1af0f38b97b453`. Re-read the pinned TOML,
+YAML, and merge specifications when that pin moves. The Rust behavior at the matching implementation milestone has
+its own [commit-pinned reference](/morphir-rust-configuration-cdfa6c63.md).
 
 ## Discovery
 
-Tooling treats a directory as a **workspace** when it contains a `morphir.toml`, or the hidden variant
-`.morphir/morphir.toml`.
+The canonical project and workspace candidates are `morphir.toml`, `morphir.yaml`,
+`.morphir/morphir.toml`, and `.morphir/morphir.yaml`. These are alternatives at one location. Discovery must fail
+when more than one exists. It must not merge sibling TOML and YAML files or prefer an extension.
+[yaml-spec](https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-yaml/morphir-yaml-specification.md#file-names-and-discovery)
 
-The file at hand is only one of six configuration sources that are merged into an effective configuration — see
-[Merge Rules](/merge-rules.md).
+The specification leaves hidden-file root resolution ambiguous. The TOML specification says an omitted workspace
+root defaults to the directory containing the configuration file, while the YAML design rule says path resolution
+does not change with serialization. The Rust implementation resolves either hidden serialization from the directory
+above `.morphir`, so `src` remains a project-root-relative path. This is verified implementation behavior, not a
+settled normative rule.
+[toml-spec](https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-toml/morphir-toml-specification.md#workspace)
+[yaml-spec](https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-yaml/morphir-yaml-specification.md#design-rule)
+[rust-config-root](https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir-design/src/config.rs#L162-L176)
+
+`morphir.yaml` is the canonical YAML name. Discovery must ignore `morphir.yml`, but a command that accepts an
+explicit path may load it. The distinction keeps automatic discovery deterministic while allowing an existing
+`.yml` file to be selected directly.
+
+Global user configuration has two alternate roots. The platform root contains `morphir/morphir.toml` or
+`morphir/morphir.yaml`. The home alternative contains `.morphir/morphir.toml` or `.morphir/morphir.yaml`.
+Discovery must find at most one file across both roots and both serializations.
+
+| Platform | Platform configuration directory |
+| --- | --- |
+| Linux and other XDG systems | Absolute, non-empty `$XDG_CONFIG_HOME`; otherwise `$HOME/.config` |
+| macOS | Absolute, non-empty `$XDG_CONFIG_HOME`; otherwise `$HOME/Library/Application Support` |
+| Windows | `FOLDERID_RoamingAppData`, commonly `%APPDATA%` |
+
+An XDG system ignores a relative `XDG_CONFIG_HOME`. Windows resolves the home alternative through
+`FOLDERID_Profile`. `XDG_CONFIG_DIRS` does not define the user-global location.
+[merge-spec](https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-toml/morphir-toml-merge-rules.md#global-user-path-resolution)
+
+Figure 1 separates upward project discovery from the global candidate check.
+
+```mermaid
+flowchart TD
+  start[Start directory] -->|inspect directory| local[Check four project candidates]
+  local -->|one file| load[Load selected file]
+  local -->|more than one| fail[Fail and name every candidate]
+  local -->|none found| parent{Parent exists?}
+  parent -->|yes, ascend| local
+  parent -->|no, reached root| missing[Report no project configuration]
+  global[Check platform and home global candidates] -->|one file| merge[Merge below selected project file]
+  global -->|more than one found| fail
+  global -->|none found| load
+  load -->|selected project value| merge
+```
+
+**Figure 1:** Project discovery walks upward, while global discovery checks two roots at one precedence level.
+
+The normative model merges six sources into an effective configuration. The current Rust implementation covers a
+subset. See [Merge Rules](/merge-rules.md) for the specification and
+[Morphir Rust configuration support](/morphir-rust-configuration-cdfa6c63.md) for verified implementation behavior.
 
 ## Data model
 
-The document is [TOML](https://toml.io/); its semantics are defined by mapping to an equivalent JSON-like object
-model.
+Both serializations normalize to an equivalent JSON-like object model.
 
-| TOML | Object model |
-| ---- | ------------ |
-| `[workspace]` table | `{ "workspace": { ... } }` |
-| `[toolchain.morphir-elm.tasks.make]` dotted table | `toolchain["morphir-elm"]["tasks"]["make"]` |
-| Array | JSON array |
-| Inline table | JSON object |
+| TOML | YAML | Object model |
+| ---- | ---- | ------------ |
+| `[workspace]` table | `workspace:` mapping | `{ "workspace": { ... } }` |
+| `[toolchain.morphir-elm.tasks.make]` dotted table | nested mappings | `toolchain["morphir-elm"]["tasks"]["make"]` |
+| Array | Sequence | JSON array |
+| Inline table | Mapping | JSON object |
 
-Specifying semantics against the object model rather than TOML syntax is what lets environment variables and other
-non-TOML sources participate in the same merge.
+The shared value model lets either file format participate in the same merge. It also defines conversion: a converter
+must preserve the parsed value, but it does not need to preserve comments, key order, quoting, or whitespace.
+
+## Restricted YAML profile
+
+The YAML format uses YAML 1.2 with the Core Schema, UTF-8 encoding, one document, and a mapping root. Mapping keys
+must be case-sensitive strings. Values may be mappings, sequences, strings, finite numbers, or booleans.
+
+The profile rejects nulls, duplicate keys, custom tags, anchors, aliases, and the `<<` merge key. These restrictions
+remove YAML features that libraries interpret differently and keep conversion to the shared value deterministic.
+Authors should quote values such as versions, durations, dates, `null`, `true`, and `1.0` when a parser could assign
+the wrong scalar type.
+[yaml-spec](https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-yaml/morphir-yaml-specification.md#yaml-profile)
 
 ## Top-level keys
 
@@ -48,7 +121,7 @@ All are optional; an absent section uses defaults.
 
 | Key | Covers | Concept |
 | --- | ------ | ------- |
-| `morphir` | Core settings — IR version constraints | [IR, Codegen, and Runtime](/ir-codegen-and-runtime.md) |
+| `morphir` | Core settings for IR version constraints | [IR, Codegen, and Runtime](/ir-codegen-and-runtime.md) |
 | `workspace` | Workspace discovery and output layout | [Workspace and Project](/workspace-and-project.md) |
 | `project` | Project metadata | [Workspace and Project](/workspace-and-project.md) |
 | `ir` | IR processing settings | [IR, Codegen, and Runtime](/ir-codegen-and-runtime.md) |
@@ -58,7 +131,7 @@ All are optional; an absent section uses defaults.
 | `ui` | UI and TUI settings | [IR, Codegen, and Runtime](/ir-codegen-and-runtime.md) |
 | `tasks` | Project task definitions | [Tasks and Workflows](/tasks-and-workflows.md) |
 | `workflows` | Named staged workflows | [Tasks and Workflows](/tasks-and-workflows.md) |
-| `bindings` | External binding type mapping — WIT, Protobuf, JSON | — |
+| `bindings` | External binding type mapping for WIT, Protobuf, and JSON | No separate concept |
 | `toolchain` | External tool adapters and task catalogs | [Toolchains](/toolchains.md) |
 
 `bindings` is listed in the specification's top-level key map but has no section of its own; treat its shape as
@@ -66,8 +139,8 @@ unspecified.
 
 ## Naming convention
 
-Keys use `snake_case` (`source_directory`, `output_dir`, `format_version`) — unlike `morphir.json`, which uses
-camelCase. See [Relationship to morphir.json](/relationship-to-morphir-json.md).
+Keys use `snake_case` (`source_directory`, `output_dir`, `format_version`) in both serializations. `morphir.json`
+uses camelCase. See [Relationship to morphir.json](/relationship-to-morphir-json.md).
 
 ## Machine-readable schema
 

--- a/kb/bundles/morphir/morphir-configuration/relationship-to-morphir-json.md
+++ b/kb/bundles/morphir/morphir-configuration/relationship-to-morphir-json.md
@@ -1,16 +1,25 @@
 ---
-type: Concept
+type: Reference
 title: Relationship to morphir.json
-description: How morphir.toml and the older morphir.json project file compare, and which tools read which.
-tags: [morphir, configuration, morphir-toml, morphir-json, migration]
+description: How the TOML and YAML configuration model compares with the older morphir.json project file, and which tools read each.
+tags: [morphir, configuration, morphir-toml, morphir-yaml, morphir-json, migration]
 status: draft
 sources:
   - id: toml-spec
-    resource: https://github.com/finos/morphir/blob/4d5e5c06a7cf269c5f86b050a16a6f82bb5c29bc/docs/spec/morphir-toml/morphir-toml-specification.md
-    title: Morphir TOML Configuration Specification — status and scope
+    resource: https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-toml/morphir-toml-specification.md
+    title: Morphir TOML Configuration Specification, status and scope
+  - id: yaml-spec
+    resource: https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-yaml/morphir-yaml-specification.md
+    title: Morphir YAML Configuration Specification
   - id: json-spec
-    resource: https://github.com/finos/morphir/blob/4d5e5c06a7cf269c5f86b050a16a6f82bb5c29bc/docs/spec/morphir-json/morphir-json-specification.md
+    resource: https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-json/morphir-json-specification.md
     title: Morphir JSON Project Configuration Specification
+  - id: rust-parser
+    resource: https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir-common/src/config/mod.rs
+    title: Morphir Rust configuration parser
+  - id: rust-model
+    resource: https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir-common/src/config/model.rs
+    title: Morphir Rust configuration model
 generated:
   by: process:kb-seed
   at: 2026-07-28T00:00:00Z
@@ -18,43 +27,63 @@ generated:
 
 # Relationship to morphir.json
 
-Two project configuration formats exist. They are not versions of each other.
+Two configuration models exist. They are not versions of each other. The newer model has equivalent TOML and YAML
+serializations.
 
-| | `morphir.json` | `morphir.toml` |
+## Baseline
+
+This comparison uses the TOML, YAML, and legacy JSON specifications at `finos/morphir` commit
+`4d2a6d836da1c3a114241e911f1af0f38b97b453` and the Rust configuration sources at `finos/morphir-rust` commit
+`cdfa6c6323ab0f08a285b77a8a857eb9915a83fb`. Re-read the pinned sources when either pin moves.
+
+| | `morphir.json` | `morphir.toml` or `morphir.yaml` |
 | --- | --- | --- |
-| **Read by** | `finos/morphir-elm`; supported for compatibility by Morphir Go | Morphir tooling parsing into `pkg/config.Config` |
+| **Known readers** | `finos/morphir-elm`; supported for compatibility by Morphir Go | The TOML specification targets Go `pkg/config.Config`; Morphir Rust loads TOML and YAML into `MorphirConfig` |
 | **Scope** | One project | Workspace, projects, tasks, workflows, toolchains |
 | **Key style** | camelCase | snake_case |
-| **Required fields** | `name`, `sourceDirectory`, `exposedModules` | none — everything is optional |
-| **Layering** | Single file | Six merged sources — see [Merge Rules](/merge-rules.md) |
-| **Status** | Draft; `morphir-elm` docs authoritative | Draft; intended to become authoritative |
+| **Required fields** | `name`, `sourceDirectory`, `exposedModules` | None. Every field is optional. |
+| **Layering** | Single file | Six merged sources. See [Merge Rules](/merge-rules.md). |
+| **Status** | Draft; `morphir-elm` docs authoritative | TOML draft; YAML supported by the Rust loader and CLI |
 
-Each specification explicitly puts the other out of scope.
+[rust-parser](https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir-common/src/config/mod.rs#L35-L72)
+[json-spec-table](https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-json/morphir-json-specification.md)
+[toml-spec-table](https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-toml/morphir-toml-specification.md)
+[yaml-spec-table](https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-yaml/morphir-yaml-specification.md)
+
+The legacy JSON specification places `morphir.toml` out of scope. The YAML specification places legacy
+`morphir.json` out of scope. The TOML specification excludes Morphir IR JSON, not the legacy project file, so it does
+not state the reciprocal exclusion.
+[json-spec](https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-json/morphir-json-specification.md#status-and-scope)
+[yaml-spec](https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-yaml/morphir-yaml-specification.md#status-and-scope)
+[toml-spec](https://github.com/finos/morphir/blob/4d2a6d836da1c3a114241e911f1af0f38b97b453/docs/spec/morphir-toml/morphir-toml-specification.md#status-and-scope)
 
 ## Overlapping fields
 
-| Concept | `morphir.json` | `morphir.toml` |
+| Concept | `morphir.json` | TOML or YAML configuration model |
 | ------- | -------------- | -------------- |
 | Project name | `name` (required) | `[project].name` |
 | Source directory | `sourceDirectory` (required) | `[project].source_directory` |
 | Public API | `exposedModules` (required) | `[project].exposed_modules` |
 | Decorations | `decorations.<id>` with `displayName`, `ir`, `entryPoint` | `[project.decorations.<id>]` with the same three plus `storage_location` |
-| Dependencies | `dependencies`, `localDependencies` — arrays of IR references | **no equivalent section** |
+| Dependencies | `dependencies` and `localDependencies`, both arrays of IR references | No normative section; Rust adds `dependencies` and `dev-dependencies` maps with a different value shape |
 
 ## What each has that the other does not
 
-**Only in `morphir.json`**: dependency references, with their resolution rules for `data:`, `file:`, `http:`,
+The legacy specification alone defines dependency references with resolution rules for `data:`, `file:`, `http:`,
 `https:`, `ftp:`, and plain paths, plus the reserved-but-unimplemented `git:`, `github:`, and `npm:` schemes. See the
 `morphir-ir-v3` bundle's project configuration concept.
 
-**Only in `morphir.toml`**: workspaces and member discovery, `module_prefix`, IR format version and strict mode,
-codegen targets, cache, logging, and UI settings, tasks, workflows, toolchains, and the layered merge.
+The newer normative model alone defines workspaces and member discovery, `module_prefix`, IR format version and
+strict mode, codegen targets, cache, logging, and UI settings, tasks, workflows, toolchains, and the layered merge.
 
-The dependency gap is the notable one. `morphir.toml` covers strictly more ground in every other respect, but the
-specification names no section for dependency references — so the two formats are not yet interchangeable for a
-project with dependencies.
+The dependency gap is the notable one. The normative TOML and YAML model names no dependency section. The Rust
+`MorphirConfig` extends that model with top-level `dependencies` and `dev-dependencies` maps whose values are version
+strings or detailed version, path, and Git specifications. Those maps are not equivalent to the legacy arrays of IR
+references, so the models remain non-interchangeable for a project with dependencies.
+[rust-model](https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir-common/src/config/model.rs#L35-L44)
+[rust-dependency-spec](https://github.com/finos/morphir-rust/blob/cdfa6c6323ab0f08a285b77a8a857eb9915a83fb/crates/morphir-common/src/config/model.rs#L191-L210)
 
-## Where morphir.toml appears in v4
+## Where the newer model appears in v4
 
 The v4 Document Tree layout places a `morphir.toml` at the root of a `.morphir-dist/` distribution, as
 "project-level configuration". See the `morphir-ir-v4-draft` bundle. That is a further sign of direction of travel,
@@ -62,5 +91,5 @@ though nothing states that `morphir.json` is deprecated.
 
 ## Practical guidance
 
-If you are working with `morphir-elm`, you are working with `morphir.json` — it is what that toolchain reads. Treat
-`morphir.toml` as the configuration model of the newer, polyglot toolchain, and do not assume a tool reads both.
+`morphir-elm` reads `morphir.json`. Treat the TOML and YAML model as configuration for the newer, polyglot
+toolchain, and do not assume a tool reads every serialization.

--- a/kb/bundles/morphir/morphir-scala/design/pipeline-workspace-boundaries.md
+++ b/kb/bundles/morphir/morphir-scala/design/pipeline-workspace-boundaries.md
@@ -42,9 +42,9 @@ sources:
 # Multi-frontend pipeline and workspace boundaries
 
 Morphir buildkit should provide language-neutral phase and workspace contracts while each frontend retains its own
-effects, native manifests, syntax trees, and compiler accommodations. `morphir.toml` owns workspace orchestration;
-manifest adapters normalize ecosystem projects; package resolution supplies frontend-readable sources without making
-an Elm cache or compiler sandbox part of the shared model.
+effects, native manifests, syntax trees, and compiler accommodations. `morphir.toml` and `morphir.yaml` own workspace
+orchestration. Manifest adapters normalize ecosystem projects. Package resolution supplies frontend-readable sources
+without making an Elm cache or compiler sandbox part of the shared model.
 
 This is a mutable Design Note for [intent 0007](../../../intent/0007-multi-frontend-morphir-transformation-pipeline.md).
 The boundaries below are settled enough to guide refinement, but implementation feedback has not yet made their
@@ -59,8 +59,13 @@ registries, and materialization evolve separately in the
 - The reusable `Stage` abstraction lived under the Elm compiler API even though sequencing typed input and output
   values is not intrinsically Elm-specific. It has since moved to `morphir/buildkit/core` (package
   `morphir.buildkit`).
-- Existing draft Morphir configuration knowledge gives `morphir.toml` responsibility for workspace members, tasks,
-  workflows, outputs, and toolchain policy. It does not erase `elm.json`, `morphir.json`, or future native manifests.
+- Existing Morphir configuration knowledge assigns workspace members, tasks, workflows, outputs, and toolchain policy
+  to one model with TOML and YAML serializations. The normative merge model has six sources. The pinned Rust
+  implementation loads a smaller subset and handles daemon projects separately. The
+  [configuration overview](../../morphir-configuration/overview.md) and the
+  [Morphir Rust configuration reference](../../morphir-configuration/morphir-rust-configuration-cdfa6c63.md)
+  document this difference.
+  This configuration does not erase `elm.json`, `morphir.json`, or future native manifests.
 - Morphir transforms projects rather than isolated files. A frontend needs normalized project inputs and resolved
   dependency modules before it can produce Morphir IR.
 - Issue #930 needs dependency source to resolve Elm operator fixities. That need is narrower than delivering the
@@ -126,10 +131,11 @@ closed by the report executor on this branch; parallel execution remains open.
 
 ### Workspace ownership and normalization
 
-`morphir.toml` owns workspace discovery, members, task and workflow policy, outputs, and toolchain selection. Native
-manifests remain authoritative for ecosystem semantics and normalize through adapters into a shared project model.
-Explicit request values override `morphir.toml`; `morphir.toml` overrides adapter defaults. Contradictory native
-claims produce diagnostics rather than being silently merged.
+The shared Morphir configuration model, serialized as `morphir.toml` or `morphir.yaml`, owns workspace discovery,
+members, task and workflow policy, outputs, and toolchain selection. Native manifests remain authoritative for
+ecosystem semantics and normalize through adapters into a shared project model. Explicit request values override
+Morphir configuration. Morphir configuration overrides adapter defaults. Contradictory native claims produce
+diagnostics rather than being silently merged.
 
 This arrangement makes Morphir orchestration explicit without inventing a second representation of every ecosystem's
 package and compiler rules.
@@ -161,8 +167,8 @@ is part of the issue #930 API.
 2. Which validation belongs in an immutable pipeline definition, and which checks require per-run workspace data?
 3. How do plugin repetition, replacement, and ordering remain explicit without an untyped option-merging model?
 4. What normalized project fields are genuinely shared across ecosystems, and which must remain adapter-owned?
-5. How should contradictory information from `morphir.toml`, `morphir.json`, and a native manifest be reported when
-   no source has universal authority?
+5. How should contradictory information from Morphir configuration, `morphir.json`, and a native manifest be
+   reported when no source has universal authority?
 6. Which minimal package interpreters does issue #930 require before the full package-management intent is delivered?
 7. Which of the settled-enough boundaries need separate Decision Records rather than one combined record?
 

--- a/kb/bundles/morphir/morphir-scala/log.md
+++ b/kb/bundles/morphir/morphir-scala/log.md
@@ -1,5 +1,10 @@
 # Log
 
+## 2026-08-24
+
+* **Update**: Linked the pipeline and workspace narrative to the pinned Morphir Rust configuration reference. The
+  narrative now distinguishes the normative six-source merge from the smaller subset implemented in Rust.
+
 ## 2026-08-21
 
 * **Creation**: Added [GitHub connection settings and local web host](/design/github-connection-settings-and-local-web-host.md), covering the shared connection contract, loopback server, Electron host, optional persistence, UI states, and required security audit.


### PR DESCRIPTION
## Summary

- document the shared TOML and YAML configuration model
- record YAML discovery, platform paths, ambiguity rules, and merge behavior
- add a commit-pinned reference for the Morphir Rust parser, CLI, daemon, and known specification gaps
- update KB indexes, source pins, history, and the morphir.json comparison

## Validation

- KB checker: 0 errors
- KB checker reports 17 pre-existing warnings outside the changed files
- git diff --check
- independent KB writer and reviewer passes completed