### PR TITLE
Add configurable linker worker controls and profiling

### DIFF
--- a/.claude/skills/squire/SquireTests.scala
+++ b/.claude/skills/squire/SquireTests.scala
@@ -168,6 +168,18 @@ object SquireCiPolicy:
       case _                                         => false
     }
 
+  def yamlKeysAtIndent(block: String, indent: Int): List[String] =
+    block.linesIterator.collect {
+      case line @ YamlKey(doubleQuoted, singleQuoted, bare) if leadingSpaces(line) == indent =>
+        List(doubleQuoted, singleQuoted, bare).find(_ != null).get
+    }.toList
+
+  def unquoteYamlScalar(value: String): String =
+    if value.length >= 2 &&
+      ((value.head == '"' && value.last == '"') || (value.head == '\'' && value.last == '\''))
+    then value.drop(1).dropRight(1)
+    else value
+
   def yamlSequenceEntries(block: String, indent: Int): List[String] =
     block.linesIterator.filter { line =>
       val item = line.drop(indent)
@@ -447,6 +459,268 @@ object SquireCiPolicy:
       "workflow permissions must be exactly contents: read"
     )
 
+  def assertNoForbiddenLinkerBenchmarkTokens(workflow: String): Unit =
+    val forbidden = List(
+      "mise",
+      "ci.test",
+      "ci.publish",
+      "publication",
+      "uses: ./.github/workflows",
+      "secrets."
+    )
+    forbidden.foreach(token =>
+      expect(!workflow.toLowerCase.contains(token), s"workflow contains forbidden token: $token")
+    )
+
+  def assertLinkerBenchmarkWorkflowPolicy(workflow: String): Unit =
+    val hostedOutput = ".dev/.sdlc/mill-jvm-worker-pool/out/hosted"
+    val launcher     = "./mill --ticker false scripts/ci/LinkerBenchmark.scala"
+    val presets      = List(
+      "quick-smoke",
+      "js-strategies",
+      "wasm-strategies",
+      "native-long-lived",
+      "native-fresh-recycled"
+    )
+    val overrides = List(
+      ("platforms", "string", "", "PLATFORMS", "platforms"),
+      ("strategies", "string", "", "STRATEGIES", "strategies"),
+      ("trials", "number", "0", "TRIALS", "trials"),
+      ("order_seed", "string", "", "ORDER_SEED", "order-seed"),
+      ("target_filter", "string", "", "TARGET_FILTER", "target-filter"),
+      ("target_limit", "number", "0", "TARGET_LIMIT", "target-limit"),
+      ("memory_gib", "number", "0", "MEMORY_GIB", "memory-gib"),
+      ("reserve_gib", "number", "0", "RESERVE_GIB", "reserve-gib"),
+      ("mill_jobs", "number", "0", "MILL_JOBS", "mill-jobs"),
+      ("max_children", "number", "0", "MAX_CHILDREN", "max-children"),
+      ("batch_size", "number", "0", "BATCH_SIZE", "batch-size"),
+      ("timeout_minutes", "number", "0", "TIMEOUT_MINUTES", "timeout-minutes")
+    )
+    val inputNames = "preset" :: overrides.map(_._1) ::: List("continue_on_failure")
+
+    expect(
+      workflow.linesIterator.nextOption().contains(
+        "# Manual dispatch appears in the Actions UI only after this file exists on the default branch."
+      ),
+      "workflow header must explain the default-branch dispatch requirement"
+    )
+    val events = indentedBlock(workflow, "on:", 0)
+    expect(
+      yamlKeysAtIndent(events, 2) == List("workflow_dispatch"),
+      "linker benchmark workflow must be workflow_dispatch-only"
+    )
+    List("push", "pull_request", "schedule", "release", "workflow_call").foreach { event =>
+      expect(!hasYamlKey(events, event), s"linker benchmark workflow must not use $event")
+    }
+    assertReadOnlyPermissions(workflow)
+
+    val dispatch = indentedBlock(events, "workflow_dispatch:", 2)
+    val inputs   = indentedBlock(dispatch, "inputs:", 4)
+    expect(
+      yamlKeysAtIndent(inputs, 6) == inputNames,
+      s"unexpected linker benchmark inputs: ${yamlKeysAtIndent(inputs, 6)}"
+    )
+
+    def input(name: String): String                                         = indentedBlock(inputs, s"$name:", 6)
+    def assertInput(name: String, inputType: String, default: String): Unit =
+      val block = input(name)
+      expect(unquoteYamlScalar(scalar(block, "type")) == inputType, s"$name must be a $inputType input")
+      expect(unquoteYamlScalar(scalar(block, "default")) == default, s"$name has an unexpected default")
+
+    assertInput("preset", "choice", "quick-smoke")
+    expect(
+      yamlSequenceEntries(indentedBlock(input("preset"), "options:", 8), 10).map(line =>
+        unquoteYamlScalar(line.trim.drop(2))
+      ) == presets,
+      "preset choices must be the exact hosted preset tokens"
+    )
+    overrides.foreach { case (name, inputType, default, _, _) => assertInput(name, inputType, default) }
+    assertInput("continue_on_failure", "choice", "preset")
+    expect(
+      yamlSequenceEntries(indentedBlock(input("continue_on_failure"), "options:", 8), 10).map(line =>
+        unquoteYamlScalar(line.trim.drop(2))
+      ) ==
+        List("preset", "true", "false"),
+      "continuation choices must be preset, true, false"
+    )
+    expect(
+      !inputNames.contains("profile") && !inputNames.exists(_.contains("heap")),
+      "hosted inputs must not expose profile or heap"
+    )
+
+    val jobs = indentedBlock(workflow, "jobs:", 0)
+    expect(yamlKeysAtIndent(jobs, 2) == List("benchmark"), "workflow must contain exactly one benchmark job")
+    val job = indentedBlock(jobs, "benchmark:", 2)
+    expect(unquoteYamlScalar(scalar(job, "runs-on")) == "ubuntu-latest", "benchmark must run on ubuntu-latest")
+    expect(unquoteYamlScalar(scalar(job, "timeout-minutes")) == "360", "benchmark job timeout must be 360 minutes")
+    val stepNames = job.linesIterator.collect {
+      case line if line.startsWith("      - name: ") => line.stripPrefix("      - name: ")
+    }.toList
+    expect(
+      stepNames == List(
+        "Checkout current branch",
+        "Setup Scala and Java",
+        "Cache scala dependencies",
+        "Generate artifact name",
+        "Run linker benchmark",
+        "Upload benchmark results",
+        "Publish benchmark summary"
+      ),
+      s"unexpected linker benchmark steps: $stepNames"
+    )
+    expect(yamlSequenceEntries(job, 6).size == 7, "benchmark job must contain exactly seven named steps")
+    expect(job.linesIterator.count(_.trim.startsWith("run:")) == 3, "benchmark job must contain exactly three run steps")
+
+    def runLines(step: String, name: String): List[String] =
+      val lines    = step.linesIterator.toList
+      val runIndex = lines.indexWhere(_.trim == "run: |")
+      if runIndex < 0 then fail(s"$name must use a literal run block")
+      val runIndent = leadingSpaces(lines(runIndex))
+      lines.drop(runIndex + 1).takeWhile(line => line.trim.isEmpty || leadingSpaces(line) > runIndent)
+        .map(_.drop(runIndent + 2)).filter(_.nonEmpty)
+
+    val expectedActions = List(
+      "actions/checkout@v7.0.1",
+      "actions/setup-java@v5",
+      "coursier/cache-action@v8",
+      "actions/upload-artifact@v7"
+    )
+    val actualActions = job.linesIterator.map(_.trim).filter(_.startsWith("uses: ")).map(_.drop(6)).toList
+    expect(actualActions == expectedActions, s"unexpected linker benchmark actions: $actualActions")
+    val checkout = indentedBlock(job, "- name: Checkout current branch", 6)
+    expect(unquoteYamlScalar(scalar(checkout, "fetch-depth")) == "0", "checkout must fetch full history")
+    val java = indentedBlock(job, "- name: Setup Scala and Java", 6)
+    expect(unquoteYamlScalar(scalar(java, "distribution")) == "temurin", "setup-java must use Temurin")
+    expect(unquoteYamlScalar(scalar(java, "java-version")) == "25", "setup-java must use Java 25")
+
+    val artifactName = indentedBlock(job, "- name: Generate artifact name", 6)
+    expect(
+      unquoteYamlScalar(scalar(artifactName, "id")) == "artifact-name",
+      "artifact name step must expose its output"
+    )
+    val artifactEnvironment = indentedBlock(artifactName, "env:", 8)
+    expect(yamlKeysAtIndent(artifactEnvironment, 10) == List("PRESET"), "artifact name env must contain only PRESET")
+    expect(
+      scalar(artifactEnvironment, "PRESET") == "${{ inputs.preset }}",
+      "artifact name PRESET must map from inputs.preset"
+    )
+    expect(count(artifactName, launcher) == 1, "artifact name step must invoke the linker benchmark launcher once")
+    List(
+      "--artifact-name-only true",
+      "--artifact-ref \"$GITHUB_REF_NAME\"",
+      "--artifact-run-id \"$GITHUB_RUN_ID\"",
+      "--artifact-run-attempt \"$GITHUB_RUN_ATTEMPT\"",
+      "printf 'name=%s\\n' \"$name\" >> \"$GITHUB_OUTPUT\""
+    ).foreach(required => expect(artifactName.contains(required), s"artifact name step is missing: $required"))
+    expect(
+      runLines(artifactName, "artifact name step") == List(
+        s"name=\"$$($launcher \\",
+        "  --preset \"$PRESET\" \\",
+        "  --artifact-name-only true \\",
+        "  --artifact-ref \"$GITHUB_REF_NAME\" \\",
+        "  --artifact-run-id \"$GITHUB_RUN_ID\" \\",
+        "  --artifact-run-attempt \"$GITHUB_RUN_ATTEMPT\")\"",
+        "printf 'name=%s\\n' \"$name\" >> \"$GITHUB_OUTPUT\""
+      ),
+      "artifact name shell must contain only command substitution and the GITHUB_OUTPUT write"
+    )
+
+    val benchmark = indentedBlock(job, "- name: Run linker benchmark", 6)
+    val benchmarkEnvironment = indentedBlock(benchmark, "env:", 8)
+    val expectedBenchmarkEnvironment = "PRESET" :: overrides.map(_._4) ::: List("CONTINUE_ON_FAILURE")
+    expect(
+      yamlKeysAtIndent(benchmarkEnvironment, 10) == expectedBenchmarkEnvironment,
+      s"unexpected benchmark environment: ${yamlKeysAtIndent(benchmarkEnvironment, 10)}"
+    )
+    expect(
+      scalar(benchmarkEnvironment, "PRESET") == "${{ inputs.preset }}",
+      "benchmark PRESET must map from inputs.preset"
+    )
+    expect(count(benchmark, launcher) == 1, "benchmark step must invoke the linker benchmark launcher once")
+    expect(benchmark.contains("--preset \"$PRESET\""), "benchmark preset must cross the quoted environment boundary")
+    overrides.foreach { case (inputName, _, _, environmentName, flag) =>
+      expect(
+        benchmark.contains(s"$environmentName: $${{ inputs.$inputName }}"),
+        s"benchmark step must map $inputName to $environmentName"
+      )
+      expect(benchmark.contains(s"--$flag \"$$$environmentName\""), s"benchmark step must quote $environmentName")
+    }
+    expect(
+      benchmark.contains("CONTINUE_ON_FAILURE: ${{ inputs.continue_on_failure }}") &&
+        benchmark.contains("--continue-on-failure \"$CONTINUE_ON_FAILURE\""),
+      "continuation must cross the quoted environment boundary"
+    )
+    expect(benchmark.contains(s"--output \"$hostedOutput\""), "benchmark output must use the fixed hosted directory")
+    expect(
+      runLines(benchmark, "benchmark step") == List(
+        s"$launcher \\",
+        "  --preset \"$PRESET\" \\",
+        "  --platforms \"$PLATFORMS\" \\",
+        "  --strategies \"$STRATEGIES\" \\",
+        "  --trials \"$TRIALS\" \\",
+        "  --order-seed \"$ORDER_SEED\" \\",
+        "  --target-filter \"$TARGET_FILTER\" \\",
+        "  --target-limit \"$TARGET_LIMIT\" \\",
+        "  --memory-gib \"$MEMORY_GIB\" \\",
+        "  --reserve-gib \"$RESERVE_GIB\" \\",
+        "  --mill-jobs \"$MILL_JOBS\" \\",
+        "  --max-children \"$MAX_CHILDREN\" \\",
+        "  --batch-size \"$BATCH_SIZE\" \\",
+        "  --timeout-minutes \"$TIMEOUT_MINUTES\" \\",
+        "  --continue-on-failure \"$CONTINUE_ON_FAILURE\" \\",
+        s"  --output \"$hostedOutput\""
+      ),
+      "benchmark shell must contain only the approved direct launcher command"
+    )
+    expect(count(workflow, launcher) == 2, "workflow must contain exactly two approved benchmark launcher invocations")
+    workflow.linesIterator.filter(_.contains("${{ inputs.")).foreach { line =>
+      val trimmed = line.trim
+      expect(
+        trimmed.matches("[A-Z][A-Z0-9_]*: \\$\\{\\{ inputs\\.[a-z0-9_]+ \\}\\}"),
+        s"GitHub input expression may appear only in a step env mapping: $trimmed"
+      )
+    }
+    expect(
+      !workflow.contains("--profile") && !workflow.toLowerCase.contains("--heap"),
+      "hosted workflow must not override profile or heap"
+    )
+
+    val upload = indentedBlock(job, "- name: Upload benchmark results", 6)
+    expect(scalar(upload, "if") == "${{ always() }}", "artifact upload must always run")
+    expect(
+      unquoteYamlScalar(scalar(upload, "name")) ==
+        "${{ steps.artifact-name.outputs.name || format('linker-benchmark-{0}-{1}', github.run_id, github.run_attempt) }}",
+      "artifact upload must use the generated safe name with a run-based fallback"
+    )
+    expect(unquoteYamlScalar(scalar(upload, "path")) == s"$hostedOutput/**", "artifact upload path must be hosted/**")
+    expect(
+      unquoteYamlScalar(scalar(upload, "include-hidden-files")) == "true",
+      "artifact upload must include hidden files within the fixed hosted path"
+    )
+    expect(unquoteYamlScalar(scalar(upload, "retention-days")) == "14", "artifact retention must be 14 days")
+
+    val summary = indentedBlock(job, "- name: Publish benchmark summary", 6)
+    expect(scalar(summary, "if") == "${{ always() }}", "benchmark summary must always run")
+    val summaryEnvironment = indentedBlock(summary, "env:", 8)
+    expect(yamlKeysAtIndent(summaryEnvironment, 10) == List("ARTIFACT_NAME"), "summary env must contain ARTIFACT_NAME")
+    expect(
+      scalar(summaryEnvironment, "ARTIFACT_NAME") ==
+        "${{ steps.artifact-name.outputs.name || format('linker-benchmark-{0}-{1}', github.run_id, github.run_attempt) }}",
+      "summary must use the generated artifact name with its safe fallback"
+    )
+    expect(
+      runLines(summary, "summary step") == List(
+        s"summary=\"$$(find \"$hostedOutput\" -type f -name summary.md -print -quit 2>/dev/null || true)\"",
+        "if [[ -n \"$summary\" ]]; then",
+        "  cat \"$summary\" >> \"$GITHUB_STEP_SUMMARY\"",
+        "else",
+        "  printf 'Linker benchmark results: artifact %s.\\n' \"$ARTIFACT_NAME\" >> \"$GITHUB_STEP_SUMMARY\"",
+        "fi"
+      ),
+      "summary shell must contain only nonfailing find and summary-or-artifact output glue"
+    )
+    assertNoForbiddenLinkerBenchmarkTokens(workflow)
+
   def assertMorphirCapabilityPolicy(workflow: String): Unit =
     val commands = List(
       "mill-morphir-unit:" -> "'mill-plugins.morphir.{toolchain,javascript,elm-tooling,core,elm}.__.test'",
@@ -476,10 +750,13 @@ object SquireCiPolicy:
   def assertJvmPlatformPolicy(workflow: String, buildMill: String, task: String): Unit =
     val testJvm = indentedBlock(workflow, "test-jvm:", 2)
     val runJvm  = indentedBlock(testJvm, "- name: Run JVM tests", 6)
-    expect(scalar(runJvm, "run") == "mise run test:jvm-platform", "generic JVM CI must use test:jvm-platform")
     expect(
-      task.linesIterator.map(_.trim).contains("./mill --ticker false -i Alias/run testJVMPlatform"),
-      "test:jvm-platform must invoke Alias/run testJVMPlatform"
+      scalar(runJvm, "run") == "./mill --ticker false -i ci.testJvm",
+      "generic JVM CI must use ci.testJvm"
+    )
+    expect(
+      task.linesIterator.map(_.trim).contains("./mill --ticker false -i ci.testJvm"),
+      "test:jvm-platform must invoke ci.testJvm"
     )
     val definitions = "(?m)^\\s*def testJVMPlatform\\b".r.findAllMatchIn(buildMill).size
     expect(definitions == 1, s"build must provide exactly one testJVMPlatform alias, found $definitions")
@@ -1425,6 +1702,10 @@ class SquireCiPolicySpec extends Test[Any]:
     skillDirectory.resolve("../../../.github/workflows/ci.yml").normalize,
     StandardCharsets.UTF_8
   )
+  private val linkerBenchmarkWorkflow = Files.readString(
+    skillDirectory.resolve("../../../.github/workflows/linker-benchmark.yml").normalize,
+    StandardCharsets.UTF_8
+  )
   private val buildMill = Files.readString(
     skillDirectory.resolve("../../../build.mill").normalize,
     StandardCharsets.UTF_8
@@ -1555,6 +1836,176 @@ class SquireCiPolicySpec extends Test[Any]:
   }
 
   "hosted CI policy" - {
+    "guards the manual hosted linker benchmark workflow" in {
+      assertLinkerBenchmarkWorkflowPolicy(linkerBenchmarkWorkflow)
+
+      val events        = indentedBlock(linkerBenchmarkWorkflow, "on:", 0)
+      val dispatch      = indentedBlock(events, "workflow_dispatch:", 2)
+      val inputs        = indentedBlock(dispatch, "inputs:", 4)
+      val overrideNames = List(
+        "platforms",
+        "strategies",
+        "trials",
+        "order_seed",
+        "target_filter",
+        "target_limit",
+        "memory_gib",
+        "reserve_gib",
+        "mill_jobs",
+        "max_children",
+        "batch_size",
+        "timeout_minutes",
+        "continue_on_failure"
+      )
+      val missingOverrideMutations = overrideNames.map { name =>
+        val declaration = s"      $name:\n" + indentedBlock(inputs, s"$name:", 6)
+        name -> replaceOnce(linkerBenchmarkWorkflow, declaration, "")
+      }
+      missingOverrideMutations.foreach { case (name, mutation) =>
+        assert(rejects(assertLinkerBenchmarkWorkflowPolicy, mutation), s"missing $name input must be rejected")
+      }
+
+      val artifactPresetUnmapped = replaceOnce(
+        linkerBenchmarkWorkflow,
+        "      - name: Generate artifact name\n        id: artifact-name\n        env:\n          PRESET: ${{ inputs.preset }}\n",
+        "      - name: Generate artifact name\n        id: artifact-name\n"
+      )
+      val benchmarkPresetUnmapped = replaceOnce(
+        linkerBenchmarkWorkflow,
+        "      - name: Run linker benchmark\n        env:\n          PRESET: ${{ inputs.preset }}\n",
+        "      - name: Run linker benchmark\n        env:\n"
+      )
+      val bothPresetsUnmapped = replaceOnce(
+        artifactPresetUnmapped,
+        "      - name: Run linker benchmark\n        env:\n          PRESET: ${{ inputs.preset }}\n",
+        "      - name: Run linker benchmark\n        env:\n"
+      )
+      val forbiddenCommandMutation = replaceOnce(
+        linkerBenchmarkWorkflow,
+        "          printf 'name=%s\\n' \"$name\" >> \"$GITHUB_OUTPUT\"",
+        "          printf 'name=%s\\n' \"$name\" >> \"$GITHUB_OUTPUT\"\n          echo ci.publish"
+      )
+      assert(
+        rejects(assertNoForbiddenLinkerBenchmarkTokens, forbiddenCommandMutation),
+        "forbidden command token must be rejected independently"
+      )
+
+      val mutations = List(
+        "artifact preset env mapping removed" -> artifactPresetUnmapped,
+        "benchmark preset env mapping removed" -> benchmarkPresetUnmapped,
+        "both preset env mappings removed" -> bothPresetsUnmapped,
+        "manual trigger replaced" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "  workflow_dispatch:\n",
+          "  push:\n"
+        ),
+        "pull request trigger added" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "on:\n  workflow_dispatch:\n",
+          "on:\n  pull_request:\n  workflow_dispatch:\n"
+        ),
+        "write permission added" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "permissions:\n  contents: read",
+          "permissions:\n  contents: read\n  actions: write"
+        ),
+        "upload always removed" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "      - name: Upload benchmark results\n        if: ${{ always() }}\n",
+          "      - name: Upload benchmark results\n"
+        ),
+        "summary always removed" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "      - name: Publish benchmark summary\n        if: ${{ always() }}\n",
+          "      - name: Publish benchmark summary\n"
+        ),
+        "default preset changed" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "        default: quick-smoke",
+          "        default: js-strategies"
+        ),
+        "ticker re-enabled" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "./mill --ticker false scripts/ci/LinkerBenchmark.scala",
+          "./mill scripts/ci/LinkerBenchmark.scala"
+        ),
+        "input interpolated directly in shell" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "--platforms \"$PLATFORMS\"",
+          "--platforms \"${{ inputs.platforms }}\""
+        ),
+        "production command added" -> forbiddenCommandMutation,
+        "summary find can fail" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          " -print -quit 2>/dev/null || true)",
+          " -print -quit 2>/dev/null)"
+        ),
+        "summary fallback removed" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "          else\n            printf 'Linker benchmark results: artifact %s.\\n' \"$ARTIFACT_NAME\" >> \"$GITHUB_STEP_SUMMARY\"\n",
+          ""
+        ),
+        "summary fallback loses artifact reference" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "\"$ARTIFACT_NAME\" >> \"$GITHUB_STEP_SUMMARY\"",
+          "\"results\" >> \"$GITHUB_STEP_SUMMARY\""
+        ),
+        "case validator injected" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "          ./mill --ticker false scripts/ci/LinkerBenchmark.scala \\",
+          "          case \"$PRESET\" in\n            quick-smoke) ;;\n            *) exit 2 ;;\n          esac\n          ./mill --ticker false scripts/ci/LinkerBenchmark.scala \\",
+        ),
+        "scheduling loop injected" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "          ./mill --ticker false scripts/ci/LinkerBenchmark.scala \\",
+          "          for attempt in 1; do\n            true\n          done\n          ./mill --ticker false scripts/ci/LinkerBenchmark.scala \\",
+        ),
+        "extra run step injected" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "      - name: Upload benchmark results\n",
+          "      - name: Extra shell\n        run: echo extra\n\n      - name: Upload benchmark results\n"
+        ),
+        "checkout pin drifted" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "actions/checkout@v7.0.1",
+          "actions/checkout@v7"
+        ),
+        "setup-java pin drifted" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "actions/setup-java@v5",
+          "actions/setup-java@v4"
+        ),
+        "Coursier pin drifted" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "coursier/cache-action@v8",
+          "coursier/cache-action@v7"
+        ),
+        "upload pin drifted" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "actions/upload-artifact@v7",
+          "actions/upload-artifact@v6"
+        ),
+        "retention drifted" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "          retention-days: 14",
+          "          retention-days: 30"
+        ),
+        "hidden-file upload removed" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "          include-hidden-files: true\n",
+          ""
+        ),
+        "hidden-file upload disabled" -> replaceOnce(
+          linkerBenchmarkWorkflow,
+          "          include-hidden-files: true",
+          "          include-hidden-files: false"
+        )
+      )
+      mutations.foreach { case (name, mutation) =>
+        assert(rejects(assertLinkerBenchmarkWorkflowPolicy, mutation), s"$name must be rejected")
+      }
+    }
+
     "targets the exact supported pull-request and push branches" in {
       assertBranchPolicy(workflow)
       assert(true)
@@ -1724,8 +2175,8 @@ class SquireCiPolicySpec extends Test[Any]:
         ((workflow: String) => assertJvmPlatformPolicy(workflow, buildMill, jvmPlatformTask)) -> replaceInJob(
           workflow,
           "test-jvm:",
-          "mise run test:jvm-platform",
-          "mise run test:jvm"
+          "./mill --ticker false -i ci.testJvm",
+          "mise run test:jvm-platform"
         ),
         assertMorphirCapabilityPolicy -> replaceInJob(
           workflow,
@@ -1743,7 +2194,7 @@ class SquireCiPolicySpec extends Test[Any]:
       assert(capabilityMutations.forall((validator, mutation) => rejects(validator, mutation)))
     }
 
-    "keeps generic JVM CI on the non-classic platform alias" in {
+    "keeps generic JVM CI on ci.testJvm and the non-classic platform alias" in {
       assertJvmPlatformPolicy(workflow, buildMill, jvmPlatformTask)
 
       val missingPublishAliasMutation = replaceOnce(
@@ -1770,8 +2221,8 @@ class SquireCiPolicySpec extends Test[Any]:
       )
       val taskMutation = replaceOnce(
         jvmPlatformTask,
-        "./mill --ticker false -i Alias/run testJVMPlatform",
-        "./mill --ticker false -i Alias/run testJVM"
+        "./mill --ticker false -i ci.testJvm",
+        "./mill --ticker false -i Alias/run testJVMPlatform"
       )
       val aliasMutations = List(
         missingPublishAliasMutation,

--- a/.config/mise/tasks/test/js
+++ b/.config/mise/tasks/test/js
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 # MISE description="Run JS compile/publish/test workflow"
 
-set -e
+set -euo pipefail
 
 echo "Running JS tests..."
 
-# The `wasm` link variants are named separately: they sit beside their `js`
-# sibling rather than under it, so the `morphir.__.js.__` glob never matches
-# them. `fullLinkJS` is included so a linker regression fails here rather than
-# at release time — the tests alone only exercise `fastLinkJSTest`.
+# `ci.testJs` owns the compile, publish, JS-test and Wasm-test selectors. Run its platform and desktop/UI groups in
+# separate daemonless Mill JVMs, matching hosted CI's split while releasing each in-process Scala.js linker worker
+# before the next group starts.
 #
 # `-j 4` rather than `-j 0`. Every Scala.js link runs inside the single Mill
 # daemon JVM and holds a full linker working set, so the constraint is that
@@ -24,23 +23,16 @@ echo "Running JS tests..."
 # therefore at `-Xmx8g`, which fits GitHub's 16 GB runners. Treat `-j` and
 # `-Xmx` as one setting: lowering the heap means lowering this too.
 #
-# `-j 4` is this task's own default, tuned for a developer machine with headroom to spare. CI runs
-# at `-j 2` instead — see the `test-js` / `test-js-desktop` steps in .github/workflows/ci.yml — a
-# GitHub-hosted runner is smaller and shares its 8 GB daemon heap with everything else on the box,
-# so CI needs a lower cap even after morphir-oyn split the desktop/UI link load into its own job.
-./mill -i -k -j 4 \
-    "morphir.__.js.__.compile" \
-    + \
-    "morphir.__.js.publishArtifacts" \
-    + \
-    "morphir.__.js.__.test" \
-    + \
-    "morphir.__.wasm.__.test"
+# `-j 4` is this task's own default, tuned for a developer machine with headroom to spare. Hosted CI runs at `-j 2`
+# instead; its runners are smaller, so they need a lower cap even after morphir-oyn split the desktop/UI load.
+./mill -i -k -j 4 ci.testJs --group platform
+./mill -i -k -j 4 ci.testJs --group desktop
 
 # The Wasm `fullLinkJS` tasks link one at a time. Each holds the largest working set in this task,
 # and running several concurrently exhausted the daemon heap inside the linker's BinaryWriter
 # (`OutOfMemoryError` in `WebAssemblyLinkerBackend.writeWasmFile`) once a third Wasm variant joined
 # the build. Serial here costs a few minutes; parallel costs the whole job.
-./mill -i -k -j 1 "morphir.__.wasm.fullLinkJS"
+./mill -i -k -j 1 ci.testJsWasmLink --group platform
+./mill -i -k -j 1 ci.testJsWasmLink --group desktop
 
 echo "JS tests completed successfully"

--- a/.config/mise/tasks/test/jvm-platform
+++ b/.config/mise/tasks/test/jvm-platform
@@ -3,4 +3,4 @@
 
 set -euo pipefail
 
-./mill --ticker false -i Alias/run testJVMPlatform
+./mill --ticker false -i ci.testJvm

--- a/.config/mise/tasks/test/native
+++ b/.config/mise/tasks/test/native
@@ -10,7 +10,7 @@ echo "Running Native tests..."
 # `morphir.__` — every other module is jvm/js only and would resolve to
 # nothing.
 #
-# The links run in BATCHES, each its own `./mill` process, because the binding
+# The links run in SHARDS, each its own `./mill` process, because the binding
 # constraint is heap *retention* rather than concurrency. `-i` is daemonless, so
 # one invocation linking every module holds one JVM for all of them, and the
 # linker state from each link is not fully released. On CI the fourteenth link
@@ -21,51 +21,35 @@ echo "Running Native tests..."
 # fine, and the one that died was mid-pack at 6090.
 #
 # Halving `-j` did NOT help, which is what proves the cause: at `-j 2` it died
-# the same way, only later. So concurrency stays at 4 and the batches, not the
+# the same way, only later. So concurrency stays at 4 and the shards, not the
 # job, bound how many links share a heap.
 #
-# The batch list is resolved from Mill rather than written here, so a new native
-# module joins automatically and cannot drift out of step with the build.
+# `ci.testNative` resolves and partitions the target list, so a new native module
+# joins automatically and cannot drift out of step with the build. This launcher
+# only supplies the process boundary that an in-process Mill command cannot.
 #
 # CI runs this task rather than repeating the invocation in ci.yml. It used to
 # hold its own copy, synchronised by hand, and the two drifted apart — which is
 # how `-j 4` survived here while ci.yml ran `-j 2` and each file's comments
 # described the other's settings.
 #
-# This is a stopgap. The durable fix is to shard these across runners from a
-# Mill command, which also gives each shard a fresh JVM — see morphir-lc8.38.
-BATCH="${MORPHIR_NATIVE_BATCH:-5}"
+# Four shards currently put three or four of the 14 Native test targets in each
+# JVM. Keep the count configurable for local and CI memory profiles.
+SHARDS="${MORPHIR_NATIVE_SHARDS:-4}"
 
-# Compile and publish in one pass: these are cheap next to `nativeLink`, and
-# sharing a JVM across them is not what exhausts the heap.
-./mill -i -k -j 4 \
-    "morphir.__.native.__.compile" \
-    + \
-    "morphir.__.native.publishArtifacts"
-
-# Read with a `while` loop rather than `mapfile`: mise runs this under
-# `/usr/bin/env bash`, which is bash 3.2 on macOS, and `mapfile` is bash 4+.
-targets=()
-while IFS= read -r target; do
-  targets+=("$target")
-done < <(./mill --ticker false resolve "morphir.__.native.__.test" | grep '^morphir\.')
-
-if [ "${#targets[@]}" -eq 0 ]; then
-  echo "no native test targets resolved — refusing to report success" >&2
+if [[ ! "$SHARDS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "MORPHIR_NATIVE_SHARDS must be a positive integer (was '$SHARDS')" >&2
   exit 1
 fi
 
-echo "Linking and running ${#targets[@]} native test module(s) in batches of $BATCH"
+# Compile and publish in one pass: these are cheap next to `nativeLink`, and
+# sharing a JVM across them is not what exhausts the heap.
+./mill -i -k -j 4 ci.testNativePrepare
 
-for ((i = 0; i < ${#targets[@]}; i += BATCH)); do
-  batch=("${targets[@]:i:BATCH}")
-  args=()
-  for target in "${batch[@]}"; do
-    [ "${#args[@]}" -eq 0 ] || args+=("+")
-    args+=("$target")
-  done
-  echo "--- batch $((i / BATCH + 1)): ${batch[*]}"
-  ./mill -i -k -j 4 "${args[@]}"
+echo "Linking and running Native tests in $SHARDS fresh-JVM shard(s)"
+for ((shard = 0; shard < SHARDS; shard++)); do
+  echo "--- shard $((shard + 1)) of $SHARDS"
+  ./mill -i -k -j 4 ci.testNative --shard "$shard" --shards "$SHARDS"
 done
 
 echo "Native tests completed successfully"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -557,7 +557,7 @@ jobs:
           experimental: true
 
       - name: Run JVM tests
-        run: mise run test:jvm-platform
+        run: ./mill --ticker false -i ci.testJvm
 
       - name: Cache JVM build output
         # when in master repo: all commits to main branch and all additional tags

--- a/.github/workflows/linker-benchmark.yml
+++ b/.github/workflows/linker-benchmark.yml
@@ -1,0 +1,177 @@
+# Manual dispatch appears in the Actions UI only after this file exists on the default branch.
+name: Linker benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      preset:
+        description: Hosted benchmark preset
+        required: true
+        type: choice
+        default: quick-smoke
+        options:
+          - quick-smoke
+          - js-strategies
+          - wasm-strategies
+          - native-long-lived
+          - native-fresh-recycled
+      platforms:
+        description: Optional comma-separated platform override
+        required: false
+        type: string
+        default: ""
+      strategies:
+        description: Optional comma-separated strategy override
+        required: false
+        type: string
+        default: ""
+      trials:
+        description: Trial count override; zero uses the preset
+        required: false
+        type: number
+        default: 0
+      order_seed:
+        description: Optional strategy-order seed override
+        required: false
+        type: string
+        default: ""
+      target_filter:
+        description: Optional target filter
+        required: false
+        type: string
+        default: ""
+      target_limit:
+        description: Target limit override; zero uses the preset
+        required: false
+        type: number
+        default: 0
+      memory_gib:
+        description: Memory budget override in GiB; zero uses the preset
+        required: false
+        type: number
+        default: 0
+      reserve_gib:
+        description: Reserved memory override in GiB; zero uses the preset
+        required: false
+        type: number
+        default: 0
+      mill_jobs:
+        description: Mill jobs override; zero uses the preset
+        required: false
+        type: number
+        default: 0
+      max_children:
+        description: Maximum child-process override; zero uses the preset
+        required: false
+        type: number
+        default: 0
+      batch_size:
+        description: Batch-size override; zero uses the preset
+        required: false
+        type: number
+        default: 0
+      timeout_minutes:
+        description: Per-operation timeout override; zero uses the preset
+        required: false
+        type: number
+        default: 0
+      continue_on_failure:
+        description: Continue after a failed trial
+        required: true
+        type: choice
+        default: preset
+        options:
+          - preset
+          - "true"
+          - "false"
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup Scala and Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "25"
+
+      - name: Cache scala dependencies
+        uses: coursier/cache-action@v8
+
+      - name: Generate artifact name
+        id: artifact-name
+        env:
+          PRESET: ${{ inputs.preset }}
+        run: |
+          name="$(./mill --ticker false scripts/ci/LinkerBenchmark.scala \
+            --preset "$PRESET" \
+            --artifact-name-only true \
+            --artifact-ref "$GITHUB_REF_NAME" \
+            --artifact-run-id "$GITHUB_RUN_ID" \
+            --artifact-run-attempt "$GITHUB_RUN_ATTEMPT")"
+          printf 'name=%s\n' "$name" >> "$GITHUB_OUTPUT"
+
+      - name: Run linker benchmark
+        env:
+          PRESET: ${{ inputs.preset }}
+          PLATFORMS: ${{ inputs.platforms }}
+          STRATEGIES: ${{ inputs.strategies }}
+          TRIALS: ${{ inputs.trials }}
+          ORDER_SEED: ${{ inputs.order_seed }}
+          TARGET_FILTER: ${{ inputs.target_filter }}
+          TARGET_LIMIT: ${{ inputs.target_limit }}
+          MEMORY_GIB: ${{ inputs.memory_gib }}
+          RESERVE_GIB: ${{ inputs.reserve_gib }}
+          MILL_JOBS: ${{ inputs.mill_jobs }}
+          MAX_CHILDREN: ${{ inputs.max_children }}
+          BATCH_SIZE: ${{ inputs.batch_size }}
+          TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
+          CONTINUE_ON_FAILURE: ${{ inputs.continue_on_failure }}
+        run: |
+          ./mill --ticker false scripts/ci/LinkerBenchmark.scala \
+            --preset "$PRESET" \
+            --platforms "$PLATFORMS" \
+            --strategies "$STRATEGIES" \
+            --trials "$TRIALS" \
+            --order-seed "$ORDER_SEED" \
+            --target-filter "$TARGET_FILTER" \
+            --target-limit "$TARGET_LIMIT" \
+            --memory-gib "$MEMORY_GIB" \
+            --reserve-gib "$RESERVE_GIB" \
+            --mill-jobs "$MILL_JOBS" \
+            --max-children "$MAX_CHILDREN" \
+            --batch-size "$BATCH_SIZE" \
+            --timeout-minutes "$TIMEOUT_MINUTES" \
+            --continue-on-failure "$CONTINUE_ON_FAILURE" \
+            --output ".dev/.sdlc/mill-jvm-worker-pool/out/hosted"
+
+      - name: Upload benchmark results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.artifact-name.outputs.name || format('linker-benchmark-{0}-{1}', github.run_id, github.run_attempt) }}
+          path: .dev/.sdlc/mill-jvm-worker-pool/out/hosted/**
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Publish benchmark summary
+        if: ${{ always() }}
+        env:
+          ARTIFACT_NAME: ${{ steps.artifact-name.outputs.name || format('linker-benchmark-{0}-{1}', github.run_id, github.run_attempt) }}
+        run: |
+          summary="$(find ".dev/.sdlc/mill-jvm-worker-pool/out/hosted" -type f -name summary.md -print -quit 2>/dev/null || true)"
+          if [[ -n "$summary" ]]; then
+            cat "$summary" >> "$GITHUB_STEP_SUMMARY"
+          else
+            printf 'Linker benchmark results: artifact %s.\n' "$ARTIFACT_NAME" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/build.mill
+++ b/build.mill
@@ -985,10 +985,13 @@ trait MorphirMillbuildHelpersModule extends ScalaModule with ScalafmtModule {
     helpersRoot / "FormatKind.scala",
     helpersRoot / "FormatSelection.scala",
     helpersRoot / "LintSelectors.scala",
-    helpersRoot / "JsTestSelectors.scala"
+    helpersRoot / "JsTestSelectors.scala",
+    helpersRoot / "NativeTestSelectors.scala",
+    helpersRoot / "LinkerBenchmark.scala",
+    helpersRoot / "LinkerBenchmarkProcess.scala"
   )
 
-  override def mvnDeps = Seq(Deps.com.lihaoyi.`os-lib`)
+  override def mvnDeps = Seq(Deps.com.lihaoyi.`os-lib`) ++ Deps.com.lihaoyi.upickleManaged
 }
 
 // The following section contains aliases used to simplify build tasks

--- a/ci/LinkerBenchmark.mill
+++ b/ci/LinkerBenchmark.mill
@@ -68,6 +68,13 @@ trait LinkerBenchmarkModule extends Module {
       platform: String,
       strategy: String,
       profile: String,
+      memoryGib: Int,
+      reserveGib: Int,
+      heapGib: Int,
+      millJobs: Int,
+      maxChildren: Int,
+      batchSize: Int,
+      timeoutMinutes: Int,
       trials: Int,
       orderSeed: Long,
       trial: Int,
@@ -81,8 +88,19 @@ trait LinkerBenchmarkModule extends Module {
     val startedPath      = os.Path(started, workspace)
     val selectedPlatform = parsePlatform(platform)
     val selectedStrategy = parseStrategy(strategy)
-    val selectedProfile  = parseProfile(profile)
-    val settings         = LinkerBenchmark
+    val selectedProfile  = LinkerBenchmark
+      .reconstructWorkerProfile(
+        parseProfile(profile),
+        memoryGib,
+        reserveGib,
+        heapGib,
+        millJobs,
+        maxChildren,
+        batchSize,
+        timeoutMinutes
+      )
+      .fold(message => throw new Exception(message), identity)
+    val settings = LinkerBenchmark
       .validate(EvaluationSettings(trials, orderSeed))
       .fold(message => throw new Exception(message), identity)
     val selectedTargets = targets.split(',').iterator.map(_.trim).filter(_.nonEmpty).toSeq.distinct.sorted

--- a/ci/LinkerBenchmark.mill
+++ b/ci/LinkerBenchmark.mill
@@ -1,0 +1,231 @@
+package build.ci
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{AtomicMoveNotSupportedException, Files, StandardCopyOption}
+
+import scala.util.control.NonFatal
+
+import mill.*
+import mill.api.{BuildCtx, Evaluator, Result, SelectMode}
+import millbuild.LinkerBenchmark
+import millbuild.LinkerBenchmark.*
+import upickle.default.write
+
+trait LinkerBenchmarkModule extends Module {
+  private val RequestedHeapBytes = 1024L * 1024L * 1024L
+  private val OneGiBLow          = 768L * 1024L * 1024L
+  private val OneGiBHigh         = 1280L * 1024L * 1024L
+  private val OutputIdentityEnv  = "MORPHIR_LINKER_BENCHMARK_OUTPUT_IDENTITY"
+
+  def linkerBenchmarkWorkerSmoke(marker: String) = Task.Command(exclusive = true) {
+    BuildCtx.withFilesystemCheckerDisabled {
+      val workspace      = BuildCtx.workspaceRoot
+      val markerPath     = os.Path(marker, workspace)
+      val effectiveHeap  = Runtime.getRuntime.maxMemory()
+      val outputIdentity = sys.env.getOrElse(
+        OutputIdentityEnv,
+        throw new Exception("linker benchmark smoke child output identity is missing")
+      )
+      val childPid      = ProcessHandle.current().pid()
+      val proofFilename = s"worker-proof-$childPid.json"
+      val record        = SmokeRecord(
+        childPid = childPid,
+        javaVersion = System.getProperty("java.version", "unknown"),
+        pinnedMillVersion = os.read(workspace / ".mill-version").trim,
+        requestedHeapBytes = RequestedHeapBytes,
+        effectiveMaxHeapBytes = effectiveHeap,
+        requestedHeapHonored = effectiveHeap >= OneGiBLow && effectiveHeap <= OneGiBHigh,
+        outputDirectoryIdentity = outputIdentity,
+        proofFilename = proofFilename
+      )
+      writeAtomically(markerPath, write(record))
+      writeAtomically(Task.dest / proofFilename, write(SmokeProof(childPid, outputIdentity)))
+    }
+  }
+
+  def linkerBenchmarkInventory(
+      evaluator: Evaluator,
+      record: String,
+      platforms: String = "js,wasm,native"
+  ) = Task.Command(exclusive = true) {
+    val requested   = parsePlatforms(platforms)
+    val inventories = requested.map { platform =>
+      val targets = resolveTargets(evaluator, platform.selector)
+      if targets.isEmpty then throw new Exception(s"${platform.token}: no linker targets resolved")
+      PlatformInventory(platform, targets)
+    }
+    writeAtomically(
+      os.Path(record, BuildCtx.workspaceRoot),
+      write(InventoryRecord(Runtime.getRuntime.maxMemory(), inventories))
+    )
+  }
+
+  def linkerBenchmarkWorker(
+      evaluator: Evaluator,
+      record: String,
+      started: String,
+      runId: String,
+      platform: String,
+      strategy: String,
+      profile: String,
+      trials: Int,
+      orderSeed: Long,
+      trial: Int,
+      strategyPosition: Int,
+      lane: Int,
+      batch: Int,
+      targets: String
+  ) = Task.Command(exclusive = true) {
+    val workspace        = BuildCtx.workspaceRoot
+    val recordPath       = os.Path(record, workspace)
+    val startedPath      = os.Path(started, workspace)
+    val selectedPlatform = parsePlatform(platform)
+    val selectedStrategy = parseStrategy(strategy)
+    val selectedProfile  = parseProfile(profile)
+    val settings         = LinkerBenchmark
+      .validate(EvaluationSettings(trials, orderSeed))
+      .fold(message => throw new Exception(message), identity)
+    val selectedTargets = targets.split(',').iterator.map(_.trim).filter(_.nonEmpty).toSeq.distinct.sorted
+    if selectedTargets.isEmpty then throw new Exception("linker benchmark worker targets must not be empty")
+    writeAtomically(startedPath, ProcessHandle.current().pid().toString)
+    val inventory = resolveTargets(evaluator, selectedPlatform.selector).toSet
+    val foreign   = selectedTargets.filterNot(inventory)
+    if foreign.nonEmpty then
+      throw new Exception(s"targets do not belong to ${selectedPlatform.token}: ${foreign.mkString(",")}")
+
+    val phases  = Seq.newBuilder[PhaseMetrics]
+    var outcome = Outcome.Succeeded
+    var detail  = Option.empty[String]
+    try {
+      phases += evaluatePhase(evaluator, selectedTargets, "cold-link")
+      phases += evaluatePhase(evaluator, selectedTargets, "warm-worker-relink")
+    } catch {
+      case NonFatal(error) =>
+        outcome = Outcome.Failed
+        detail = Some(LinkerBenchmark.redact(Option(error.getMessage).getOrElse(error.getClass.getSimpleName)))
+    }
+    val workerRecord = WorkerRecord(
+      runId = runId,
+      trial = trial,
+      strategyPosition = strategyPosition,
+      settings = settings,
+      platform = selectedPlatform,
+      strategy = selectedStrategy,
+      profile = selectedProfile,
+      lane = lane,
+      batch = batch,
+      targets = selectedTargets,
+      startupMillis = 0L,
+      peakRssKiB = 0L,
+      phases = phases.result(),
+      outcome = outcome,
+      detail = detail,
+      runtime = RuntimeMetadata(
+        javaVersion = System.getProperty("java.version", "unknown"),
+        pinnedMillVersion = os.read(workspace / ".mill-version").trim,
+        operatingSystem = System.getProperty("os.name", "unknown"),
+        architecture = System.getProperty("os.arch", "unknown"),
+        availableProcessors = Runtime.getRuntime.availableProcessors(),
+        effectiveMaxHeapBytes = Runtime.getRuntime.maxMemory(),
+        outputDirectoryIdentity = sys.env.getOrElse(
+          OutputIdentityEnv,
+          throw new Exception("linker benchmark worker output identity is missing")
+        )
+      )
+    )
+    writeAtomically(recordPath, write(workerRecord))
+    if outcome != Outcome.Succeeded then throw new Exception(detail.getOrElse("linker benchmark worker failed"))
+  }
+
+  def linkerBenchmarkPrepare(evaluator: Evaluator, platform: String, targets: String) =
+    Task.Command(exclusive = true) {
+      val selectedPlatform = parsePlatform(platform)
+      val selectedTargets  = targets.split(',').iterator.map(_.trim).filter(_.nonEmpty).toSeq.distinct.sorted
+      if selectedTargets.isEmpty then throw new Exception("linker benchmark preparation targets must not be empty")
+      val inventory = resolveTargets(evaluator, selectedPlatform.selector).toSet
+      val foreign   = selectedTargets.filterNot(inventory)
+      if foreign.nonEmpty then
+        throw new Exception(s"targets do not belong to ${selectedPlatform.token}: ${foreign.mkString(",")}")
+      val prepared = unwrap(evaluator.evaluate(selectedTargets, SelectMode.Multi), "linker benchmark preparation")
+      prepared.values.toEither.fold(
+        message => throw new Exception(s"linker benchmark preparation failed: $message"),
+        _ => ()
+      )
+      unwrap(
+        evaluator.evaluate(Seq("clean") ++ selectedTargets, SelectMode.Separated),
+        "clean linker benchmark preparation"
+      ).values.toEither.fold(
+        message => throw new Exception(s"clean linker benchmark preparation failed: $message"),
+        _ => ()
+      )
+    }
+
+  private def evaluatePhase(evaluator: Evaluator, targets: Seq[String], name: String): PhaseMetrics = {
+    unwrap(evaluator.evaluate(Seq("clean") ++ targets, SelectMode.Separated), s"clean $name").values.toEither.fold(
+      message => throw new Exception(s"clean $name failed: $message"),
+      _ => ()
+    )
+    JvmSnapshot.resetPeakUsage()
+    val before    = JvmSnapshot.capture()
+    val startedAt = System.nanoTime()
+    val evaluated = unwrap(evaluator.evaluate(targets, SelectMode.Multi), name)
+    evaluated.values.toEither.fold(message => throw new Exception(s"$name failed: $message"), _ => ())
+    val wallMillis = math.max(0L, (System.nanoTime() - startedAt) / 1000000L)
+    val after      = JvmSnapshot.capture()
+    val uncached   = evaluated.executionResults.uncached.size.toLong
+    val cached     = math.max(0L, evaluated.executionResults.transitiveResults.size.toLong - uncached)
+    JvmSnapshot.phaseDelta(name, wallMillis, before, after, uncached, cached)
+  }
+
+  private def parsePlatforms(value: String): Seq[Platform] = {
+    val parsed = value.split(',').iterator.map(_.trim).filter(_.nonEmpty).map(parsePlatform).toSeq.distinct
+    if parsed.isEmpty then throw new Exception("requested linker platform inventory must not be empty") else parsed
+  }
+
+  private def parsePlatform(value: String): Platform = value match {
+    case "js" | "scala-js" => Platform.ScalaJs
+    case "wasm"            => Platform.Wasm
+    case "native"          => Platform.Native
+    case other             => throw new Exception(s"unknown linker platform: $other")
+  }
+
+  private def parseStrategy(value: String): Strategy =
+    Strategy.values.find(_.token == value).getOrElse(throw new Exception(s"unknown linker strategy: $value"))
+
+  private def parseProfile(value: String): Profile = value match {
+    case "ci"    => LinkerBenchmark.ciProfile
+    case "local" => LinkerBenchmark.detectedLocalProfile().fold(message => throw new Exception(message), identity)
+    case other   => throw new Exception(s"unknown linker benchmark profile: $other")
+  }
+
+  private def resolveTargets(evaluator: Evaluator, selector: String): Seq[String] =
+    unwrap(
+      evaluator.resolveSegments(Seq(selector), SelectMode.Multi),
+      s"resolve $selector"
+    ).map(_.render).distinct.sorted
+
+  private def unwrap[A](result: Result[A], what: String): A =
+    result.toEither.fold(message => throw new Exception(s"$what failed: $message"), identity)
+
+  private def writeAtomically(marker: os.Path, value: String): Unit = {
+    val parent = marker.toNIO.getParent
+    Files.createDirectories(parent)
+    val temporary = parent.resolve(s".${marker.last}.tmp-${ProcessHandle.current().pid()}")
+    try
+      Files.writeString(temporary, value, StandardCharsets.UTF_8)
+      Files.move(
+        temporary,
+        marker.toNIO,
+        StandardCopyOption.ATOMIC_MOVE,
+        StandardCopyOption.REPLACE_EXISTING
+      )
+    catch {
+      case error: AtomicMoveNotSupportedException =>
+        Files.deleteIfExists(temporary)
+        throw new Exception(s"atomic move is not supported for linker benchmark smoke output: ${marker.last}", error)
+      case NonFatal(error) =>
+        Files.deleteIfExists(temporary)
+        throw error
+    }
+  }
+}

--- a/ci/MorphirCi.mill
+++ b/ci/MorphirCi.mill
@@ -6,7 +6,7 @@ import build.{morphir => morphirArea}
 import build.morphir.{desktop => desktopArea}
 import mill.*
 import mill.api.{BuildCtx, DefaultTaskModule, Evaluator, ModuleRef, Result, SelectMode, TaskCtx}
-import millbuild.{JsTestSelectors, LintSelectors, MillVersions}
+import millbuild.{JsTestSelectors, LintSelectors, MillVersions, NativeTestSelectors}
 import org.finos.morphir.mill.publish.{MillPublishEnvFile, MillSonatypeEnv, PgpSecret, PublishSelectors}
 import org.finos.morphir.mill.publish.desktop.{
   DesktopPlatform,
@@ -45,7 +45,7 @@ object ReleaseAreaRow {
  * `./mill -i ci.publish` so `Task.env` sees `MILL_*`. Conversion lives in mill-morphir-core
  * (`org.finos.morphir.mill.publish`).
  */
-trait MorphirCiModule extends Module {
+trait MorphirCiModule extends Module, LinkerBenchmarkModule {
 
   /** Module-path prefix for library Sonatype publishables. Set in `package.mill.yaml`. */
   def libraryModulePrefix = Task { "" }
@@ -443,6 +443,42 @@ trait MorphirCiModule extends Module {
     }
   }
 
+  /** Runs the curated non-classic JVM platform inventory through the CI command surface. */
+  def testJvm(evaluator: Evaluator) = Task.Command(exclusive = true) {
+    Task.log.info("ci.testJvm: evaluating the non-classic JVM platform inventory")
+    evaluateAll(
+      evaluator,
+      Seq("Alias/run", "testJVMPlatform"),
+      "ci.testJvm",
+      selectMode = SelectMode.Separated
+    )
+  }
+
+  /** Compiles the Scala Native modules and builds their publish artifacts before process-sharded tests run. */
+  def testNativePrepare(evaluator: Evaluator) = Task.Command(exclusive = true) {
+    val resolved = resolveTargets(evaluator, NativeTestSelectors.prepareSelectors)
+    Task.log.info(s"ci.testNativePrepare: evaluating ${resolved.size} targets")
+    evaluateAll(evaluator, resolved, "ci.testNativePrepare")
+  }
+
+  /**
+   * Runs one deterministic Scala Native test shard.
+   *
+   * The shard is deliberately only one command invocation. `.config/mise/tasks/test/native` starts each shard in a
+   * fresh daemonless Mill JVM, which releases the in-process Scala Native linker worker and its retained heap between
+   * shards. Evaluating all shards from this command would keep that worker alive and recreate the OOM this split
+   * avoids.
+   */
+  def testNative(evaluator: Evaluator, shard: Int = 0, shards: Int = 1) = Task.Command(exclusive = true) {
+    val resolved = resolveTargets(evaluator, Seq(NativeTestSelectors.testSelector))
+    val selected = NativeTestSelectors.selectShard(resolved, shard, shards, "ci.testNative") match {
+      case Right(targets) => targets
+      case Left(message)  => throw new Exception(message)
+    }
+    Task.log.info(s"ci.testNative: evaluating ${selected.size} targets (shard=$shard, shards=$shards)")
+    evaluateAll(evaluator, selected, s"ci.testNative (shard=$shard, shards=$shards)")
+  }
+
   /**
    * The "Run JS tests" phase of the `test-js` / `test-js-desktop` CI jobs — compile, publish, and both JS and Wasm test
    * runs — scoped to `group` (`"platform"` or `"desktop"`).
@@ -473,16 +509,19 @@ trait MorphirCiModule extends Module {
       group: String,
       what: String
   )(using TaskCtx): Unit = {
-    val resolved = selectors.flatMap { selector =>
-      unwrap(evaluator.resolveSegments(Seq(selector), SelectMode.Multi), s"resolve $selector").map(_.render)
-    }
-    val kept = JsTestSelectors.selectGroup(resolved, group, what) match {
+    val resolved = resolveTargets(evaluator, selectors)
+    val kept     = JsTestSelectors.selectGroup(resolved, group, what) match {
       case Right(selected) => selected
       case Left(message)   => throw new Exception(message)
     }
     Task.log.info(s"$what: evaluating ${kept.size} targets (group=$group)")
     evaluateAll(evaluator, kept, s"$what (group=$group)")
   }
+
+  private def resolveTargets(evaluator: Evaluator, selectors: Seq[String]): Seq[String] =
+    selectors.flatMap { selector =>
+      unwrap(evaluator.resolveSegments(Seq(selector), SelectMode.Multi), s"resolve $selector").map(_.render)
+    }
 
   /**
    * Cross-destination aggregator. CI calls `ci.publish`. Today that is Sonatype only; the desktop destination is

--- a/kb/bundles/morphir/morphir-scala/continuous-integration.md
+++ b/kb/bundles/morphir/morphir-scala/continuous-integration.md
@@ -116,9 +116,11 @@ cancellation. It explicitly includes hidden `.dev` files and retains the artifac
 Markdown redact workspace paths. Raw logs may contain the checkout path. The artifact name safely encodes the
 preset, ref, run id, and run attempt.
 
-The rollout has two stages. First, the profiler lands while production test grouping stays unchanged. After that
-workflow reaches the default branch, `quick-smoke` runs on a hosted runner, followed by the more expensive presets.
-No complete hosted result exists yet.
+This change keeps each platform's resolved test inventory intact. It does change Native execution from batches of
+five to four deterministic shards, with each shard running in a fresh daemonless Mill JVM. Scala.js and Wasm keep
+their existing production grouping. Long-lived and recycled workers remain profiler-only strategies; CI will not
+adopt either one until hosted evidence passes the gates below. After the profiler reaches the default branch,
+`quick-smoke` runs on a hosted runner, followed by the more expensive presets. No complete hosted result exists yet.
 
 ### Local evidence and adoption gates
 

--- a/kb/bundles/morphir/morphir-scala/continuous-integration.md
+++ b/kb/bundles/morphir/morphir-scala/continuous-integration.md
@@ -76,7 +76,7 @@ The five presets fix the initial comparison matrix:
 | Mill jobs | 2 | Positive, at most 64 | Number-typed zero inherits |
 | Active children | 1 | Positive, at most 16; must pass resource admission | Number-typed zero inherits |
 | Recycled batch size | 4 | Positive, at most 256 | Number-typed zero inherits |
-| Timeout | 30 minutes, except 40 for `native-long-lived` | Positive, at most 360 minutes | Number-typed zero inherits |
+| Timeout | 30 minutes, except 40 for `native-long-lived` | Positive, at most 330 minutes | Number-typed zero inherits |
 | Continue after failure | `true` | Choice of `preset`, `true`, or `false` | `preset` inherits |
 
 Resource admission requires the rounded-up observed heap multiplied by active children, plus reserve, to fit within
@@ -84,7 +84,8 @@ the memory budget. Malformed or unknown settings and failed admission stop the r
 use the fixed CI profile and expose no profile override. They also expose no heap override and use the fixed 8 GiB
 heap from `.mill-jvm-opts`. The hosted runner budget is 16 GiB. An override may lower that budget or explicitly
 restate 16 GiB, but it cannot claim memory the runner does not have. The reserve cap follows at 15 GiB so it always
-leaves room for a positive admitted workload.
+leaves room for a positive admitted workload. The job has a 360-minute limit, so the 330-minute operation cap
+reserves 30 minutes for timeout cleanup, report writing, and artifact publication.
 
 The pinned Mill version, `1.2.0-RC1-46-16168f`, ignores the documented `MILL_JVM_OPTS_PATH`. `_JAVA_OPTIONS` is not
 a safe substitute because it also changes Java descendants. The hosted profile therefore keeps the heap at 8 GiB.

--- a/kb/bundles/morphir/morphir-scala/continuous-integration.md
+++ b/kb/bundles/morphir/morphir-scala/continuous-integration.md
@@ -18,10 +18,10 @@ branches.
 | `lint` | Mill `ci.lint`: scalafmt `checkFormatAll` over resolved `morphir.__.sources` tasks. `--exclude` drops matching module paths. |
 | `squire-policy` | `mise run test:squire`. Squire and release-policy gates. |
 | `knowledge-base` | `kb check` and `kb intent check` |
-| `test-jvm` | JVM tests, including the Cucumber/JUnit5 `langkit.itest` suite |
+| `test-jvm` | Mill `ci.testJvm`: the curated non-classic JVM platform inventory, including the Cucumber/JUnit5 `langkit.itest` suite. The generated-fixture-backed classic runtime remains in its separate jobs. |
 | `test-js` | ScalaJS tests, including the WebAssembly link variants, for every JS/Wasm module except the desktop/UI subset (see `test-js-desktop`) |
 | `test-js-desktop` | The same ScalaJS/WebAssembly workload as `test-js`, scoped to `morphir.ui`, `morphir.desktop` and `morphir.appkit.electron`. Split into its own runner because linking that subset alongside the rest of the JS tree in one Mill daemon exceeded the 8 GB heap in `.mill-jvm-opts`; `ci.testJs`/`ci.testJsWasmLink` (`ci/MorphirCi.mill`) resolve the shared wildcard once and partition it with `millbuild.JsTestSelectors`, so the two jobs' targets are exhaustive and disjoint by construction. |
-| `test-native` | Scala Native tests |
+| `test-native` | Mill `ci.testNativePrepare` followed by four `ci.testNative` shards. `millbuild.NativeTestSelectors` resolves and partitions every Native test target; the Mise launcher gives each shard a fresh daemonless Mill JVM. |
 | `publish` | Sonatype publication via Mill `ci.publish`. Branch snapshots on `main`; VCS milestones and releases on `0.4.x` and tags. The publish set is whatever Mill resolves for `__.publishSonatypeCentral`, including the Mill Morphir plugin family (`org.finos.morphir.mill`); the test-only `integration` module is not a publish module and is not uploaded. Destination tasks live under `ci.sonatype.*`. |
 | `desktop-package` | Matrix job, one runner per platform token (`mac-aarch64`, `mac-amd64`, `linux-amd64`, `linux-aarch64`, `win-amd64`). Links Scala.js with `fullLinkJS` and runs `electron-builder`, then uploads the raw output as a workflow artifact. Runs only when a GitHub Release publishes or the ref is a tag. |
 | `desktop-release` | One Linux runner. Canonicalizes the staged assets, signs `checksums.txt`, verifies, then uploads to the GitHub Release and to Sonatype Central as one bundle. Destination tasks live under `ci.desktop.*`. Same trigger scope as `desktop-package`, and needs it to finish first. |
@@ -35,6 +35,117 @@ CI runs on pull requests into `main` and `0.4.x`; pushes to those same branches;
 manual dispatch. Older runs of the same pull request are cancelled automatically. Hosted mill invocations pass
 `--ticker false`. That includes the workflow, the local `lint` mise wrapper, and `test:jvm-platform`. The GitHub
 log is then a linear task trace rather than a replayed progress ticker.
+
+The platform test inventories belong to Mill's `ci.*` command surface in `ci/MorphirCi.mill`. The hosted jobs and
+the local `test:jvm-platform`, `test:js` and `test:native` Mise tasks call the same commands; Mise only supplies the
+process boundaries that cannot be expressed inside one Mill evaluation. Scala.js, Wasm and Scala Native linkers are
+in-process Mill workers in the pinned Mill release, so JVM test forking does not isolate their heap. A direct
+`./mill __.test` still puts every matched linker in one build JVM and can exhaust it; the platform tasks and
+`mise run ci:local` split link-heavy groups across fresh daemonless invocations instead.
+
+## Manual linker profiling
+
+`.github/workflows/linker-benchmark.yml` is a read-only, `workflow_dispatch`-only profiler for comparing linker
+worker lifetimes on a hosted runner. It is separate from ordinary and required CI. GitHub offers the manual dispatch
+only after the workflow file exists on the default branch.
+
+The profiler compares three worker-lifetime strategies. A long-lived child handles all selected targets in one case
+and then exits. A fresh child handles one target and then exits. A recycled child handles up to the configured batch
+size sequentially and then exits.
+
+The five presets fix the initial comparison matrix:
+
+| Preset | Platforms | Strategies | Trials | Targets | Timeout |
+| --- | --- | --- | ---: | --- | ---: |
+| `quick-smoke` | Scala.js, Wasm, Native | long-lived, fresh, recycled | 1 | first sorted target per platform | 30 minutes |
+| `js-strategies` | Scala.js | long-lived, fresh, recycled | 3 | all | 30 minutes |
+| `wasm-strategies` | Wasm | long-lived, fresh, recycled | 3 | all | 30 minutes |
+| `native-long-lived` | Native | long-lived | 1 | all | 40 minutes |
+| `native-fresh-recycled` | Native | fresh, recycled | 3 | all | 30 minutes |
+
+| Setting | Preset/default | Hosted cap or validation | Inheritance |
+| --- | --- | --- | --- |
+| Platforms | Preset matrix | Nonempty, unique known platform tokens | Empty string inherits |
+| Strategies | Preset matrix | Nonempty, unique known strategy tokens | Empty string inherits |
+| Trials | 1 or 3 by preset | Positive, at most 100 | Number-typed zero inherits |
+| Order seed | 0 | Nonnegative; no hosted cap | Empty string inherits; explicit `0` sets zero |
+| Target filter | None | Substring match; rejects control characters and an empty target result | Empty string inherits |
+| Target limit | One for `quick-smoke`; otherwise all | Positive, at most 10,000; selection is sorted per platform | Number-typed zero inherits |
+| Memory budget | 16 GiB | Positive, at most 64 GiB; must pass resource admission | Number-typed zero inherits |
+| Reserve | 4 GiB | Positive override, at most 63 GiB and less than memory | Number-typed zero inherits |
+| Mill jobs | 2 | Positive, at most 64 | Number-typed zero inherits |
+| Active children | 1 | Positive, at most 16; must pass resource admission | Number-typed zero inherits |
+| Recycled batch size | 4 | Positive, at most 256 | Number-typed zero inherits |
+| Timeout | 30 minutes, except 40 for `native-long-lived` | Positive, at most 360 minutes | Number-typed zero inherits |
+| Continue after failure | `true` | Choice of `preset`, `true`, or `false` | `preset` inherits |
+
+Resource admission requires the rounded-up observed heap multiplied by active children, plus reserve, to fit within
+the memory budget. Malformed or unknown settings and failed admission stop the run before linker work. Hosted runs
+use the fixed CI profile and expose no profile override. They also expose no heap override and use the fixed 8 GiB
+heap from `.mill-jvm-opts`.
+
+The pinned Mill version, `1.2.0-RC1-46-16168f`, ignores the documented `MILL_JVM_OPTS_PATH`. `_JAVA_OPTIONS` is not
+a safe substitute because it also changes Java descendants. The hosted profile therefore keeps the heap at 8 GiB.
+Inventory records `Runtime.maxMemory`, verifies it within 256 MiB of that value, and rounds the observed heap up to
+whole GiB for admission. A lane is an isolated child-JVM workspace. Figure 1 shows the boundary between validation
+and measurement.
+
+```mermaid
+flowchart LR
+    A[Manual dispatch] -->|select preset and overrides| B[Resolve configuration]
+    B -->|validated settings| C[Inventory targets and verify heap]
+    C -->|admitted resources| D[Prepare lanes]
+    D -->|prepared targets| E[Measure linker strategies]
+    E -->|available files| F[Upload reports and logs]
+```
+
+**Figure 1:** A manual linker-profile run validates its configuration and observed heap before it starts preparation
+or measurement.
+
+Each run writes configuration and inventory as it reaches those early stages. Results, summaries, preparation
+records, process logs, and garbage collection (GC) logs appear only after their corresponding phases run. A worker
+record is the per-child JSON account of targets, timing, memory, runtime, and outcome. Worker records appear only
+after their child phase runs. Normal benchmark failure handling also retains timeout, teardown, and recovery evidence
+when it produces that evidence. The hosted workflow does not run the separate recovery-smoke mode, and an early
+failure may leave only partial artifacts.
+
+The workflow uploads the files that exist after ordinary success or failure and makes a best effort after
+cancellation. It explicitly includes hidden `.dev` files and retains the artifact for 14 days. Structured JSON and
+Markdown redact workspace paths. Raw logs may contain the checkout path. The artifact name safely encodes the
+preset, ref, run id, and run attempt.
+
+The rollout has two stages. First, the profiler lands while production test grouping stays unchanged. After that
+workflow reaches the default branch, `quick-smoke` runs on a hosted runner, followed by the more expensive presets.
+No complete hosted result exists yet.
+
+### Local evidence and adoption gates
+
+The complete local evaluation ran on a 36 GiB host with a 9 GiB reserve, an 8 GiB heap, two lanes, recycled batches
+of four, three trials, and seed zero. It found 45 targets and completed 24 of 27 strategy cases. Native long-lived
+preparation timed out in all three trials. Fresh and recycled completed all three trials on every platform, and
+Scala.js and Wasm long-lived completed all three. All 177 measured worker records succeeded. Peak aggregate RSS for
+the whole run, the combined resident set size (RSS) of live process trees, was 15,322,800 KiB.
+
+Median fresh and recycled measurements differ by platform:
+
+| Platform | Fresh median | Recycled median | Local interpretation |
+| --- | ---: | ---: | --- |
+| Native | 352,866 ms | 257,860 ms | Recycled is about 27% faster, with higher memory and GC use. |
+| Scala.js | 120,220 ms | 74,504 ms | Recycled is about 38% faster, with roughly twice the RSS. |
+| Wasm | 22,219 ms | 8,698 ms | Recycled is faster; long-lived is 7,238 ms and reliable locally. |
+
+A focused local workflow acceptance on 2026-08-24 resolved all five presets in plan-only mode exactly as specified.
+Its `quick-smoke` run completed all 9 cases, one target per platform under all three strategies, in 551.77 seconds
+and observed the 8 GiB heap. This validates local wiring only. It does not establish hosted policy.
+
+A production candidate must complete all three hosted trials, keep peak aggregate RSS below the 12 GiB budget left
+after reserve, avoid out-of-memory failures, remain reliable, and avoid an unacceptable wall-time or cache
+regression. A recycled candidate must also improve reliability over long-lived workers. Every failure and timeout
+remains in the evidence. Three trials support medians and ranges, not confidence intervals. The candidates are
+recycled with batches of four for Scala.js, recycled with batches of four for Native with fresh as fallback, and
+long-lived for Wasm. If recycled proves unsafe, that platform returns to fresh grouping without removing the
+profiler. Any production change starts with one platform and remains under observation before the policy expands.
+Recycled workers are candidates, not current production policy.
 
 The Release step runs `ci.sonatype.writeMillEnv` first, with Morphir `GPG_*` and `SONATYPE_*` names in that mill.
 It sources the written file and then starts `./mill --ticker false -i ci.publish`. Mill snapshots `Task.env` at process start, so
@@ -75,7 +186,10 @@ warning that fails the build is a warning people route around.
 ```bash
 mise run kb:check
 mise run test:squire
+mise run test:jvm-platform
+mise run test:js
+mise run test:native
 ```
 
-These run the knowledge-base checks and the Squire/release-policy tests with the same exit codes used by CI.
-`mise run ci:local` includes `test:squire` in the full local aggregate workflow.
+These run the knowledge-base checks, policy tests and platform tests through the same entry points used by CI.
+`mise run ci:local` includes them in the full local aggregate workflow.

--- a/kb/bundles/morphir/morphir-scala/continuous-integration.md
+++ b/kb/bundles/morphir/morphir-scala/continuous-integration.md
@@ -71,8 +71,8 @@ The five presets fix the initial comparison matrix:
 | Order seed | 0 | Nonnegative; no hosted cap | Empty string inherits; explicit `0` sets zero |
 | Target filter | None | Substring match; rejects control characters and an empty target result | Empty string inherits |
 | Target limit | One for `quick-smoke`; otherwise all | Positive, at most 10,000; selection is sorted per platform | Number-typed zero inherits |
-| Memory budget | 16 GiB | Positive, at most 64 GiB; must pass resource admission | Number-typed zero inherits |
-| Reserve | 4 GiB | Positive override, at most 63 GiB and less than memory | Number-typed zero inherits |
+| Memory budget | 16 GiB | Positive, at most 16 GiB; must pass resource admission | Number-typed zero inherits |
+| Reserve | 4 GiB | Positive override, at most 15 GiB and less than memory | Number-typed zero inherits |
 | Mill jobs | 2 | Positive, at most 64 | Number-typed zero inherits |
 | Active children | 1 | Positive, at most 16; must pass resource admission | Number-typed zero inherits |
 | Recycled batch size | 4 | Positive, at most 256 | Number-typed zero inherits |
@@ -82,7 +82,9 @@ The five presets fix the initial comparison matrix:
 Resource admission requires the rounded-up observed heap multiplied by active children, plus reserve, to fit within
 the memory budget. Malformed or unknown settings and failed admission stop the run before linker work. Hosted runs
 use the fixed CI profile and expose no profile override. They also expose no heap override and use the fixed 8 GiB
-heap from `.mill-jvm-opts`.
+heap from `.mill-jvm-opts`. The hosted runner budget is 16 GiB. An override may lower that budget or explicitly
+restate 16 GiB, but it cannot claim memory the runner does not have. The reserve cap follows at 15 GiB so it always
+leaves room for a positive admitted workload.
 
 The pinned Mill version, `1.2.0-RC1-46-16168f`, ignores the documented `MILL_JVM_OPTS_PATH`. `_JAVA_OPTIONS` is not
 a safe substitute because it also changes Java descendants. The hosted profile therefore keeps the heap at 8 GiB.

--- a/kb/bundles/morphir/morphir-scala/log.md
+++ b/kb/bundles/morphir/morphir-scala/log.md
@@ -3,8 +3,9 @@
 ## 2026-08-24
 
 * **Update**: [Continuous Integration](/continuous-integration.md) now documents the configurable manual hosted
-  linker profiler. Production grouping stays unchanged pending hosted artifacts, and the local `quick-smoke`
-  acceptance passed all nine cases.
+  linker profiler. The same Native test inventory now runs as four deterministic fresh-JVM shards instead of
+  batches of five. Long-lived and recycled workers remain profiler-only pending hosted evidence. The local
+  `quick-smoke` acceptance passed all nine cases.
 
 ## 2026-08-23
 

--- a/kb/bundles/morphir/morphir-scala/log.md
+++ b/kb/bundles/morphir/morphir-scala/log.md
@@ -1,5 +1,17 @@
 # Log
 
+## 2026-08-24
+
+* **Update**: [Continuous Integration](/continuous-integration.md) now documents the configurable manual hosted
+  linker profiler. Production grouping stays unchanged pending hosted artifacts, and the local `quick-smoke`
+  acceptance passed all nine cases.
+
+## 2026-08-23
+
+* **Update**: [Continuous Integration](/continuous-integration.md) now records that hosted and local platform tests
+  enter through Mill `ci.*` commands, while Mise supplies fresh process boundaries for retained Scala.js, Wasm and
+  Scala Native linker workers. A direct `./mill __.test` remains a single build JVM and is not an isolation boundary.
+
 ## 2026-08-21
 
 * **Creation**: Added [GitHub connection settings and local web host](/design/github-connection-settings-and-local-web-host.md), covering the shared connection contract, loopback server, Electron host, optional persistence, UI states, and required security audit.

--- a/mill-build/src/millbuild/LinkerBenchmark.scala
+++ b/mill-build/src/millbuild/LinkerBenchmark.scala
@@ -1,0 +1,1563 @@
+package millbuild
+
+import java.lang.management.ManagementFactory
+import java.lang.management.MemoryType
+import java.nio.charset.StandardCharsets
+import java.nio.file.{AtomicMoveNotSupportedException, Files, LinkOption, Path, StandardCopyOption}
+import java.security.MessageDigest
+import java.util.Locale
+import java.util.concurrent.{Callable, ExecutionException, ExecutorCompletionService, Executors, TimeUnit}
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+import scala.util.control.NonFatal
+import scala.util.matching.Regex
+
+import upickle.default.{ReadWriter, write}
+
+object LinkerBenchmark {
+  enum Platform(val token: String, val selector: String) derives ReadWriter {
+    case ScalaJs extends Platform("scala-js", "morphir.__.js.__.fastLinkJSTest")
+    case Wasm    extends Platform("wasm", "morphir.__.wasm.fullLinkJS")
+    case Native  extends Platform("native", "morphir.__.native.__.test.nativeLink")
+  }
+
+  enum Strategy(val token: String) derives ReadWriter {
+    case LongLived extends Strategy("long-lived")
+    case Fresh     extends Strategy("fresh")
+    case Recycled  extends Strategy("recycled")
+  }
+
+  enum Outcome derives ReadWriter {
+    case Succeeded, Failed, TimedOut, Cancelled
+  }
+
+  final case class PhaseMetrics(
+      name: String,
+      wallMillis: Long,
+      heapUsedBytes: Long,
+      peakHeapBytes: Long,
+      gcCount: Long,
+      gcMillis: Long,
+      evaluated: Long,
+      cached: Long
+  ) derives ReadWriter
+
+  final case class JvmSnapshot(heapUsedBytes: Long, peakHeapBytes: Long, gcCount: Long, gcMillis: Long)
+
+  object JvmSnapshot {
+    private def heapPools = ManagementFactory.getMemoryPoolMXBeans.asScala.filter(_.getType == MemoryType.HEAP)
+
+    def sumNonnegative(values: IterableOnce[Long]): Long = {
+      val iterator                         = values.iterator
+      @tailrec def loop(total: Long): Long =
+        if !iterator.hasNext then total
+        else {
+          val value = iterator.next()
+          if value < 0L then loop(total)
+          else if total > Long.MaxValue - value then Long.MaxValue
+          else loop(total + value)
+        }
+      loop(0L)
+    }
+
+    def resetPeakUsage(): Unit = heapPools.foreach(_.resetPeakUsage())
+
+    def capture(): JvmSnapshot = {
+      val peakHeapBytes = sumNonnegative(heapPools.iterator.flatMap(pool => Option(pool.getPeakUsage)).map(_.getUsed))
+      val garbageCollectors = ManagementFactory.getGarbageCollectorMXBeans.asScala
+      JvmSnapshot(
+        heapUsedBytes = math.max(0L, ManagementFactory.getMemoryMXBean.getHeapMemoryUsage.getUsed),
+        peakHeapBytes = peakHeapBytes,
+        gcCount = sumNonnegative(garbageCollectors.iterator.map(_.getCollectionCount)),
+        gcMillis = sumNonnegative(garbageCollectors.iterator.map(_.getCollectionTime))
+      )
+    }
+
+    def phaseDelta(
+        name: String,
+        wallMillis: Long,
+        before: JvmSnapshot,
+        after: JvmSnapshot,
+        evaluated: Long,
+        cached: Long
+    ): PhaseMetrics =
+      PhaseMetrics(
+        name = name,
+        wallMillis = wallMillis,
+        heapUsedBytes = after.heapUsedBytes,
+        peakHeapBytes = after.peakHeapBytes,
+        gcCount = math.max(0L, after.gcCount - before.gcCount),
+        gcMillis = math.max(0L, after.gcMillis - before.gcMillis),
+        evaluated = evaluated,
+        cached = cached
+      )
+  }
+
+  final case class Profile(
+      name: String,
+      memoryGiB: Int,
+      reserveGiB: Int,
+      heapGiB: Int,
+      millJobs: Int,
+      maxChildren: Int,
+      batchSize: Int,
+      timeoutMinutes: Int
+  ) derives ReadWriter
+
+  val ciProfile: Profile = Profile("ci", 16, 4, 8, 2, 1, 4, 30)
+
+  def localProfile(memoryGiB: Int, availableProcessors: Int): Either[String, Profile] =
+    if memoryGiB <= 0 then Left("local memory budget must be greater than zero")
+    else if availableProcessors <= 0 then Left("local available processors must be greater than zero")
+    else {
+      val reserveGiB       = math.max(4, memoryGiB / 4)
+      val admittedByMemory = (memoryGiB - reserveGiB) / ciProfile.heapGiB
+      if admittedByMemory <= 0 then Left("local memory budget cannot admit one child heap and the safety reserve")
+      else {
+        val maxChildren = math.min(2, math.min(availableProcessors, admittedByMemory))
+        validate(
+          Profile(
+            name = "local",
+            memoryGiB = memoryGiB,
+            reserveGiB = reserveGiB,
+            heapGiB = ciProfile.heapGiB,
+            millJobs = maxChildren,
+            maxChildren = maxChildren,
+            batchSize = ciProfile.batchSize,
+            timeoutMinutes = ciProfile.timeoutMinutes
+          )
+        )
+      }
+    }
+
+  def detectedLocalProfile(): Either[String, Profile] = {
+    val totalBytes = ManagementFactory.getOperatingSystemMXBean match {
+      case operatingSystem: com.sun.management.OperatingSystemMXBean => operatingSystem.getTotalMemorySize
+      case _ => ciProfile.memoryGiB.toLong * 1024L * 1024L * 1024L
+    }
+    val memoryGiB = math.max(1L, totalBytes / (1024L * 1024L * 1024L)).min(Int.MaxValue.toLong).toInt
+    localProfile(memoryGiB, Runtime.getRuntime.availableProcessors())
+  }
+
+  final case class Batch(lane: Int, index: Int, targets: Seq[String]) derives ReadWriter
+
+  final case class WorkPlan(lanes: Int, batches: Seq[Batch]) derives ReadWriter
+
+  final case class PreparationLane(lane: Int, batches: Seq[Batch])
+
+  final case class PlatformInventory(platform: Platform, targets: Seq[String]) derives ReadWriter
+
+  final case class InventoryRecord(effectiveMaxHeapBytes: Long, inventories: Seq[PlatformInventory]) derives ReadWriter
+
+  final case class EvaluationSettings(trials: Int, orderSeed: Long) derives ReadWriter
+
+  final case class ResolvedBenchmarkConfiguration(
+      preset: String,
+      profile: Profile,
+      settings: EvaluationSettings,
+      platforms: Seq[Platform],
+      strategies: Seq[Strategy],
+      targetFilter: Option[String],
+      targetLimit: Option[Int],
+      continueOnFailure: Boolean
+  ) derives ReadWriter
+
+  final case class BenchmarkOverrides(
+      platforms: Option[String] = None,
+      strategies: Option[String] = None,
+      trials: Option[Int] = None,
+      orderSeed: Option[Long] = None,
+      targetFilter: Option[String] = None,
+      targetLimit: Option[Int] = None,
+      memoryGiB: Option[Int] = None,
+      reserveGiB: Option[Int] = None,
+      millJobs: Option[Int] = None,
+      maxChildren: Option[Int] = None,
+      batchSize: Option[Int] = None,
+      timeoutMinutes: Option[Int] = None,
+      continueOnFailure: Option[Boolean] = None
+  ) derives ReadWriter
+
+  private val hostedPresets: Map[String, ResolvedBenchmarkConfiguration] = Seq(
+    ResolvedBenchmarkConfiguration(
+      preset = "quick-smoke",
+      profile = ciProfile,
+      settings = EvaluationSettings(1, 0L),
+      platforms = Platform.values.toSeq,
+      strategies = Strategy.values.toSeq,
+      targetFilter = None,
+      targetLimit = Some(1),
+      continueOnFailure = true
+    ),
+    ResolvedBenchmarkConfiguration(
+      preset = "js-strategies",
+      profile = ciProfile,
+      settings = EvaluationSettings(3, 0L),
+      platforms = Seq(Platform.ScalaJs),
+      strategies = Strategy.values.toSeq,
+      targetFilter = None,
+      targetLimit = None,
+      continueOnFailure = true
+    ),
+    ResolvedBenchmarkConfiguration(
+      preset = "wasm-strategies",
+      profile = ciProfile,
+      settings = EvaluationSettings(3, 0L),
+      platforms = Seq(Platform.Wasm),
+      strategies = Strategy.values.toSeq,
+      targetFilter = None,
+      targetLimit = None,
+      continueOnFailure = true
+    ),
+    ResolvedBenchmarkConfiguration(
+      preset = "native-long-lived",
+      profile = ciProfile.copy(timeoutMinutes = 40),
+      settings = EvaluationSettings(1, 0L),
+      platforms = Seq(Platform.Native),
+      strategies = Seq(Strategy.LongLived),
+      targetFilter = None,
+      targetLimit = None,
+      continueOnFailure = true
+    ),
+    ResolvedBenchmarkConfiguration(
+      preset = "native-fresh-recycled",
+      profile = ciProfile,
+      settings = EvaluationSettings(3, 0L),
+      platforms = Seq(Platform.Native),
+      strategies = Seq(Strategy.Fresh, Strategy.Recycled),
+      targetFilter = None,
+      targetLimit = None,
+      continueOnFailure = true
+    )
+  ).map(configuration => configuration.preset -> configuration).toMap
+
+  /**
+   * Bounds manual hosted dispatches to an ubuntu-latest-sized machine and GitHub's six-hour job envelope while leaving
+   * enough range for diagnostic repetitions. Profile admission applies the stricter cross-field memory constraint after
+   * these individual limits.
+   */
+  val maxHostedTrials: Int         = 100
+  val maxHostedMemoryGiB: Int      = 64
+  val maxHostedReserveGiB: Int     = 63
+  val maxHostedMillJobs: Int       = 64
+  val maxHostedChildren: Int       = 16
+  val maxHostedBatchSize: Int      = 256
+  val maxHostedTimeoutMinutes: Int = 360
+  val maxHostedTargetLimit: Int    = 10_000
+
+  def parseOptionalTrimmedString(value: String, field: String): Either[String, Option[String]] =
+    if value.exists(Character.isISOControl) then Left(s"$field contains invalid characters")
+    else Right(Option.when(value.trim.nonEmpty)(value.trim))
+
+  private def parseInt(value: String, field: String): Either[String, Int] =
+    parseOptionalTrimmedString(value, field).flatMap {
+      case Some(token) => token.toIntOption.toRight(s"$field must be a whole number")
+      case None        => Left(s"$field must be a whole number")
+    }
+
+  def parseZeroAsUnsetPositiveInt(value: String, field: String): Either[String, Option[Int]] =
+    parseInt(value, field).flatMap(parsed =>
+      if parsed < 0 then Left(s"$field must be nonnegative")
+      else Right(Option.when(parsed > 0)(parsed))
+    )
+
+  def parsePositiveInt(value: String, field: String): Either[String, Int] =
+    parseInt(value, field).flatMap(parsed => Either.cond(parsed > 0, parsed, s"$field must be greater than zero"))
+
+  /** Boolean CLI tokens are trimmed and compared case-insensitively using the root locale. */
+  def parseBoolean(value: String, field: String): Either[String, Boolean] =
+    parseOptionalTrimmedString(value, field).flatMap {
+      case Some(token) =>
+        token.toLowerCase(Locale.ROOT) match {
+          case "true"  => Right(true)
+          case "false" => Right(false)
+          case _       => Left(s"$field must be true or false")
+        }
+      case None => Left(s"$field must be true or false")
+    }
+
+  def parseOptionalLong(value: String, field: String): Either[String, Option[Long]] =
+    parseOptionalTrimmedString(value, field).flatMap {
+      case None        => Right(None)
+      case Some(token) => token.toLongOption.map(Some(_)).toRight(s"$field must be a whole number")
+    }
+
+  /** Continuation tokens are trimmed and compared case-insensitively using the root locale. */
+  def parseContinuationChoice(value: String): Either[String, Option[Boolean]] =
+    parseOptionalTrimmedString(value, "continue on failure").flatMap {
+      case Some(token) =>
+        token.toLowerCase(Locale.ROOT) match {
+          case "preset" => Right(None)
+          case "true"   => Right(Some(true))
+          case "false"  => Right(Some(false))
+          case _        => Left("continue on failure must be preset, true, or false")
+        }
+      case None => Left("continue on failure must be preset, true, or false")
+    }
+
+  def hostedPreset(token: String): Either[String, ResolvedBenchmarkConfiguration] =
+    if token.exists(Character.isISOControl) then Left("preset contains invalid characters")
+    else hostedPresets.get(token).toRight("preset selection is invalid")
+
+  def hostedArtifactName(
+      preset: String,
+      refName: String,
+      runId: String,
+      runAttempt: Int
+  ): Either[String, String] = {
+    val prefix = "linker-benchmark-"
+
+    def normalize(value: String, field: String): Either[String, String] =
+      if value.exists(Character.isISOControl) then Left(s"$field contains invalid characters")
+      else {
+        val normalized = value.trim.iterator
+          .map {
+            case character if character >= 'A' && character <= 'Z' => character.toLower
+            case character
+                if (character >= 'a' && character <= 'z') ||
+                  (character >= '0' && character <= '9') || character == '.' || character == '-' =>
+              character
+            case _ => '-'
+          }
+          .mkString
+          .replaceAll("-+", "-")
+          .dropWhile(character => character == '-' || character == '.')
+          .reverse
+          .dropWhile(character => character == '-' || character == '.')
+          .reverse
+        Either.cond(normalized.nonEmpty, normalized, s"$field must not be empty")
+      }
+
+    def shorten(value: String, original: String, maximum: Int): String =
+      if value.length <= maximum then value
+      else {
+        val hash   = sha256Hex(original).take(16)
+        val prefix = value.take(maximum - hash.length - 1).reverse.dropWhile(character =>
+          character == '-' || character == '.'
+        ).reverse
+        s"$prefix-$hash"
+      }
+
+    for {
+      rawPreset   <- parseOptionalTrimmedString(preset, "preset").flatMap(_.toRight("preset must not be empty"))
+      _           <- hostedPreset(rawPreset)
+      presetToken <- normalize(rawPreset, "preset")
+      refToken    <- normalize(refName, "artifact ref")
+      runToken    <- normalize(runId, "artifact run id")
+      _           <- Either.cond(runAttempt > 0, (), "artifact run attempt must be greater than zero")
+      safeRun     = shorten(runToken, runId, 40)
+      fixedLength = prefix.length + presetToken.length + safeRun.length + runAttempt.toString.length + 3
+      refMaximum  = 120 - fixedLength
+      _ <- Either.cond(refMaximum >= 18, (), "artifact name inputs are too long")
+      safeRef = shorten(refToken, refName, refMaximum)
+      result  = s"$prefix$presetToken-$safeRef-$safeRun-$runAttempt"
+    } yield result
+  }
+
+  private def sha256Hex(value: String): String =
+    MessageDigest
+      .getInstance("SHA-256")
+      .digest(value.getBytes(StandardCharsets.UTF_8))
+      .iterator
+      .map(byte => f"${byte & 0xff}%02x")
+      .mkString
+
+  def validateHostedOverrideBounds(overrides: BenchmarkOverrides): Either[String, Unit] = {
+    def bounded(value: Option[Int], field: String, maximum: Int): Either[String, Unit] =
+      value match {
+        case Some(number) if number <= 0      => Left(s"$field must be greater than zero")
+        case Some(number) if number > maximum => Left(s"$field exceeds the hosted maximum")
+        case _                                => Right(())
+      }
+
+    for {
+      _ <- bounded(overrides.trials, "trials", maxHostedTrials)
+      _ <- bounded(overrides.targetLimit, "target limit", maxHostedTargetLimit)
+      _ <- bounded(overrides.memoryGiB, "memory GiB", maxHostedMemoryGiB)
+      _ <- bounded(overrides.reserveGiB, "reserve GiB", maxHostedReserveGiB)
+      _ <- bounded(overrides.millJobs, "Mill jobs", maxHostedMillJobs)
+      _ <- bounded(overrides.maxChildren, "max children", maxHostedChildren)
+      _ <- bounded(overrides.batchSize, "batch size", maxHostedBatchSize)
+      _ <- bounded(overrides.timeoutMinutes, "timeout minutes", maxHostedTimeoutMinutes)
+    } yield ()
+  }
+
+  private def parseOverrideTokens[A](
+      value: String,
+      label: String,
+      parse: String => Option[A]
+  ): Either[String, Seq[A]] =
+    if value.exists(Character.isISOControl) then Left(s"$label selection contains invalid characters")
+    else {
+      val tokens = value.split(",", -1).toSeq.map(_.trim)
+      if tokens.exists(_.isEmpty) then Left(s"$label selection must be nonempty")
+      else {
+        val parsed = tokens.map(parse)
+        if parsed.exists(_.isEmpty) then Left(s"$label selection is invalid")
+        else {
+          val values = parsed.flatten
+          if values.distinct.size != values.size then Left(s"$label selection contains duplicates")
+          else Right(values)
+        }
+      }
+    }
+
+  private def validateTargetFilter(value: String): Either[String, String] =
+    if value.trim.isEmpty then Left("target filter must not be empty")
+    else if value.exists(Character.isISOControl) then Left("target filter must not contain control characters")
+    else Right(value)
+
+  def resolveHostedConfiguration(
+      preset: String,
+      overrides: BenchmarkOverrides
+  ): Either[String, ResolvedBenchmarkConfiguration] =
+    for {
+      _         <- validateHostedOverrideBounds(overrides)
+      base      <- hostedPreset(preset)
+      platforms <- overrides.platforms.fold[Either[String, Seq[Platform]]](Right(base.platforms))(value =>
+        parseOverrideTokens(
+          value,
+          "platforms",
+          {
+            case "js" | "scala-js" => Some(Platform.ScalaJs)
+            case token             => Platform.values.find(_.token == token)
+          }
+        )
+      )
+      strategies <- overrides.strategies.fold[Either[String, Seq[Strategy]]](Right(base.strategies))(value =>
+        parseOverrideTokens(value, "strategies", token => Strategy.values.find(_.token == token))
+      )
+      targetFilter <- overrides.targetFilter match {
+        case None        => Right(base.targetFilter)
+        case Some(value) => validateTargetFilter(value).map(Some(_))
+      }
+      targetLimit = overrides.targetLimit.orElse(base.targetLimit)
+      _ <- Either.cond(overrides.orderSeed.forall(_ >= 0L), (), "order seed must be nonnegative")
+      trials = overrides.trials.getOrElse(base.settings.trials)
+      settings <- validate(
+        EvaluationSettings(
+          trials = trials,
+          orderSeed = overrides.orderSeed.getOrElse(base.settings.orderSeed)
+        )
+      )
+      profile <- validate(
+        base.profile.copy(
+          memoryGiB = overrides.memoryGiB.getOrElse(base.profile.memoryGiB),
+          reserveGiB = overrides.reserveGiB.getOrElse(base.profile.reserveGiB),
+          millJobs = overrides.millJobs.getOrElse(base.profile.millJobs),
+          maxChildren = overrides.maxChildren.getOrElse(base.profile.maxChildren),
+          batchSize = overrides.batchSize.getOrElse(base.profile.batchSize),
+          timeoutMinutes = overrides.timeoutMinutes.getOrElse(base.profile.timeoutMinutes)
+        )
+      )
+    } yield base.copy(
+      profile = profile,
+      settings = settings,
+      platforms = platforms,
+      strategies = strategies,
+      targetFilter = targetFilter,
+      targetLimit = targetLimit,
+      continueOnFailure = overrides.continueOnFailure.getOrElse(base.continueOnFailure)
+    )
+
+  def resolveBenchmarkConfiguration(
+      preset: String,
+      profileToken: String,
+      local: Profile,
+      overrides: BenchmarkOverrides
+  ): Either[String, ResolvedBenchmarkConfiguration] =
+    parseOptionalTrimmedString(preset, "preset").flatMap {
+      case Some(hosted) =>
+        parseOptionalTrimmedString(profileToken, "profile").flatMap {
+          case Some(_) => Left("profile is available only without a hosted preset")
+          case None    => resolveHostedConfiguration(hosted, overrides)
+        }
+      case None =>
+        for {
+          profileChoice <- parseOptionalTrimmedString(profileToken, "profile")
+          baseProfile   <- profileChoice.getOrElse("local") match {
+            case "local" => validate(local)
+            case "ci"    => Right(ciProfile)
+            case _       => Left("profile selection is invalid")
+          }
+          platforms <- overrides.platforms.fold[Either[String, Seq[Platform]]](Right(Platform.values.toSeq))(value =>
+            parseOverrideTokens(
+              value,
+              "platforms",
+              {
+                case "js" | "scala-js" => Some(Platform.ScalaJs)
+                case token             => Platform.values.find(_.token == token)
+              }
+            )
+          )
+          strategies <- overrides.strategies.fold[Either[String, Seq[Strategy]]](Right(Strategy.values.toSeq))(value =>
+            parseOverrideTokens(value, "strategies", token => Strategy.values.find(_.token == token))
+          )
+          targetFilter <- overrides.targetFilter match {
+            case None        => Right(None)
+            case Some(value) => validateTargetFilter(value).map(Some(_))
+          }
+          _        <- Either.cond(overrides.targetLimit.forall(_ > 0), (), "target limit must be greater than zero")
+          settings <- validate(
+            EvaluationSettings(overrides.trials.getOrElse(3), overrides.orderSeed.getOrElse(0L))
+          )
+          profile <- validate(
+            baseProfile.copy(
+              memoryGiB = overrides.memoryGiB.getOrElse(baseProfile.memoryGiB),
+              reserveGiB = overrides.reserveGiB.getOrElse(baseProfile.reserveGiB),
+              millJobs = overrides.millJobs.getOrElse(baseProfile.millJobs),
+              maxChildren = overrides.maxChildren.getOrElse(baseProfile.maxChildren),
+              batchSize = overrides.batchSize.getOrElse(baseProfile.batchSize),
+              timeoutMinutes = overrides.timeoutMinutes.getOrElse(baseProfile.timeoutMinutes)
+            )
+          )
+        } yield ResolvedBenchmarkConfiguration(
+          preset = "direct",
+          profile = profile,
+          settings = settings,
+          platforms = platforms,
+          strategies = strategies,
+          targetFilter = targetFilter,
+          targetLimit = overrides.targetLimit,
+          continueOnFailure = overrides.continueOnFailure.getOrElse(false)
+        )
+    }
+
+  def selectInventoryTargets(
+      targets: Seq[String],
+      filter: Option[String],
+      limit: Option[Int],
+      platform: Platform
+  ): Either[String, Seq[String]] =
+    for {
+      validatedFilter <- filter match {
+        case None        => Right(None)
+        case Some(value) => validateTargetFilter(value).map(Some(_))
+      }
+      _ <- Either.cond(limit.forall(_ > 0), (), "target limit must be greater than zero")
+      selected = {
+        val ordered  = targets.distinct.sorted
+        val filtered = validatedFilter.fold(ordered)(value => ordered.filter(_.contains(value)))
+        limit.fold(filtered)(filtered.take)
+      }
+      _ <- Either.cond(selected.nonEmpty, (), s"no ${platform.token} inventory targets matched the selection")
+    } yield selected
+
+  final case class SmokeRecord(
+      childPid: Long,
+      javaVersion: String,
+      pinnedMillVersion: String,
+      requestedHeapBytes: Long,
+      effectiveMaxHeapBytes: Long,
+      requestedHeapHonored: Boolean,
+      outputDirectoryIdentity: String,
+      proofFilename: String
+  ) derives ReadWriter
+
+  final case class SmokeProof(childPid: Long, outputDirectoryIdentity: String) derives ReadWriter
+
+  final case class RecoveryAttemptRecord(
+      outcome: Outcome,
+      wallMillis: Long,
+      exitCode: Option[Int],
+      worker: Option[SmokeRecord]
+  ) derives ReadWriter
+
+  final case class RecoveryRecord(first: RecoveryAttemptRecord, replacement: RecoveryAttemptRecord)
+      derives ReadWriter
+
+  def validateRecovery(record: RecoveryRecord): Either[String, Unit] =
+    if record.first.outcome != Outcome.TimedOut then Left("first recovery worker must time out")
+    else if record.first.wallMillis < 0L || record.replacement.wallMillis < 0L then
+      Left("recovery wall times must be nonnegative")
+    else if record.replacement.outcome != Outcome.Succeeded then Left("replacement recovery worker must succeed")
+    else if !record.replacement.exitCode.contains(0) then Left("replacement recovery worker must exit zero")
+    else if record.replacement.worker.isEmpty then Left("replacement recovery worker marker is required")
+    else Right(())
+
+  def renderRecoveryJson(record: RecoveryRecord): String = renderRecoveryJson(record, sys.env)
+
+  def renderRecoveryJson(record: RecoveryRecord, environment: Map[String, String]): String = {
+    def cleanWorker(worker: SmokeRecord): SmokeRecord =
+      worker.copy(
+        javaVersion = redact(worker.javaVersion, environment),
+        pinnedMillVersion = redact(worker.pinnedMillVersion, environment),
+        outputDirectoryIdentity = redact(worker.outputDirectoryIdentity, environment),
+        proofFilename = redact(worker.proofFilename, environment)
+      )
+    write(
+      record.copy(
+        first = record.first.copy(worker = record.first.worker.map(cleanWorker)),
+        replacement = record.replacement.copy(worker = record.replacement.worker.map(cleanWorker))
+      )
+    )
+  }
+
+  def validateRecoveryProof(
+      workspace: os.Path,
+      rootOutput: os.Path,
+      lane: os.Path,
+      proofPath: os.Path,
+      expectedOutputIdentity: String,
+      worker: SmokeRecord,
+      proof: SmokeProof
+  ): Either[String, Path] =
+    validateRecoveryProofPath(
+      workspace,
+      rootOutput,
+      lane,
+      proofPath,
+      expectedOutputIdentity,
+      worker
+    ).flatMap(canonicalProof =>
+      Either.cond(
+        proof == SmokeProof(worker.childPid, worker.outputDirectoryIdentity),
+        canonicalProof,
+        "replacement recovery worker proof does not match its marker"
+      )
+    )
+
+  def validateRecoveryProofPath(
+      workspace: os.Path,
+      rootOutput: os.Path,
+      lane: os.Path,
+      proofPath: os.Path,
+      expectedOutputIdentity: String,
+      worker: SmokeRecord
+  ): Either[String, Path] = {
+    val lexicalLane  = lane.wrapped.toAbsolutePath.normalize()
+    val lexicalProof = proofPath.wrapped.toAbsolutePath.normalize()
+
+    def containsSymlink: Boolean =
+      if !lexicalProof.startsWith(lexicalLane) then true
+      else
+        lexicalLane
+          .relativize(lexicalProof)
+          .iterator()
+          .asScala
+          .scanLeft(lexicalLane)((current, segment) => current.resolve(segment))
+          .exists(Files.isSymbolicLink)
+
+    if worker.outputDirectoryIdentity != expectedOutputIdentity then
+      Left("replacement recovery worker reported the wrong output directory identity")
+    else if proofPath.last != worker.proofFilename then Left("replacement recovery worker proof has the wrong name")
+    else if containsSymlink then Left("replacement recovery worker proof must not use symbolic links")
+    else if !Files.isRegularFile(lexicalProof, LinkOption.NOFOLLOW_LINKS) then
+      Left("replacement recovery worker proof must be a regular file")
+    else
+      for {
+        canonicalWorkspace  <- canonicalPhysicalPath(workspace)
+        canonicalRootOutput <- canonicalPhysicalPath(rootOutput)
+        canonicalLane       <- canonicalPhysicalPath(lane)
+        canonicalProof      <- canonicalPhysicalPath(proofPath)
+        result              <- Either.cond(
+          canonicalProof != canonicalLane &&
+            canonicalProof.startsWith(canonicalLane) &&
+            !canonicalProof.startsWith(canonicalWorkspace) &&
+            !canonicalProof.startsWith(canonicalRootOutput) &&
+            Files.isRegularFile(canonicalProof, LinkOption.NOFOLLOW_LINKS),
+          canonicalProof,
+          "replacement recovery worker proof escaped its external lane"
+        )
+      } yield result
+  }
+
+  def renderValidatedRecoveryJson(
+      record: RecoveryRecord,
+      proofValidation: Either[String, Path],
+      environment: Map[String, String]
+  ): Either[String, String] =
+    validateRecovery(record).flatMap(_ => proofValidation.map(_ => renderRecoveryJson(record, environment)))
+
+  def benchmarkOutputRoot(
+      base: os.Path,
+      configuration: ResolvedBenchmarkConfiguration,
+      recoverySmoke: Boolean,
+      planOnly: Boolean
+  ): Either[String, os.Path] = {
+    val safeToken = "[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
+    if recoverySmoke && planOnly then Left("recovery-smoke and plan-only are exclusive")
+    else
+      for {
+        identity <- benchmarkOutputIdentity(configuration)
+        _ <- Either.cond(configuration.profile.name.matches(safeToken), (), "profile name is not a safe output token")
+        _ <- Either.cond(configuration.platforms.nonEmpty, (), "platforms must not be empty")
+        platformDirectory = configuration.platforms.distinct.map(_.token).sorted.mkString("+")
+      } yield {
+        val root = base / identity / configuration.profile.name
+        if recoverySmoke then root / "recovery-smoke"
+        else if planOnly then root / "plan-only" / platformDirectory
+        else root / platformDirectory
+      }
+  }
+
+  def benchmarkOutputIdentity(configuration: ResolvedBenchmarkConfiguration): Either[String, String] = {
+    val safeToken = "[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
+    Either.cond(
+      configuration.preset.matches(safeToken),
+      s"${configuration.preset}-${sha256Hex(write(configuration)).take(16)}",
+      "preset is not a safe output token"
+    )
+  }
+
+  final case class RuntimeMetadata(
+      javaVersion: String,
+      pinnedMillVersion: String,
+      operatingSystem: String,
+      architecture: String,
+      availableProcessors: Int,
+      effectiveMaxHeapBytes: Long,
+      outputDirectoryIdentity: String
+  ) derives ReadWriter
+
+  object RuntimeMetadata {
+    val Unknown: RuntimeMetadata = RuntimeMetadata("unknown", "unknown", "unknown", "unknown", 0, 0L, "unknown")
+  }
+
+  final case class WorkerRecord(
+      runId: String,
+      trial: Int,
+      strategyPosition: Int,
+      settings: EvaluationSettings,
+      platform: Platform,
+      strategy: Strategy,
+      profile: Profile,
+      lane: Int,
+      batch: Int,
+      targets: Seq[String],
+      startupMillis: Long,
+      peakRssKiB: Long,
+      phases: Seq[PhaseMetrics],
+      outcome: Outcome,
+      detail: Option[String],
+      runtime: RuntimeMetadata = RuntimeMetadata.Unknown
+  ) derives ReadWriter
+
+  final case class StrategyTrialRecord(
+      runId: String,
+      trial: Int,
+      strategyPosition: Int,
+      platform: Platform,
+      strategy: Strategy,
+      profile: Profile,
+      wallMillis: Long,
+      peakAggregateRssKiB: Long,
+      targetsCompleted: Long,
+      outcome: Outcome
+  ) derives ReadWriter
+
+  final case class PreparationRecord(
+      runId: String,
+      trial: Int,
+      platform: Platform,
+      strategy: Strategy,
+      profile: Profile,
+      lane: Int,
+      wallMillis: Long,
+      targets: Seq[String],
+      outcome: Outcome
+  ) derives ReadWriter
+
+  final case class PreparationDecision(measure: Boolean, outcome: Outcome, failRun: Boolean)
+
+  def preparationDecision(outcomes: Seq[Outcome], continueOnFailure: Boolean): PreparationDecision = {
+    val outcome =
+      if outcomes.isEmpty then Outcome.Failed
+      else if outcomes.contains(Outcome.Cancelled) then Outcome.Cancelled
+      else if outcomes.contains(Outcome.TimedOut) then Outcome.TimedOut
+      else if outcomes.contains(Outcome.Failed) then Outcome.Failed
+      else Outcome.Succeeded
+    val measure = outcome == Outcome.Succeeded
+    PreparationDecision(measure, outcome, failRun = !measure && !continueOnFailure)
+  }
+
+  final case class BenchmarkResult(
+      configuration: ResolvedBenchmarkConfiguration,
+      peakAggregateRssKiB: Long,
+      cases: Seq[StrategyTrialRecord],
+      records: Seq[WorkerRecord],
+      preparations: Seq[PreparationRecord] = Seq.empty
+  ) derives ReadWriter
+
+  final case class LongSummary(median: Long, min: Long, max: Long) derives ReadWriter
+
+  final case class DoubleSummary(median: Double, min: Double, max: Double) derives ReadWriter
+
+  final case class AggregateMetrics(
+      profile: Profile,
+      platform: Platform,
+      strategy: Strategy,
+      succeeded: Int,
+      failed: Int,
+      timedOut: Int,
+      cancelled: Int,
+      wallMillis: Option[LongSummary],
+      peakAggregateRssKiB: Option[LongSummary],
+      startupShare: Option[DoubleSummary],
+      throughputTargetsPerMinute: Option[DoubleSummary],
+      peakChildRssKiB: Option[LongSummary],
+      peakHeapBytes: Option[LongSummary],
+      gcShare: Option[DoubleSummary]
+  ) derives ReadWriter
+
+  private final case class TrialWorkerMetrics(
+      startupShare: Option[Double],
+      throughputTargetsPerMinute: Option[Double],
+      peakChildRssKiB: Long,
+      peakHeapBytes: Long,
+      gcShare: Option[Double]
+  )
+
+  private def deduplicate[A, Identity](values: Seq[A], label: String)(identity: A => Identity): Seq[A] = {
+    val unique = mutable.LinkedHashMap.empty[Identity, A]
+    values.foreach { value =>
+      val key = identity(value)
+      unique.get(key) match {
+        case None                                => unique.addOne(key -> value)
+        case Some(existing) if existing == value => ()
+        case Some(_) => throw new IllegalArgumentException(s"conflicting duplicate $label identity: $key")
+      }
+    }
+    unique.values.toSeq
+  }
+
+  private def deduplicateCases(cases: Seq[StrategyTrialRecord]): Seq[StrategyTrialRecord] =
+    deduplicate(cases, "strategy trial")(value =>
+      (value.runId, value.profile, value.platform, value.strategy, value.trial, value.strategyPosition)
+    )
+
+  private def deduplicateRecords(records: Seq[WorkerRecord]): Seq[WorkerRecord] =
+    deduplicate(records, "worker")(value =>
+      (
+        value.runId,
+        value.profile,
+        value.platform,
+        value.strategy,
+        value.trial,
+        value.strategyPosition,
+        value.lane,
+        value.batch
+      )
+    )
+
+  private def deduplicatePreparations(records: Seq[PreparationRecord]): Seq[PreparationRecord] =
+    deduplicate(records, "preparation")(value =>
+      (value.runId, value.profile, value.platform, value.strategy, value.trial, value.lane)
+    )
+
+  private def summarizeLong(values: Seq[Long]): Option[LongSummary] =
+    if values.isEmpty then None
+    else {
+      val sorted = values.sorted
+      val middle = sorted.size / 2
+      val median =
+        if sorted.size % 2 == 1 then sorted(middle)
+        else ((BigInt(sorted(middle - 1)) + BigInt(sorted(middle))) / 2).toLong
+      Some(LongSummary(median, sorted.head, sorted.last))
+    }
+
+  private[millbuild] def summarizeDoubles(values: Seq[Double]): Option[DoubleSummary] = {
+    val finite = values.filter(_.isFinite)
+    if finite.isEmpty then None
+    else {
+      val sorted = finite.sorted
+      val middle = sorted.size / 2
+      val median =
+        if sorted.size % 2 == 1 then sorted(middle)
+        else ((BigDecimal(sorted(middle - 1)) + BigDecimal(sorted(middle))) / BigDecimal(2)).toDouble
+      Some(DoubleSummary(median, sorted.head, sorted.last))
+    }
+  }
+
+  def aggregate(cases: Seq[StrategyTrialRecord], records: Seq[WorkerRecord]): Seq[AggregateMetrics] = {
+    val uniqueCases   = deduplicateCases(cases)
+    val uniqueRecords = deduplicateRecords(records)
+    uniqueCases
+      .groupBy(value => (value.profile, value.platform, value.strategy))
+      .toSeq
+      .sortBy { case ((profile, platform, strategy), _) =>
+        (
+          profile.name,
+          (
+            profile.memoryGiB,
+            profile.reserveGiB,
+            profile.heapGiB,
+            profile.millJobs,
+            profile.maxChildren,
+            profile.batchSize,
+            profile.timeoutMinutes
+          ),
+          platform.token,
+          strategy.token
+        )
+      }
+      .map { case ((profile, platform, strategy), groupedCases) =>
+        val successfulCases = groupedCases.filter(_.outcome == Outcome.Succeeded)
+        val workerMetrics   = successfulCases.flatMap { strategyTrial =>
+          val matching = uniqueRecords.filter(record =>
+            record.runId == strategyTrial.runId &&
+              record.profile == strategyTrial.profile &&
+              record.platform == strategyTrial.platform &&
+              record.strategy == strategyTrial.strategy &&
+              record.trial == strategyTrial.trial &&
+              record.strategyPosition == strategyTrial.strategyPosition
+          )
+          Option.when(matching.nonEmpty) {
+            val startupMillis   = matching.iterator.map(_.startupMillis.toDouble).sum
+            val phaseWallMillis = matching.iterator.flatMap(_.phases).map(_.wallMillis.toDouble).sum
+            val gcMillis        = matching.iterator.flatMap(_.phases).map(_.gcMillis.toDouble).sum
+            TrialWorkerMetrics(
+              startupShare = Option.when(startupMillis + phaseWallMillis > 0.0)(
+                startupMillis / (startupMillis + phaseWallMillis)
+              ),
+              throughputTargetsPerMinute = Option.when(strategyTrial.wallMillis > 0L)(
+                strategyTrial.targetsCompleted.toDouble * 60000.0 / strategyTrial.wallMillis
+              ),
+              peakChildRssKiB = matching.iterator.map(_.peakRssKiB).max,
+              peakHeapBytes = matching.iterator.flatMap(_.phases).map(_.peakHeapBytes).maxOption.getOrElse(0L),
+              gcShare = Option.when(phaseWallMillis > 0.0)(gcMillis / phaseWallMillis)
+            )
+          }
+        }
+        AggregateMetrics(
+          profile = profile,
+          platform = platform,
+          strategy = strategy,
+          succeeded = groupedCases.count(_.outcome == Outcome.Succeeded),
+          failed = groupedCases.count(_.outcome == Outcome.Failed),
+          timedOut = groupedCases.count(_.outcome == Outcome.TimedOut),
+          cancelled = groupedCases.count(_.outcome == Outcome.Cancelled),
+          wallMillis = summarizeLong(successfulCases.map(_.wallMillis)),
+          peakAggregateRssKiB = summarizeLong(successfulCases.map(_.peakAggregateRssKiB)),
+          startupShare = summarizeDoubles(workerMetrics.flatMap(_.startupShare)),
+          throughputTargetsPerMinute = summarizeDoubles(workerMetrics.flatMap(_.throughputTargetsPerMinute)),
+          peakChildRssKiB = summarizeLong(workerMetrics.map(_.peakChildRssKiB)),
+          peakHeapBytes = summarizeLong(workerMetrics.map(_.peakHeapBytes)),
+          gcShare = summarizeDoubles(workerMetrics.flatMap(_.gcShare))
+        )
+      }
+  }
+
+  private val HomePath: Regex         = raw"/(?:Users|home)/[^/\s]+".r
+  private val SecretAssignment: Regex =
+    raw"(?i)\b([A-Z][A-Z0-9_]*)(\s*=\s*)([^\s]+)".r
+  private val SecretSuffixes = Seq("TOKEN", "PASSWORD", "SECRET", "KEY")
+
+  def redact(value: String): String = redact(value, sys.env)
+
+  def redact(value: String, environment: Map[String, String]): String = {
+    val withoutAssignments = SecretAssignment.replaceAllIn(
+      value,
+      matched =>
+        if SecretSuffixes.exists(matched.group(1).toUpperCase(Locale.ROOT).endsWith) then
+          s"${matched.group(1)}${matched.group(2)}<redacted>"
+        else matched.matched
+    )
+    val withoutHomes = HomePath.replaceAllIn(
+      withoutAssignments,
+      matched =>
+        if matched.matched.startsWith("/Users/") then "/Users/<redacted>" else "/home/<redacted>"
+    )
+    environment.iterator
+      .filter { case (name, secret) =>
+        secret.nonEmpty && SecretSuffixes.exists(name.toUpperCase(Locale.ROOT).endsWith)
+      }
+      .map(_._2)
+      .toSeq
+      .distinct
+      .sortBy(secret => -secret.length)
+      .foldLeft(withoutHomes)((text, secret) => text.replace(secret, "<redacted>"))
+  }
+
+  def sanitize(result: BenchmarkResult): BenchmarkResult = sanitize(result, sys.env)
+
+  def sanitize(result: BenchmarkResult, environment: Map[String, String]): BenchmarkResult = {
+    def clean(value: String): String            = redact(value, environment)
+    def cleanProfile(profile: Profile): Profile = profile.copy(name = clean(profile.name))
+    result.copy(
+      configuration = result.configuration.copy(
+        preset = clean(result.configuration.preset),
+        profile = cleanProfile(result.configuration.profile),
+        targetFilter = result.configuration.targetFilter.map(clean)
+      ),
+      cases =
+        result.cases.map(record => record.copy(runId = clean(record.runId), profile = cleanProfile(record.profile))),
+      records = result.records.map(record =>
+        record.copy(
+          runId = clean(record.runId),
+          profile = cleanProfile(record.profile),
+          targets = record.targets.map(clean),
+          phases = record.phases.map(phase => phase.copy(name = clean(phase.name))),
+          detail = record.detail.map(clean),
+          runtime = record.runtime.copy(
+            javaVersion = clean(record.runtime.javaVersion),
+            pinnedMillVersion = clean(record.runtime.pinnedMillVersion),
+            operatingSystem = clean(record.runtime.operatingSystem),
+            architecture = clean(record.runtime.architecture),
+            outputDirectoryIdentity = clean(record.runtime.outputDirectoryIdentity)
+          )
+        )
+      ),
+      preparations = result.preparations.map(record =>
+        record.copy(
+          runId = clean(record.runId),
+          profile = cleanProfile(record.profile),
+          targets = record.targets.map(clean)
+        )
+      )
+    )
+  }
+
+  private def normalized(result: BenchmarkResult): BenchmarkResult =
+    result.copy(
+      cases = deduplicateCases(result.cases),
+      records = deduplicateRecords(result.records),
+      preparations = deduplicatePreparations(result.preparations)
+    )
+
+  def renderJson(result: BenchmarkResult): String = renderJson(result, sys.env)
+
+  def renderJson(result: BenchmarkResult, environment: Map[String, String]): String =
+    write(sanitize(normalized(result), environment))
+
+  def renderConfigurationJson(configuration: ResolvedBenchmarkConfiguration): String =
+    renderConfigurationJson(configuration, sys.env)
+
+  def renderConfigurationJson(
+      configuration: ResolvedBenchmarkConfiguration,
+      environment: Map[String, String]
+  ): String =
+    write(sanitize(BenchmarkResult(configuration, 0L, Seq.empty, Seq.empty), environment).configuration, indent = 2)
+
+  private def renderLong(value: Option[LongSummary]): String =
+    value.fold("n/a")(summary => s"${summary.median} [${summary.min}-${summary.max}]")
+
+  private def renderDouble(value: Option[DoubleSummary]): String =
+    value.fold("n/a")(summary =>
+      String.format(
+        Locale.ROOT,
+        "%.3f [%.3f-%.3f]",
+        Double.box(summary.median),
+        Double.box(summary.min),
+        Double.box(summary.max)
+      )
+    )
+
+  private def tableCell(value: String): String =
+    value.replace("\\", "\\\\").replace("|", "\\|").replace('\r', ' ').replace('\n', ' ')
+
+  def renderMarkdown(result: BenchmarkResult): String = renderMarkdown(result, sys.env)
+
+  def renderMarkdown(result: BenchmarkResult, environment: Map[String, String]): String = {
+    val uniqueResult = normalized(result)
+    val safeResult   = sanitize(uniqueResult, environment)
+    val rawRows      = safeResult.records
+      .sortBy(record =>
+        (
+          (
+            record.trial,
+            record.strategyPosition,
+            record.platform.token,
+            record.strategy.token,
+            record.lane,
+            record.batch
+          ),
+          record.runId,
+          (
+            record.profile.name,
+            record.profile.memoryGiB,
+            record.profile.reserveGiB,
+            record.profile.heapGiB,
+            record.profile.millJobs,
+            record.profile.maxChildren,
+            record.profile.batchSize,
+            record.profile.timeoutMinutes
+          )
+        )
+      )
+      .map { record =>
+        val phaseWallMillis = record.phases.iterator.map(_.wallMillis).sum
+        s"| ${record.trial} | ${record.strategyPosition} | ${tableCell(record.platform.token)} | ${tableCell(record.strategy.token)} | ${tableCell(record.profile.name)} | ${tableCell(record.outcome.toString.toLowerCase(Locale.ROOT))} | $phaseWallMillis | ${record.peakRssKiB} |"
+      }
+    val strategyRows = safeResult.cases
+      .sortBy(record => (record.trial, record.strategyPosition, record.platform.token, record.strategy.token))
+      .map { record =>
+        s"| ${record.trial} | ${record.strategyPosition} | ${tableCell(record.platform.token)} | ${tableCell(record.strategy.token)} | ${tableCell(record.profile.name)} | ${tableCell(record.outcome.toString.toLowerCase(Locale.ROOT))} | ${record.wallMillis} | ${record.peakAggregateRssKiB} | ${record.targetsCompleted} |"
+      }
+    val preparationRows = safeResult.preparations
+      .sortBy(record => (record.trial, record.platform.token, record.strategy.token, record.lane))
+      .map { record =>
+        s"| ${record.trial} | ${tableCell(record.platform.token)} | ${tableCell(record.strategy.token)} | ${tableCell(record.profile.name)} | ${record.lane} | ${tableCell(record.outcome.toString.toLowerCase(Locale.ROOT))} | ${record.wallMillis} | ${record.targets.size} |"
+      }
+    val aggregateRows = aggregate(uniqueResult.cases, uniqueResult.records).map { metrics =>
+      val profileName = redact(metrics.profile.name, environment)
+      s"| ${tableCell(profileName)} | ${tableCell(metrics.platform.token)} | ${tableCell(metrics.strategy.token)} | ${metrics.succeeded} | ${metrics.failed} | ${metrics.timedOut} | ${metrics.cancelled} | ${renderLong(metrics.wallMillis)} | ${renderLong(metrics.peakAggregateRssKiB)} | ${renderDouble(metrics.startupShare)} | ${renderDouble(metrics.throughputTargetsPerMinute)} | ${renderLong(metrics.peakChildRssKiB)} | ${renderLong(metrics.peakHeapBytes)} | ${renderDouble(metrics.gcShare)} |"
+    }
+    val markdown = Seq(
+      "# Linker benchmark report",
+      "",
+      s"Preset: ${tableCell(safeResult.configuration.preset)}",
+      s"Profile: ${tableCell(safeResult.configuration.profile.name)}; memory: ${safeResult.configuration.profile.memoryGiB} GiB; reserve: ${safeResult.configuration.profile.reserveGiB} GiB; heap: ${safeResult.configuration.profile.heapGiB} GiB; Mill jobs: ${safeResult.configuration.profile.millJobs}; max children: ${safeResult.configuration.profile.maxChildren}; batch size: ${safeResult.configuration.profile.batchSize}; timeout: ${safeResult.configuration.profile.timeoutMinutes} minutes",
+      s"Platforms: ${safeResult.configuration.platforms.map(_.token).mkString(", ")}",
+      s"Strategies: ${safeResult.configuration.strategies.map(_.token).mkString(", ")}",
+      s"Trials: ${safeResult.configuration.settings.trials}; order seed: ${safeResult.configuration.settings.orderSeed}",
+      s"Target filter: ${safeResult.configuration.targetFilter.fold("none")(tableCell)}; target limit: ${safeResult.configuration.targetLimit.fold("none")(_.toString)}",
+      s"Continue on failure: ${safeResult.configuration.continueOnFailure}",
+      "",
+      s"Whole-run peak aggregate RSS: ${safeResult.peakAggregateRssKiB} KiB",
+      "",
+      "## Strategy trials",
+      "",
+      "| Trial | Position | Platform | Strategy | Profile | Outcome | Wall ms | Peak aggregate RSS KiB | Targets completed |",
+      "| ---: | ---: | --- | --- | --- | --- | ---: | ---: | ---: |"
+    ) ++ strategyRows ++ Seq(
+      "",
+      "## Preparation",
+      "",
+      "| Trial | Platform | Strategy | Profile | Lane | Outcome | Wall ms | Targets |",
+      "| ---: | --- | --- | --- | ---: | --- | ---: | ---: |"
+    ) ++ preparationRows ++ Seq(
+      "",
+      "## Worker records",
+      "",
+      "| Trial | Position | Platform | Strategy | Profile | Outcome | Worker phase wall ms | Peak child RSS KiB |",
+      "| ---: | ---: | --- | --- | --- | --- | ---: | ---: |"
+    ) ++ rawRows ++ Seq(
+      "",
+      "## Aggregates",
+      "",
+      "| Profile | Platform | Strategy | Succeeded | Failed | Timed out | Cancelled | Successful wall ms median [min-max] | Aggregate RSS KiB median [min-max] | Worker-time startup share median [min-max] | Targets/min median [min-max] | Child RSS KiB median [min-max] | Peak heap bytes median [min-max] | Worker-time GC share median [min-max] |",
+      "| --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- | --- | --- | --- | --- | --- |"
+    ) ++ aggregateRows
+    redact(markdown.mkString("\n") + "\n", environment)
+  }
+
+  val defaultEvaluationSettings: EvaluationSettings = EvaluationSettings(3, 0L)
+
+  val smokeEnvironmentRemovals: Set[String] = Set(
+    "JAVA_OPTS",
+    "JDK_JAVA_OPTIONS",
+    "JAVA_TOOL_OPTIONS",
+    "_JAVA_OPTIONS",
+    // Mill propagates this with its os-lib relativizer base. In a nested invocation it names the outer task's
+    // sandbox alias; keeping it makes the physical MILL_OUTPUT_DIR recursively resolve through mill-workspace.
+    "MILL_WORKSPACE_ROOT"
+  )
+
+  private val OneGiBBytes   = 1024L * 1024L * 1024L
+  private val HeapTolerance = 256L * 1024L * 1024L
+  private val SevenGiBBytes = 7L * OneGiBBytes
+  private val NineGiBBytes  = 9L * OneGiBBytes
+
+  def validatePinnedHeapProbe(
+      requestedHeapBytes: Long,
+      effectiveHeapBytes: Long,
+      requestedHeapHonored: Boolean
+  ): Either[String, Long] =
+    if requestedHeapBytes != OneGiBBytes then Left("heap probe must request one GiB")
+    else if requestedHeapHonored then Left("pinned eight GiB heap must override the one GiB request")
+    else if effectiveHeapBytes < SevenGiBBytes || effectiveHeapBytes > NineGiBBytes then
+      Left("effective heap must be within the seven-to-nine GiB tolerance")
+    else Right(effectiveHeapBytes)
+
+  def validateSmokeHeapProbe(record: SmokeRecord, profile: Profile): Either[String, Int] =
+    validatePinnedHeapProbe(
+      record.requestedHeapBytes,
+      record.effectiveMaxHeapBytes,
+      record.requestedHeapHonored
+    ).flatMap(_ => validateEffectiveHeap(profile, record.effectiveMaxHeapBytes))
+
+  def validateEffectiveHeap(profile: Profile, effectiveMaxHeapBytes: Long): Either[String, Int] =
+    validate(profile).flatMap { _ =>
+      if effectiveMaxHeapBytes <= 0L then Left("effective max heap bytes must be positive")
+      else {
+        val effectiveHeapGiB = (BigInt(effectiveMaxHeapBytes) + BigInt(OneGiBBytes - 1L)) / BigInt(OneGiBBytes)
+        if effectiveHeapGiB > BigInt(Int.MaxValue) then Left("effective max heap is too large")
+        else {
+          val requiredGiB = effectiveHeapGiB * BigInt(profile.maxChildren) + BigInt(profile.reserveGiB)
+          if requiredGiB > BigInt(profile.memoryGiB) then
+            Left("effective child heaps and reserve exceed available memory")
+          else Right(effectiveHeapGiB.toInt)
+        }
+      }
+    }
+
+  def validateConfiguredHeap(profile: Profile, effectiveMaxHeapBytes: Long): Either[String, Int] = {
+    val requestedBytes = BigInt(profile.heapGiB) * BigInt(OneGiBBytes)
+    val effectiveBytes = BigInt(effectiveMaxHeapBytes)
+    if profile.heapGiB <= 0 then Left("configured heap GiB must be greater than zero")
+    else if effectiveMaxHeapBytes <= 0L then Left("effective max heap bytes must be positive")
+    else if effectiveBytes < requestedBytes - BigInt(HeapTolerance) ||
+      effectiveBytes > requestedBytes + BigInt(HeapTolerance)
+    then Left("effective max heap differs from the configured heap by more than 256 MiB")
+    else validateEffectiveHeap(profile, effectiveMaxHeapBytes)
+  }
+
+  def canonicalPhysicalPath(path: os.Path): Either[String, Path] = {
+    val absolute = path.wrapped.toAbsolutePath.normalize()
+
+    @tailrec def loop(candidate: Path, missing: List[String]): Either[String, Path] =
+      if Files.exists(candidate, LinkOption.NOFOLLOW_LINKS) then
+        try Right(missing.foldLeft(candidate.toRealPath())((current, segment) => current.resolve(segment)).normalize())
+        catch {
+          case NonFatal(error) => Left(s"cannot resolve physical path: ${error.getClass.getSimpleName}")
+        }
+      else {
+        val parent = candidate.getParent
+        if parent == null then Left("cannot resolve physical path: no existing ancestor")
+        else loop(parent, candidate.getFileName.toString :: missing)
+      }
+
+    loop(absolute, Nil)
+  }
+
+  def resolveSmokeWorkspace(
+      environment: Map[String, String],
+      currentWorkingDirectory: os.Path
+  ): Either[String, os.Path] = {
+    def repositoryRoot(candidate: os.Path): Option[os.Path] =
+      canonicalPhysicalPath(candidate).toOption.flatMap { physicalCandidate =>
+        @tailrec def loop(path: Path): Option[Path] =
+          if Files.isRegularFile(path.resolve("mill")) &&
+            Files.isRegularFile(path.resolve(".mill-version")) &&
+            Files.isRegularFile(path.resolve("build.mill"))
+          then Some(path)
+          else
+            Option(path.getParent) match {
+              case Some(parent) => loop(parent)
+              case None         => None
+            }
+        loop(physicalCandidate)
+      }.map(os.Path(_))
+
+    val candidates =
+      environment.get("MILL_WORKSPACE_ROOT").filter(_.nonEmpty).map(os.Path(_, currentWorkingDirectory)).toSeq :+
+        currentWorkingDirectory
+    candidates.iterator.flatMap(repositoryRoot).nextOption().toRight(
+      "cannot resolve the physical repository from MILL_WORKSPACE_ROOT or the current working directory"
+    )
+  }
+
+  def resolveSmokeTemporaryBase(value: String, workspace: os.Path): Either[String, os.Path] = {
+    val trimmed = value.trim
+    if trimmed.isEmpty then Left("java.io.tmpdir must not be empty")
+    else {
+      val lexical = os.Path(os.Path(trimmed, workspace).wrapped.toAbsolutePath.normalize())
+      Either.cond(
+        Files.isDirectory(lexical.wrapped),
+        lexical,
+        "java.io.tmpdir must name an existing directory"
+      )
+    }
+  }
+
+  def resolveSmokeTemporaryBase(
+      javaTemporaryDirectory: String,
+      environmentTemporaryDirectory: Option[String],
+      workspace: os.Path
+  ): Either[String, os.Path] =
+    for {
+      javaBase <- resolveSmokeTemporaryBase(javaTemporaryDirectory, workspace)
+      result   <- environmentTemporaryDirectory match {
+        case None        => Right(javaBase)
+        case Some(value) =>
+          for {
+            environmentBase      <- resolveSmokeTemporaryBase(value, workspace)
+            canonicalJava        <- canonicalPhysicalPath(javaBase)
+            canonicalEnvironment <- canonicalPhysicalPath(environmentBase)
+            selected             <- Either.cond(
+              canonicalEnvironment == canonicalJava,
+              environmentBase,
+              "TMPDIR and java.io.tmpdir must resolve to the same physical directory"
+            )
+          } yield selected
+      }
+    } yield result
+
+  def smokeChildOutputDirectoryValue(lane: os.Path): String =
+    lane.wrapped.toAbsolutePath.normalize().toString
+
+  def createSmokeTemporaryRunRoot(temporaryBase: os.Path): os.Path = {
+    val allocated = Files.createTempDirectory(temporaryBase.wrapped, "morphir-linker-smoke-")
+    os.Path.pathSerializer.withValue(LexicalPathSerializer)(os.Path(allocated))
+  }
+
+  private object LexicalPathSerializer extends os.Path.Serializer {
+    override def serializeString(path: os.Path): String     = path.wrapped.toString
+    override def serializeFile(path: os.Path): java.io.File = path.wrapped.toFile
+    override def serializePath(path: os.Path): Path         = path.wrapped
+    override def deserialize(value: String): Path           = java.nio.file.Paths.get(value)
+    override def deserialize(value: java.io.File): Path     = value.toPath
+    override def deserialize(value: Path): Path             = value
+    override def deserialize(value: java.net.URI): Path     = java.nio.file.Paths.get(value)
+  }
+
+  def validatePhysicalDescendant(base: os.Path, target: os.Path, message: String): Either[String, Path] =
+    for {
+      canonicalBase   <- canonicalPhysicalPath(base)
+      canonicalTarget <- canonicalPhysicalPath(target)
+      result          <- Either.cond(
+        canonicalTarget != canonicalBase && canonicalTarget.startsWith(canonicalBase),
+        canonicalTarget,
+        message
+      )
+    } yield result
+
+  def validateSmokeRunDirectory(workspace: os.Path, smokeBase: os.Path, smokeRun: os.Path): Either[String, Path] = {
+    val fixedRelativeBase = java.nio.file.Paths.get(".dev", ".sdlc", "mill-jvm-worker-pool", "out", "smoke")
+    val workspaceLexical  = workspace.wrapped.toAbsolutePath.normalize()
+    val baseLexical       = smokeBase.wrapped.toAbsolutePath.normalize()
+    val runLexical        = smokeRun.wrapped.toAbsolutePath.normalize()
+    val expectedBase      = workspaceLexical.resolve(fixedRelativeBase).normalize()
+
+    def containsSymlink: Boolean =
+      if !runLexical.startsWith(workspaceLexical) then true
+      else {
+        val relative = workspaceLexical.relativize(runLexical)
+        relative.iterator().asScala
+          .scanLeft(workspaceLexical)((current, segment) => current.resolve(segment))
+          .exists(Files.isSymbolicLink)
+      }
+
+    if baseLexical != expectedBase then Left("smoke base must be the generated workspace smoke directory")
+    else if containsSymlink then Left("smoke run directory must not contain symbolic links")
+    else
+      for {
+        canonicalWorkspace <- canonicalPhysicalPath(workspace)
+        canonicalBase      <- canonicalPhysicalPath(smokeBase)
+        canonicalRun       <- validatePhysicalDescendant(
+          smokeBase,
+          smokeRun,
+          "smoke run directory must be below the generated smoke directory"
+        )
+        expectedPhysicalBase = canonicalWorkspace.resolve(fixedRelativeBase).normalize()
+        result <- Either.cond(
+          canonicalBase == expectedPhysicalBase,
+          canonicalRun,
+          "smoke base resolves outside the generated workspace smoke directory"
+        )
+      } yield result
+  }
+
+  private val ChildOutputDirectoryCollision =
+    "benchmark child output directory must differ from the orchestrator output directory"
+
+  def validateChildOutputDirectory(orchestrator: os.Path, child: os.Path): Either[String, os.Path] =
+    for {
+      canonicalOrchestrator <- canonicalPhysicalPath(orchestrator)
+      canonicalChild        <- canonicalPhysicalPath(child)
+      result                <- Either.cond(
+        canonicalOrchestrator != canonicalChild,
+        child,
+        ChildOutputDirectoryCollision
+      )
+    } yield result
+
+  def validateExternalChildOutputDirectory(workspace: os.Path, child: os.Path): Either[String, os.Path] =
+    for {
+      canonicalWorkspace <- canonicalPhysicalPath(workspace)
+      canonicalChild     <- canonicalPhysicalPath(child)
+      result             <- Either.cond(
+        !canonicalChild.startsWith(canonicalWorkspace),
+        child,
+        "benchmark child output directory must be outside the workspace"
+      )
+    } yield result
+
+  def validateExternalSmokeCleanupRoot(
+      workspace: os.Path,
+      temporaryBase: os.Path,
+      runRoot: os.Path
+  ): Either[String, Path] = {
+    val runLexical = runRoot.wrapped.toAbsolutePath.normalize()
+    val name       = Option(runLexical.getFileName).fold("")(_.toString)
+    if Files.isSymbolicLink(runLexical) then Left("external smoke cleanup root must not be a symbolic link")
+    else if !Files.isDirectory(runLexical, LinkOption.NOFOLLOW_LINKS) then
+      Left("external smoke cleanup root must be an existing directory")
+    else if !name.startsWith("morphir-linker-smoke-") || name == "morphir-linker-smoke-" then
+      Left("external smoke cleanup root must have the generated smoke prefix")
+    else
+      for {
+        canonicalWorkspace <- canonicalPhysicalPath(workspace)
+        canonicalBase      <- canonicalPhysicalPath(temporaryBase)
+        canonicalRun       <- canonicalPhysicalPath(runRoot)
+        result             <- Either.cond(
+          canonicalRun.getParent == canonicalBase && !canonicalRun.startsWith(canonicalWorkspace),
+          canonicalRun,
+          "external smoke cleanup root must be a direct temporary child outside the workspace"
+        )
+      } yield result
+  }
+
+  def validate(profile: Profile): Either[String, Profile] =
+    if profile.memoryGiB <= 0 then Left("memoryGiB must be greater than zero")
+    else if profile.reserveGiB < 0 then Left("reserveGiB must be nonnegative")
+    else if profile.heapGiB <= 0 then Left("heapGiB must be greater than zero")
+    else if profile.millJobs <= 0 then Left("millJobs must be greater than zero")
+    else if profile.maxChildren <= 0 then Left("maxChildren must be greater than zero")
+    else if profile.batchSize <= 0 then Left("batchSize must be greater than zero")
+    else if profile.timeoutMinutes <= 0 then Left("timeoutMinutes must be greater than zero")
+    else if profile.maxChildren.toLong * profile.heapGiB + profile.reserveGiB > profile.memoryGiB then
+      Left("child heaps and reserve exceed available memory")
+    else Right(profile)
+
+  def validate(settings: EvaluationSettings): Either[String, EvaluationSettings] =
+    if settings.trials <= 0 then Left("trials must be greater than zero")
+    else Right(settings)
+
+  def strategyOrders(strategies: Seq[Strategy], settings: EvaluationSettings): Seq[Seq[Strategy]] = {
+    val canonical = strategies.distinct.sortBy(_.ordinal)
+    if canonical.isEmpty || validate(settings).isLeft then Seq.empty
+    else {
+      val seedOffset = Math.floorMod(settings.orderSeed, canonical.size.toLong).toInt
+      (0 until settings.trials).map { trial =>
+        val offset = (seedOffset + trial % canonical.size) % canonical.size
+        canonical.drop(offset) ++ canonical.take(offset)
+      }
+    }
+  }
+
+  def plan(targets: Seq[String], lanes: Int, batchSize: Int): Either[String, WorkPlan] =
+    if targets.isEmpty then Left("targets must not be empty")
+    else if lanes <= 0 then Left("lanes must be greater than zero")
+    else if batchSize <= 0 then Left("batchSize must be greater than zero")
+    else {
+      val batches = targets.distinct.sorted.grouped(batchSize).zipWithIndex.map { case (batchTargets, index) =>
+        Batch(lane = index % lanes, index = index, targets = batchTargets)
+      }.toSeq.sortBy(batch => (batch.lane, batch.index))
+      Right(WorkPlan(lanes, batches))
+    }
+
+  def strategyPlan(strategy: Strategy, targets: Seq[String], profile: Profile): Either[String, WorkPlan] =
+    validate(profile).flatMap { admitted =>
+      strategy match {
+        case Strategy.LongLived => plan(targets, lanes = 1, batchSize = targets.distinct.size)
+        case Strategy.Fresh     => plan(targets, lanes = admitted.maxChildren, batchSize = 1)
+        case Strategy.Recycled  => plan(targets, lanes = admitted.maxChildren, batchSize = admitted.batchSize)
+      }
+    }
+
+  def preparationLanes(plan: WorkPlan): Seq[PreparationLane] =
+    plan.batches
+      .groupBy(_.lane)
+      .toSeq
+      .sortBy(_._1)
+      .map { case (lane, batches) => PreparationLane(lane, batches.sortBy(_.index)) }
+
+  def millChildArguments(profile: Profile, arguments: Seq[String]): Seq[String] =
+    Seq("--ticker", "false", "--no-daemon", "-j", profile.millJobs.toString) ++ arguments
+
+  def runConcurrentLanes[A](
+      parallelism: Int,
+      tasks: Seq[() => A],
+      cleanupTimeout: FiniteDuration
+  ): Seq[A] = {
+    require(parallelism > 0, "parallelism must be positive")
+    require(cleanupTimeout > Duration.Zero, "cleanup timeout must be positive")
+    if tasks.isEmpty then Seq.empty
+    else {
+      val executor   = Executors.newFixedThreadPool(math.min(parallelism, tasks.size))
+      val completion = new ExecutorCompletionService[(Int, A)](executor)
+      val futures    = tasks.zipWithIndex.map { case (task, index) =>
+        completion.submit(new Callable[(Int, A)] {
+          override def call(): (Int, A) = index -> task()
+        })
+      }
+      def takeCompleted(): Either[(Throwable, Boolean), (Int, A)] =
+        try Right(completion.take().get())
+        catch {
+          case error: InterruptedException => Left(error -> true)
+          case error: ExecutionException   => Left(Option(error.getCause).getOrElse(error) -> false)
+          case NonFatal(error)             => Left(error -> false)
+        }
+
+      @tailrec def loop(
+          remaining: Int,
+          results: Vector[Option[A]]
+      ): (Vector[Option[A]], Option[Throwable], Boolean) =
+        if remaining == 0 then (results, None, false)
+        else
+          takeCompleted() match {
+            case Right((index, value))         => loop(remaining - 1, results.updated(index, Some(value)))
+            case Left((error, wasInterrupted)) => (results, Some(error), wasInterrupted)
+          }
+
+      val (results, initialPrimary, initiallyInterrupted) =
+        loop(tasks.size, Vector.fill(tasks.size)(None))
+      var primary     = initialPrimary.orNull
+      var interrupted = initiallyInterrupted
+      if primary != null then {
+        futures.foreach(_.cancel(true))
+        executor.shutdownNow()
+      } else executor.shutdown()
+
+      def awaitTermination(timeout: FiniteDuration): Boolean = {
+        val deadline                 = System.nanoTime() + timeout.toNanos
+        @tailrec def loop(): Boolean = {
+          val remainingNanos = deadline - System.nanoTime()
+          if remainingNanos <= 0L then executor.isTerminated
+          else
+            try executor.awaitTermination(remainingNanos, TimeUnit.NANOSECONDS)
+            catch {
+              case error: InterruptedException =>
+                interrupted = true
+                if primary == null then primary = error else primary.addSuppressed(error)
+                executor.shutdownNow()
+                loop()
+            }
+        }
+        loop()
+      }
+
+      val terminated        = awaitTermination(cleanupTimeout)
+      val finallyTerminated =
+        if terminated then true
+        else {
+          futures.foreach(_.cancel(true))
+          executor.shutdownNow()
+          awaitTermination(cleanupTimeout)
+        }
+      if !finallyTerminated then {
+        val cleanupFailure = IllegalStateException("concurrent lane executor did not terminate after cancellation")
+        if primary == null then primary = cleanupFailure else primary.addSuppressed(cleanupFailure)
+      }
+      if interrupted then Thread.currentThread().interrupt()
+      if primary != null then throw primary
+      results.iterator.map(_.getOrElse(throw IllegalStateException("concurrent lane result is missing"))).toSeq
+    }
+  }
+
+  def writeTextAtomically(path: os.Path, value: String): Unit =
+    writeTextAtomically(
+      path,
+      value,
+      (temporary, target) =>
+        try
+          Files.move(temporary, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+        catch {
+          case error: AtomicMoveNotSupportedException =>
+            throw new Exception(s"atomic move is not supported for ${path.last}", error)
+        }
+    )
+
+  private[millbuild] def writeTextAtomically(
+      path: os.Path,
+      value: String,
+      move: (Path, Path) => Unit
+  ): Unit = {
+    val parent = path.toNIO.toAbsolutePath.normalize().getParent
+    Files.createDirectories(parent)
+    val temporary = Files.createTempFile(parent, s".${path.last}.tmp-", ".part")
+    try {
+      Files.writeString(temporary, value, StandardCharsets.UTF_8)
+      move(temporary, path.toNIO)
+    } catch {
+      case NonFatal(error) =>
+        Files.deleteIfExists(temporary)
+        throw error
+    }
+  }
+}

--- a/mill-build/src/millbuild/LinkerBenchmark.scala
+++ b/mill-build/src/millbuild/LinkerBenchmark.scala
@@ -109,6 +109,48 @@ object LinkerBenchmark {
 
   val ciProfile: Profile = Profile("ci", 16, 4, 8, 2, 1, 4, 30)
 
+  def workerProfileArguments(profile: Profile): Seq[String] =
+    Seq(
+      "--profile",
+      profile.name,
+      "--memoryGib",
+      profile.memoryGiB.toString,
+      "--reserveGib",
+      profile.reserveGiB.toString,
+      "--heapGib",
+      profile.heapGiB.toString,
+      "--millJobs",
+      profile.millJobs.toString,
+      "--maxChildren",
+      profile.maxChildren.toString,
+      "--batchSize",
+      profile.batchSize.toString,
+      "--timeoutMinutes",
+      profile.timeoutMinutes.toString
+    )
+
+  def reconstructWorkerProfile(
+      base: Profile,
+      memoryGiB: Int,
+      reserveGiB: Int,
+      heapGiB: Int,
+      millJobs: Int,
+      maxChildren: Int,
+      batchSize: Int,
+      timeoutMinutes: Int
+  ): Either[String, Profile] =
+    validate(
+      base.copy(
+        memoryGiB = memoryGiB,
+        reserveGiB = reserveGiB,
+        heapGiB = heapGiB,
+        millJobs = millJobs,
+        maxChildren = maxChildren,
+        batchSize = batchSize,
+        timeoutMinutes = timeoutMinutes
+      )
+    )
+
   def localProfile(memoryGiB: Int, availableProcessors: Int): Either[String, Profile] =
     if memoryGiB <= 0 then Left("local memory budget must be greater than zero")
     else if availableProcessors <= 0 then Left("local available processors must be greater than zero")
@@ -240,8 +282,8 @@ object LinkerBenchmark {
    * these individual limits.
    */
   val maxHostedTrials: Int         = 100
-  val maxHostedMemoryGiB: Int      = 64
-  val maxHostedReserveGiB: Int     = 63
+  val maxHostedMemoryGiB: Int      = 16
+  val maxHostedReserveGiB: Int     = 15
   val maxHostedMillJobs: Int       = 64
   val maxHostedChildren: Int       = 16
   val maxHostedBatchSize: Int      = 256
@@ -736,6 +778,129 @@ object LinkerBenchmark {
       runtime: RuntimeMetadata = RuntimeMetadata.Unknown
   ) derives ReadWriter
 
+  final case class WorkerIdentity(
+      runId: String,
+      settings: EvaluationSettings,
+      platform: Platform,
+      strategy: Strategy,
+      profile: Profile,
+      trial: Int,
+      strategyPosition: Int,
+      lane: Int,
+      batch: Int,
+      targets: Seq[String]
+  )
+
+  object WorkerIdentity {
+    def from(record: WorkerRecord): WorkerIdentity =
+      WorkerIdentity(
+        record.runId,
+        record.settings,
+        record.platform,
+        record.strategy,
+        record.profile,
+        record.trial,
+        record.strategyPosition,
+        record.lane,
+        record.batch,
+        record.targets
+      )
+  }
+
+  def workerCommandArguments(record: String, started: String, identity: WorkerIdentity): Seq[String] =
+    Seq(
+      "ci.linkerBenchmarkWorker",
+      "--record",
+      record,
+      "--started",
+      started,
+      "--runId",
+      identity.runId,
+      "--platform",
+      identity.platform.token,
+      "--strategy",
+      identity.strategy.token
+    ) ++ workerProfileArguments(identity.profile) ++ Seq(
+      "--trials",
+      identity.settings.trials.toString,
+      "--orderSeed",
+      identity.settings.orderSeed.toString,
+      "--trial",
+      identity.trial.toString,
+      "--strategyPosition",
+      identity.strategyPosition.toString,
+      "--lane",
+      identity.lane.toString,
+      "--batch",
+      identity.batch.toString,
+      "--targets",
+      identity.targets.mkString(",")
+    )
+
+  def validateWorkerRecordIdentity(
+      record: WorkerRecord,
+      expected: WorkerIdentity
+  ): Either[String, WorkerRecord] =
+    Either.cond(
+      WorkerIdentity.from(record) == expected,
+      record,
+      "worker record identity does not match the scheduled worker"
+    )
+
+  def clearWorkerLaunchMarkers(directory: os.Path): Either[String, Unit] = {
+    val lexicalDirectory = directory.toNIO.toAbsolutePath.normalize()
+    val markers          = Seq("record.json", "started").map(lexicalDirectory.resolve)
+
+    def validMarker(path: Path): Boolean =
+      path.getParent == lexicalDirectory &&
+        (!Files.exists(path, LinkOption.NOFOLLOW_LINKS) ||
+          Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS))
+
+    if !Files.isDirectory(lexicalDirectory, LinkOption.NOFOLLOW_LINKS) then
+      Left("worker output directory must be a regular directory")
+    else if !markers.forall(validMarker) then Left("worker launch markers must be regular files")
+    else
+      try {
+        markers.foreach(Files.deleteIfExists)
+        Right(())
+      } catch {
+        case NonFatal(error) => Left(s"cannot clear worker launch markers: ${error.getClass.getSimpleName}")
+      }
+  }
+
+  /**
+   * Validates the existing ancestor chain before creating a worker directory. This assumes a trusted local filesystem
+   * where another process does not replace a validated parent between validation and creation.
+   */
+  def prepareWorkerOutputDirectory(outputRoot: os.Path, requested: os.Path): Either[String, os.Path] = {
+    val message          = "worker output directory escaped benchmark output"
+    val lexicalRoot      = outputRoot.toNIO.toAbsolutePath.normalize()
+    val lexicalRequested = requested.toNIO.toAbsolutePath.normalize()
+    val containsSymlink  =
+      lexicalRequested.startsWith(lexicalRoot) &&
+        lexicalRoot
+          .relativize(lexicalRequested)
+          .iterator()
+          .asScala
+          .scanLeft(lexicalRoot)((current, segment) => current.resolve(segment))
+          .exists(Files.isSymbolicLink)
+
+    if lexicalRequested == lexicalRoot || !lexicalRequested.startsWith(lexicalRoot) then Left(message)
+    else if containsSymlink then Left("worker output directory must not contain symbolic links")
+    else
+      validatePhysicalDescendant(outputRoot, requested, message).flatMap { physicalRequested =>
+        val directory = os.Path(physicalRequested)
+        try {
+          os.makeDir.all(directory)
+          validatePhysicalDescendant(outputRoot, directory, message)
+            .map(os.Path(_))
+            .flatMap(validated => clearWorkerLaunchMarkers(validated).map(_ => validated))
+        } catch {
+          case NonFatal(error) => Left(s"cannot prepare worker output directory: ${error.getClass.getSimpleName}")
+        }
+      }
+  }
+
   final case class StrategyTrialRecord(
       runId: String,
       trial: Int,
@@ -762,6 +927,49 @@ object LinkerBenchmark {
   ) derives ReadWriter
 
   final case class PreparationDecision(measure: Boolean, outcome: Outcome, failRun: Boolean)
+
+  final case class EvaluationCase(
+      trial: Int,
+      strategyPosition: Int,
+      platform: Platform,
+      strategy: Strategy
+  )
+
+  def evaluationSchedule(orders: Seq[Seq[Strategy]], platforms: Seq[Platform]): Seq[EvaluationCase] =
+    orders.zipWithIndex.flatMap { case (order, trial) =>
+      order.zipWithIndex.flatMap { case (strategy, position) =>
+        platforms.map(platform => EvaluationCase(trial, position, platform, strategy))
+      }
+    }
+
+  def runEvaluationSchedule[A](
+      scheduled: Seq[A],
+      continueOnFailure: Boolean
+  )(run: A => Outcome): Seq[(A, Outcome)] = {
+    @tailrec def loop(remaining: List[A], completed: Vector[(A, Outcome)]): Vector[(A, Outcome)] =
+      remaining match {
+        case Nil          => completed
+        case next :: tail =>
+          val outcome = run(next)
+          val updated = completed :+ (next -> outcome)
+          if outcome == Outcome.Succeeded || continueOnFailure then loop(tail, updated)
+          else updated
+      }
+
+    loop(scheduled.toList, Vector.empty)
+  }
+
+  def runBatchesUntilInterrupted[A, B](batches: Seq[A])(run: A => B): Seq[B] = {
+    @tailrec def loop(remaining: List[A], completed: Vector[B]): Vector[B] =
+      if Thread.currentThread().isInterrupted then completed
+      else
+        remaining match {
+          case Nil          => completed
+          case head :: tail => loop(tail, completed :+ run(head))
+        }
+
+    loop(batches.toList, Vector.empty)
+  }
 
   def preparationDecision(outcomes: Seq[Outcome], continueOnFailure: Boolean): PreparationDecision = {
     val outcome =

--- a/mill-build/src/millbuild/LinkerBenchmark.scala
+++ b/mill-build/src/millbuild/LinkerBenchmark.scala
@@ -277,9 +277,9 @@ object LinkerBenchmark {
   ).map(configuration => configuration.preset -> configuration).toMap
 
   /**
-   * Bounds manual hosted dispatches to an ubuntu-latest-sized machine and GitHub's six-hour job envelope while leaving
-   * enough range for diagnostic repetitions. Profile admission applies the stricter cross-field memory constraint after
-   * these individual limits.
+   * Bounds manual hosted dispatches to an ubuntu-latest-sized machine and GitHub's six-hour job envelope. The
+   * per-operation timeout leaves 30 minutes for teardown, report writing, and artifact publication. Profile admission
+   * applies the stricter cross-field memory constraint after these individual limits.
    */
   val maxHostedTrials: Int         = 100
   val maxHostedMemoryGiB: Int      = 16
@@ -287,7 +287,7 @@ object LinkerBenchmark {
   val maxHostedMillJobs: Int       = 64
   val maxHostedChildren: Int       = 16
   val maxHostedBatchSize: Int      = 256
-  val maxHostedTimeoutMinutes: Int = 360
+  val maxHostedTimeoutMinutes: Int = 330
   val maxHostedTargetLimit: Int    = 10_000
 
   def parseOptionalTrimmedString(value: String, field: String): Either[String, Option[String]] =
@@ -958,6 +958,9 @@ object LinkerBenchmark {
 
     loop(scheduled.toList, Vector.empty)
   }
+
+  def evaluationFailed(outcomes: Seq[Outcome]): Boolean =
+    outcomes.exists(_ != Outcome.Succeeded)
 
   def runBatchesUntilInterrupted[A, B](batches: Seq[A])(run: A => B): Seq[B] = {
     @tailrec def loop(remaining: List[A], completed: Vector[B]): Vector[B] =

--- a/mill-build/src/millbuild/LinkerBenchmarkProcess.scala
+++ b/mill-build/src/millbuild/LinkerBenchmarkProcess.scala
@@ -1,0 +1,463 @@
+package millbuild
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong, AtomicReference}
+import java.util.concurrent.{
+  ConcurrentHashMap, Executors, ScheduledExecutorService, ScheduledFuture, ThreadFactory, TimeUnit
+}
+
+import scala.annotation.tailrec
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+import scala.jdk.OptionConverters.*
+import scala.util.control.NonFatal
+
+object LinkerBenchmarkProcess {
+  final case class ProcessResult(
+      outcome: LinkerBenchmark.Outcome,
+      exitCode: Option[Int],
+      wallMillis: Long,
+      startupMillis: Option[Long],
+      peakRssKiB: Long,
+      detail: String
+  )
+
+  final case class AggregateRssSnapshot(
+      wholeRunPeakKiB: Long,
+      strategyWindowPeakKiB: Long,
+      detail: String
+  )
+
+  private final case class RssProbe(valueKiB: Long, detail: Option[String])
+  private final case class ChildSnapshot(
+      startupMillis: Option[Long],
+      peakRssKiB: Long,
+      rssDetail: Option[String],
+      observed: Set[ProcessHandle]
+  )
+  private final case class CleanupResult(clean: Boolean, detail: Option[String])
+
+  private val CleanupPollMillis = 25L
+  private val CleanupMillis     = 5000L
+  // ps is a process itself; fixed-delay sampling avoids overlapping probes and 25 ms process churn.
+  private val ChildSampleMillis = 150L
+
+  private def elapsedMillis(startNanos: Long): Long =
+    math.max(0L, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos))
+
+  private def saturatingSum(values: IterableOnce[Long]): Long = {
+    val iterator                         = values.iterator
+    @tailrec def loop(total: Long): Long =
+      if !iterator.hasNext then total
+      else {
+        val value = math.max(0L, iterator.next())
+        if total > Long.MaxValue - value then Long.MaxValue else loop(total + value)
+      }
+    loop(0L)
+  }
+
+  private def updateMax(target: AtomicLong, value: Long): Unit = {
+    @tailrec def loop(): Unit = {
+      val current = target.get()
+      if value <= current then ()
+      else if !target.compareAndSet(current, value) then loop()
+    }
+    loop()
+  }
+
+  def composeEnvironment(
+      inherited: Map[String, String],
+      additions: Map[String, String],
+      removals: Set[String]
+  ): Map[String, String] = (inherited -- removals) ++ additions
+
+  def peakAggregateRssKiB(samples: Seq[Seq[(Long, Long)]]): Long =
+    samples.iterator
+      .map { sample =>
+        val rssByPid = sample.iterator
+          .filter { case (pid, rss) => pid >= 0L && rss >= 0L }
+          .toSeq
+          .groupMapReduce(_._1)(_._2)(math.max)
+        saturatingSum(rssByPid.values)
+      }
+      .maxOption
+      .getOrElse(0L)
+
+  private[millbuild] def outcomeAfterCleanup(
+      outcome: LinkerBenchmark.Outcome,
+      clean: Boolean
+  ): LinkerBenchmark.Outcome =
+    if outcome == LinkerBenchmark.Outcome.Succeeded && !clean then LinkerBenchmark.Outcome.Failed else outcome
+
+  private def normalizeDetail(value: String, environmentValues: Iterable[String] = Seq.empty): String = {
+    val redacted = environmentValues.iterator
+      .filter(_.nonEmpty)
+      .foldLeft(value)((current, secret) => current.replace(secret, "<redacted>"))
+    val normalized = redacted.replaceAll("[\\p{Cntrl}\\s]+", " ").trim
+    if normalized.length <= 240 then normalized else normalized.take(237) + "..."
+  }
+
+  private def descendants(root: ProcessHandle): Seq[ProcessHandle] =
+    try {
+      val stream = root.descendants()
+      try stream.iterator().asScala.toSeq
+      finally stream.close()
+    } catch {
+      case NonFatal(_) => Seq.empty
+    }
+
+  private def liveTree(roots: IterableOnce[ProcessHandle]): Seq[ProcessHandle] =
+    roots.iterator
+      .flatMap(root => root +: descendants(root))
+      .filter(_.isAlive)
+      .toSeq
+      .groupBy(_.pid())
+      .valuesIterator
+      .map(_.head)
+      .toSeq
+
+  private def sampleRss(handles: IterableOnce[ProcessHandle], waitMillis: Long = 250L): RssProbe = {
+    val pids = handles.iterator.filter(_.isAlive).map(_.pid()).toSet.toSeq.sorted
+    if pids.isEmpty then RssProbe(0L, None)
+    else {
+      val command = Seq("ps", "-o", "rss=", "-p", pids.mkString(","))
+      try {
+        val process = new ProcessBuilder(command.asJava).redirectErrorStream(true).start()
+        try {
+          val exited = process.waitFor(math.max(1L, waitMillis), TimeUnit.MILLISECONDS)
+          if !exited then RssProbe(0L, Some("rss unavailable: ps timed out"))
+          else if process.exitValue() != 0 then
+            RssProbe(0L, Some(s"rss unavailable: ps exited ${process.exitValue()}"))
+          else {
+            val bytes  = process.getInputStream.readAllBytes()
+            val lines  = String(bytes, StandardCharsets.UTF_8).linesIterator.map(_.trim).filter(_.nonEmpty).toSeq
+            val parsed = lines.map(_.toLongOption).collect { case Some(value) if value >= 0L => value }
+            if parsed.size != lines.size then RssProbe(0L, Some("rss unavailable: unparseable ps output"))
+            else RssProbe(saturatingSum(parsed), None)
+          }
+        } finally {
+          if process.isAlive then process.destroyForcibly()
+          process.getInputStream.close()
+          process.getErrorStream.close()
+          process.getOutputStream.close()
+        }
+      } catch {
+        case _: InterruptedException =>
+          Thread.currentThread().interrupt()
+          RssProbe(0L, Some("rss unavailable: ps interrupted"))
+        case NonFatal(error) =>
+          RssProbe(0L, Some(s"rss unavailable: ${error.getClass.getSimpleName}"))
+      }
+    }
+  }
+
+  private def expandOwned(root: ProcessHandle, observed: java.util.Set[ProcessHandle]): Seq[ProcessHandle] = {
+    val owners     = root +: observed.asScala.toSeq
+    val discovered = owners.flatMap(descendants)
+    discovered.foreach(observed.add)
+    observed.asScala.toSeq
+  }
+
+  private def awaitExecutorTermination(executor: ScheduledExecutorService, timeoutMillis: Long): Unit = {
+    val deadline              = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis)
+    var interrupted           = false
+    @tailrec def loop(): Unit = {
+      val remaining = deadline - System.nanoTime()
+      if remaining <= 0L then ()
+      else
+        try
+          if !executor.awaitTermination(remaining, TimeUnit.NANOSECONDS) then ()
+        catch {
+          case _: InterruptedException =>
+            interrupted = true
+            loop()
+        }
+    }
+    try loop()
+    finally if interrupted then Thread.currentThread().interrupt()
+  }
+
+  private def cleanup(
+      root: ProcessHandle,
+      observed: java.util.Set[ProcessHandle],
+      terminateRoot: Boolean
+  ): CleanupResult = {
+    val start         = System.nanoTime()
+    val graceDeadline = start + TimeUnit.MILLISECONDS.toNanos(CleanupMillis - 1000L)
+    val forceDeadline = start + TimeUnit.MILLISECONDS.toNanos(CleanupMillis)
+    val requested     = ConcurrentHashMap.newKeySet[ProcessHandle]()
+    var interrupted   = false
+
+    def targets(): Seq[ProcessHandle] = {
+      val owned = expandOwned(root, observed).filter(_.isAlive)
+      if terminateRoot && root.isAlive then owned :+ root else owned
+    }
+
+    def pause(): Unit =
+      try Thread.sleep(CleanupPollMillis)
+      catch {
+        case _: InterruptedException => interrupted = true
+      }
+
+    @tailrec def graceful(): Seq[ProcessHandle] = {
+      val live = targets()
+      live.filterNot(handle => requested.contains(handle)).foreach { handle =>
+        handle.destroy()
+        requested.add(handle)
+      }
+      if live.isEmpty || System.nanoTime() >= graceDeadline then live
+      else {
+        pause()
+        graceful()
+      }
+    }
+
+    @tailrec def force(): Seq[ProcessHandle] = {
+      val live = targets()
+      live.foreach(_.destroyForcibly())
+      if live.isEmpty || System.nanoTime() >= forceDeadline then live
+      else {
+        pause()
+        force()
+      }
+    }
+
+    try {
+      val afterGrace = graceful()
+      val survivors  = if afterGrace.isEmpty then Seq.empty else force()
+      if survivors.isEmpty then CleanupResult(clean = true, None)
+      else CleanupResult(clean = false, Some(s"cleanup failed: ${survivors.size} owned process(es) survived"))
+    } finally if interrupted then Thread.currentThread().interrupt()
+  }
+
+  private final class ProcessSampler(
+      root: ProcessHandle,
+      startNanos: Long,
+      startupMarker: os.Path
+  ) extends AutoCloseable {
+    private val stopped   = new AtomicBoolean(false)
+    private val peakRss   = new AtomicLong(0L)
+    private val startup   = new AtomicReference(Option.empty[Long])
+    private val rssError  = new AtomicReference(Option.empty[String])
+    private val observed  = ConcurrentHashMap.newKeySet[ProcessHandle]()
+    private val scheduler = Executors.newSingleThreadScheduledExecutor(new ThreadFactory {
+      override def newThread(runnable: Runnable): Thread = {
+        val thread = new Thread(runnable, "linker-benchmark-child-sampler")
+        thread.setDaemon(true)
+        thread
+      }
+    })
+
+    private def observeStartup(): Unit =
+      if startup.get().isEmpty && os.exists(startupMarker) then
+        startup.compareAndSet(None, Some(elapsedMillis(startNanos)))
+
+    private def tick(): Unit =
+      if !stopped.get() then {
+        try {
+          observeStartup()
+          val owned = expandOwned(root, observed)
+          val probe = sampleRss(root +: owned)
+          updateMax(peakRss, probe.valueKiB)
+          probe.detail.foreach(value => rssError.compareAndSet(None, Some(value)))
+        } catch {
+          case NonFatal(error) =>
+            rssError.compareAndSet(None, Some(s"rss unavailable: ${error.getClass.getSimpleName}"))
+        }
+      }
+
+    private val scheduled = scheduler.scheduleWithFixedDelay(
+      () => tick(),
+      0L,
+      ChildSampleMillis,
+      TimeUnit.MILLISECONDS
+    )
+
+    def snapshot(): ChildSnapshot = {
+      observeStartup()
+      ChildSnapshot(startup.get(), peakRss.get(), rssError.get(), observed.asScala.toSet)
+    }
+
+    def observedHandles: java.util.Set[ProcessHandle] = observed
+
+    override def close(): Unit =
+      if stopped.compareAndSet(false, true) then {
+        scheduled.cancel(true)
+        scheduler.shutdownNow()
+        awaitExecutorTermination(scheduler, 1000L)
+      }
+  }
+
+  def run(
+      command: Seq[String],
+      workingDirectory: os.Path,
+      environment: Map[String, String],
+      timeout: FiniteDuration,
+      startupMarker: os.Path,
+      stdout: os.Path,
+      stderr: os.Path,
+      environmentRemovals: Set[String] = Set.empty
+  ): ProcessResult = {
+    val startNanos = System.nanoTime()
+    if command.isEmpty then
+      ProcessResult(LinkerBenchmark.Outcome.Failed, None, elapsedMillis(startNanos), None, 0L, "empty command")
+    else if timeout <= Duration.Zero then
+      ProcessResult(
+        LinkerBenchmark.Outcome.Failed,
+        None,
+        elapsedMillis(startNanos),
+        None,
+        0L,
+        "timeout must be positive"
+      )
+    else {
+      var process: Process        = null
+      var sampler: ProcessSampler = null
+      var interrupted             = false
+
+      def finish(
+          outcome: LinkerBenchmark.Outcome,
+          exitCode: Option[Int],
+          baseDetail: String,
+          terminateRoot: Boolean
+      ): ProcessResult = {
+        if sampler != null then sampler.close()
+        val snapshot =
+          if sampler == null then ChildSnapshot(None, 0L, None, Set.empty)
+          else sampler.snapshot()
+        val retired =
+          if process == null then CleanupResult(clean = true, None)
+          else {
+            val observed =
+              if sampler == null then ConcurrentHashMap.newKeySet[ProcessHandle]() else sampler.observedHandles
+            cleanup(process.toHandle, observed, terminateRoot)
+          }
+        val finalOutcome = outcomeAfterCleanup(outcome, retired.clean)
+        val detail       = normalizeDetail(
+          (Seq(baseDetail) ++ snapshot.rssDetail ++ retired.detail).mkString("; "),
+          environment.values
+        )
+        ProcessResult(
+          finalOutcome,
+          exitCode,
+          elapsedMillis(startNanos),
+          snapshot.startupMillis,
+          snapshot.peakRssKiB,
+          detail
+        )
+      }
+
+      try {
+        java.nio.file.Files.deleteIfExists(startupMarker.toNIO)
+        val builder = new ProcessBuilder(command.asJava)
+          .directory(workingDirectory.toIO)
+          .redirectOutput(ProcessBuilder.Redirect.to(stdout.toIO))
+          .redirectError(ProcessBuilder.Redirect.to(stderr.toIO))
+        val childEnvironment = builder.environment()
+        val composed         = composeEnvironment(childEnvironment.asScala.toMap, environment, environmentRemovals)
+        childEnvironment.clear()
+        childEnvironment.putAll(composed.asJava)
+        process = builder.start()
+        sampler = new ProcessSampler(process.toHandle, startNanos, startupMarker)
+        val remaining = timeout.toNanos - (System.nanoTime() - startNanos)
+        val exited    = remaining > 0L && process.waitFor(remaining, TimeUnit.NANOSECONDS)
+        if exited then {
+          val exitCode = process.exitValue()
+          val outcome  = if exitCode == 0 then LinkerBenchmark.Outcome.Succeeded else LinkerBenchmark.Outcome.Failed
+          val base     = if exitCode == 0 then "completed" else s"exit $exitCode"
+          finish(outcome, Some(exitCode), base, terminateRoot = false)
+        } else finish(LinkerBenchmark.Outcome.TimedOut, None, "timed out", terminateRoot = true)
+      } catch {
+        case _: InterruptedException =>
+          interrupted = true
+          finish(LinkerBenchmark.Outcome.Cancelled, None, "cancelled", terminateRoot = true)
+        case NonFatal(error) =>
+          finish(
+            LinkerBenchmark.Outcome.Failed,
+            None,
+            s"launch failed: ${error.getClass.getSimpleName}",
+            terminateRoot = process != null && process.isAlive
+          )
+      } finally {
+        if sampler != null then sampler.close()
+        if process != null then {
+          process.getInputStream.close()
+          process.getErrorStream.close()
+          process.getOutputStream.close()
+        }
+        if interrupted then Thread.currentThread().interrupt()
+      }
+    }
+  }
+
+  final class AggregateRssSampler private (
+      orchestratorPid: Long,
+      activeChildRoots: () => Iterable[ProcessHandle],
+      interval: FiniteDuration
+  ) extends AutoCloseable {
+    private val stopped                             = new AtomicBoolean(false)
+    private val lastDetail                          = new AtomicReference(Option.empty[String])
+    private val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(new ThreadFactory {
+      override def newThread(runnable: Runnable): Thread = {
+        val thread = new Thread(runnable, "linker-benchmark-rss")
+        thread.setDaemon(true)
+        thread
+      }
+    })
+    private var wholeRunPeakKiB       = 0L
+    private var strategyWindowPeakKiB = 0L
+
+    private def tick(): Unit = synchronized {
+      if !stopped.get() then {
+        try {
+          val orchestrator = ProcessHandle.of(orchestratorPid).toScala.toSeq
+          val roots        = orchestrator ++ activeChildRoots().iterator.toSeq
+          val probe        = sampleRss(liveTree(roots))
+          wholeRunPeakKiB = math.max(wholeRunPeakKiB, probe.valueKiB)
+          strategyWindowPeakKiB = math.max(strategyWindowPeakKiB, probe.valueKiB)
+          probe.detail.foreach(value => lastDetail.compareAndSet(None, Some(value)))
+        } catch {
+          case NonFatal(error) =>
+            lastDetail.compareAndSet(None, Some(s"rss unavailable: ${error.getClass.getSimpleName}"))
+        }
+      }
+    }
+
+    private val scheduled: ScheduledFuture[?] = scheduler.scheduleAtFixedRate(
+      () => tick(),
+      0L,
+      math.max(1L, interval.toMillis),
+      TimeUnit.MILLISECONDS
+    )
+
+    def snapshot(): AggregateRssSnapshot = synchronized {
+      AggregateRssSnapshot(wholeRunPeakKiB, strategyWindowPeakKiB, lastDetail.get().getOrElse(""))
+    }
+
+    def resetStrategyWindow(): AggregateRssSnapshot = synchronized {
+      val previous = snapshot()
+      strategyWindowPeakKiB = 0L
+      previous
+    }
+
+    def stop(): Unit =
+      if stopped.compareAndSet(false, true) then {
+        scheduled.cancel(true)
+        scheduler.shutdownNow()
+        awaitExecutorTermination(scheduler, 1000L)
+      }
+
+    override def close(): Unit = stop()
+  }
+
+  object AggregateRssSampler {
+    def start(
+        orchestratorPid: Long,
+        activeChildRoots: () => Iterable[ProcessHandle],
+        interval: FiniteDuration = 100.millis
+    ): AggregateRssSampler = {
+      require(interval > Duration.Zero, "RSS sample interval must be positive")
+      new AggregateRssSampler(orchestratorPid, activeChildRoots, interval)
+    }
+  }
+}

--- a/mill-build/src/millbuild/NativeTestSelectors.scala
+++ b/mill-build/src/millbuild/NativeTestSelectors.scala
@@ -1,0 +1,33 @@
+package millbuild
+
+/** Test selectors and deterministic process-shard selection for Scala Native CI. */
+object NativeTestSelectors {
+  val compileSelector: String = "morphir.__.native.__.compile"
+  val publishSelector: String = "morphir.__.native.publishArtifacts"
+  val testSelector: String    = "morphir.__.native.__.test"
+
+  val prepareSelectors: Seq[String] = Seq(compileSelector, publishSelector)
+
+  /**
+   * Selects one exhaustive, disjoint shard after sorting and deduplicating Mill's resolved targets.
+   *
+   * The caller runs each shard in a separate daemonless Mill invocation. That process boundary is what releases the
+   * Scala Native linker worker and its retained heap between shards; partitioning inside one evaluation would not.
+   */
+  def selectShard(
+      resolved: Seq[String],
+      shard: Int,
+      shards: Int,
+      what: String
+  ): Either[String, Seq[String]] =
+    if shards <= 0 then Left(s"$what: shards must be greater than zero")
+    else if shard < 0 || shard >= shards then
+      Left(s"$what: shard $shard is outside the valid range 0..${shards - 1}")
+    else {
+      val selected = resolved.distinct.sorted.zipWithIndex.collect {
+        case (target, index) if index % shards == shard => target
+      }
+      if selected.isEmpty then Left(s"$what: no targets remain for shard $shard of $shards")
+      else Right(selected)
+    }
+}

--- a/millbuildHelpers/test/src/millbuild/LinkerBenchmarkProcessTests.scala
+++ b/millbuildHelpers/test/src/millbuild/LinkerBenchmarkProcessTests.scala
@@ -1,0 +1,490 @@
+package millbuild
+
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+import scala.jdk.OptionConverters.*
+
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.AtomicBoolean
+
+import utest.*
+
+object LinkerBenchmarkProcessTests extends TestSuite {
+  import LinkerBenchmark.Outcome
+  import LinkerBenchmarkProcess.*
+
+  private val shell = os.Path("/bin/sh")
+
+  private def shellUnavailable: Boolean = {
+    val unavailable = !os.exists(shell)
+    if unavailable then println("SKIPPED: /bin/sh is unavailable on this platform")
+    unavailable
+  }
+
+  private def withWorkspace[A](run: os.Path => A): A = {
+    val workspace = os.temp.dir(prefix = "linker-process-")
+    try run(workspace)
+    finally os.remove.all(workspace)
+  }
+
+  private def processAlive(pid: Long): Boolean =
+    ProcessHandle.of(pid).toScala.exists(_.isAlive)
+
+  private def forceDead(pid: Long): Unit =
+    ProcessHandle.of(pid).toScala.filter(_.isAlive).foreach(_.destroyForcibly())
+
+  private def forceAndAwaitDead(pid: Long): Unit = {
+    forceDead(pid)
+    awaitDead(pid)
+  }
+
+  private def awaitDead(pid: Long): Unit = {
+    val deadline = System.nanoTime() + 5.seconds.toNanos
+    @annotation.tailrec
+    def loop(): Unit =
+      if !processAlive(pid) || System.nanoTime() >= deadline then ()
+      else {
+        Thread.sleep(20L)
+        loop()
+      }
+    loop()
+    assert(!processAlive(pid))
+  }
+
+  private def awaitExists(path: os.Path): Unit = {
+    val deadline = System.nanoTime() + 3.seconds.toNanos
+    @annotation.tailrec
+    def loop(): Unit =
+      if os.exists(path) || System.nanoTime() >= deadline then ()
+      else {
+        Thread.sleep(20L)
+        loop()
+      }
+    loop()
+    assert(os.exists(path))
+  }
+
+  private def awaitPositiveSample(sampler: AggregateRssSampler): AggregateRssSnapshot = {
+    val deadline = System.nanoTime() + 3.seconds.toNanos
+    @annotation.tailrec
+    def loop(): AggregateRssSnapshot = {
+      val snapshot = sampler.snapshot()
+      if snapshot.wholeRunPeakKiB > 0L && snapshot.strategyWindowPeakKiB > 0L then snapshot
+      else if System.nanoTime() >= deadline then snapshot
+      else {
+        Thread.sleep(20L)
+        loop()
+      }
+    }
+    val snapshot = loop()
+    assert(snapshot.wholeRunPeakKiB > 0L)
+    assert(snapshot.strategyWindowPeakKiB > 0L)
+    snapshot
+  }
+
+  private def destroyTree(process: Process): Unit = {
+    val root        = process.toHandle
+    val stream      = root.descendants()
+    val descendants =
+      try stream.iterator().asScala.toSeq
+      finally stream.close()
+    descendants.filter(_.isAlive).foreach(_.destroy())
+    if root.isAlive then root.destroy()
+
+    @annotation.tailrec
+    def loop(handles: Seq[ProcessHandle], deadline: Long): Seq[ProcessHandle] = {
+      val survivors = handles.filter(_.isAlive)
+      if survivors.isEmpty || System.nanoTime() >= deadline then survivors
+      else {
+        Thread.sleep(20L)
+        loop(survivors, deadline)
+      }
+    }
+    val survivors = loop(descendants :+ root, System.nanoTime() + 3.seconds.toNanos)
+    survivors.foreach(_.destroyForcibly())
+    val afterForce = loop(survivors, System.nanoTime() + 1.second.toNanos)
+    process.getInputStream.close()
+    process.getErrorStream.close()
+    process.getOutputStream.close()
+    assert(afterForce.isEmpty)
+  }
+
+  private def runShell(
+      workspace: os.Path,
+      script: String,
+      timeout: FiniteDuration = 5.seconds,
+      environment: Map[String, String] = Map.empty
+  ): ProcessResult =
+    LinkerBenchmarkProcess.run(
+      Seq(shell.toString, "-c", script),
+      workspace,
+      environment,
+      timeout,
+      workspace / "startup",
+      workspace / "stdout.log",
+      workspace / "stderr.log"
+    )
+
+  val tests = Tests {
+    test("rejects invalid requests") {
+      withWorkspace { workspace =>
+        val empty = LinkerBenchmarkProcess.run(
+          Seq.empty,
+          workspace,
+          Map.empty,
+          1.second,
+          workspace / "marker",
+          workspace / "out",
+          workspace / "err"
+        )
+        val nonpositive = LinkerBenchmarkProcess.run(
+          Seq("ignored"),
+          workspace,
+          Map.empty,
+          Duration.Zero,
+          workspace / "marker",
+          workspace / "out",
+          workspace / "err"
+        )
+        assert(empty.outcome == Outcome.Failed)
+        assert(empty.exitCode.isEmpty)
+        assert(nonpositive.outcome == Outcome.Failed)
+        assert(nonpositive.exitCode.isEmpty)
+      }
+    }
+
+    test("successful process observes startup and redirects output") {
+      if shellUnavailable then ()
+      else
+        withWorkspace { workspace =>
+          val result = runShell(workspace, ": > startup; echo done")
+          assert(result.outcome == Outcome.Succeeded)
+          assert(result.exitCode.contains(0))
+          assert(result.startupMillis.nonEmpty)
+          assert(result.wallMillis >= result.startupMillis.get)
+          assert(result.peakRssKiB >= 0L)
+          assert(os.read(workspace / "stdout.log").trim == "done")
+        }
+    }
+
+    test("missing marker remains absent") {
+      if shellUnavailable then ()
+      else
+        withWorkspace { workspace =>
+          val result = runShell(workspace, "echo done")
+          assert(result.outcome == Outcome.Succeeded)
+          assert(result.startupMillis.isEmpty)
+        }
+    }
+
+    test("stale marker from an earlier run does not count as startup") {
+      if shellUnavailable then ()
+      else
+        withWorkspace { workspace =>
+          os.write(workspace / "startup", "stale")
+          val result = runShell(workspace, "echo done")
+          assert(result.outcome == Outcome.Succeeded)
+          assert(result.startupMillis.isEmpty)
+        }
+    }
+
+    test("nonzero exit is failed") {
+      if shellUnavailable then ()
+      else
+        withWorkspace { workspace =>
+          val result = runShell(workspace, "echo bad >&2; exit 7")
+          assert(result.outcome == Outcome.Failed)
+          assert(result.exitCode.contains(7))
+          assert(result.detail.contains("exit 7"))
+        }
+    }
+
+    test("launch failure is classified without environment disclosure") {
+      withWorkspace { workspace =>
+        val secret = "launch-secret-value"
+        val result = LinkerBenchmarkProcess.run(
+          Seq((workspace / "missing-command").toString),
+          workspace,
+          Map("LINKER_BENCHMARK_SECRET" -> secret),
+          1.second,
+          workspace / "startup",
+          workspace / "stdout.log",
+          workspace / "stderr.log"
+        )
+        assert(result.outcome == Outcome.Failed)
+        assert(result.exitCode.isEmpty)
+        assert(!result.detail.contains(secret))
+      }
+    }
+
+    test("environment additions reach child but are not disclosed") {
+      if shellUnavailable then ()
+      else
+        withWorkspace { workspace =>
+          val secret = "benchmark-secret-value"
+          val result = runShell(
+            workspace,
+            "test \"$LINKER_BENCHMARK_SECRET\" = benchmark-secret-value",
+            environment = Map(
+              "LINKER_BENCHMARK_SECRET" -> secret
+            )
+          )
+          assert(result.outcome == Outcome.Succeeded)
+          assert(!result.detail.contains(secret))
+          assert(!os.read(workspace / "stdout.log").contains(secret))
+          assert(!os.read(workspace / "stderr.log").contains(secret))
+        }
+    }
+
+    test("environment removals keep inherited values out of the child") {
+      if shellUnavailable then ()
+      else
+        withWorkspace { workspace =>
+          val result = LinkerBenchmarkProcess.run(
+            Seq(shell.toString, "-c", "test -z \"${USER+x}\""),
+            workspace,
+            Map.empty,
+            5.seconds,
+            workspace / "startup",
+            workspace / "stdout.log",
+            workspace / "stderr.log",
+            environmentRemovals = Set("USER")
+          )
+          assert(result.outcome == Outcome.Succeeded)
+        }
+    }
+
+    test("smoke child environment opts out of Mill path relativization") {
+      val inherited = Map(
+        "JAVA_OPTS"                    -> "inherited-java-opts",
+        "JDK_JAVA_OPTIONS"             -> "inherited-jdk-options",
+        "JAVA_TOOL_OPTIONS"            -> "inherited-tool-options",
+        "_JAVA_OPTIONS"                -> "inherited-underscore-options",
+        "OS_LIB_PATH_RELATIVIZER_BASE" -> "inherited-relativizer-base",
+        "MILL_WORKSPACE_ROOT"          -> "inherited-workspace-root",
+        "UNCHANGED"                    -> "kept"
+      )
+      val composed = composeEnvironment(
+        inherited,
+        Map(
+          "JAVA_OPTS"                    -> "-Xmx1g",
+          "OS_LIB_PATH_RELATIVIZER_BASE" -> ""
+        ),
+        LinkerBenchmark.smokeEnvironmentRemovals
+      )
+
+      assert(composed.get("OS_LIB_PATH_RELATIVIZER_BASE").contains(""))
+      assert(!composed.contains("MILL_WORKSPACE_ROOT"))
+      assert(composed.get("JAVA_OPTS").contains("-Xmx1g"))
+      assert(!composed.contains("JDK_JAVA_OPTIONS"))
+      assert(!composed.contains("JAVA_TOOL_OPTIONS"))
+      assert(!composed.contains("_JAVA_OPTIONS"))
+      assert(composed.get("UNCHANGED").contains("kept"))
+    }
+
+    test("timeout kills root and descendant and permits replacement") {
+      if shellUnavailable then ()
+      else
+        withWorkspace { workspace =>
+          var rootPid: Option[Long]  = None
+          var childPid: Option[Long] = None
+          try {
+            val result = runShell(
+              workspace,
+              "echo $$ > root.pid; sleep 30 & echo $! > child.pid; echo ready > child.ready; wait",
+              timeout = 700.millis
+            )
+            awaitExists(workspace / "child.ready")
+            rootPid = Some(os.read(workspace / "root.pid").trim.toLong)
+            childPid = Some(os.read(workspace / "child.pid").trim.toLong)
+            assert(result.outcome == Outcome.TimedOut)
+            rootPid.foreach(awaitDead)
+            childPid.foreach(awaitDead)
+
+            val replacement = runShell(workspace, ": > startup; echo replacement")
+            assert(replacement.outcome == Outcome.Succeeded)
+            assert(os.read(workspace / "stdout.log").trim == "replacement")
+          } finally {
+            childPid.foreach(forceAndAwaitDead)
+            rootPid.foreach(forceAndAwaitDead)
+          }
+        }
+    }
+
+    test("successful root exit retires an observed background child") {
+      if shellUnavailable then ()
+      else
+        withWorkspace { workspace =>
+          var childPid: Option[Long] = None
+          try {
+            val result = runShell(
+              workspace,
+              "sleep 30 & echo $! > child.pid; echo ready > child.ready; sleep 0.4; exit 0"
+            )
+            awaitExists(workspace / "child.ready")
+            childPid = Some(os.read(workspace / "child.pid").trim.toLong)
+            assert(result.outcome == Outcome.Succeeded)
+            childPid.foreach(awaitDead)
+          } finally childPid.foreach(forceAndAwaitDead)
+        }
+    }
+
+    test("cleanup discovers and retires a descendant forked during termination") {
+      if shellUnavailable then ()
+      else
+        withWorkspace { workspace =>
+          var childPid: Option[Long]      = None
+          var grandchildPid: Option[Long] = None
+          try {
+            val script =
+              """/bin/sh -c "trap 'sleep 30 & echo \$! > grandchild.pid; echo ready > grandchild.ready; sleep 0.4; exit 0' TERM; echo \$\$ > child.pid; echo ready > child.ready; while :; do sleep 1; done" & wait"""
+            val result = runShell(workspace, script, timeout = 700.millis)
+            awaitExists(workspace / "child.ready")
+            awaitExists(workspace / "grandchild.ready")
+            childPid = Some(os.read(workspace / "child.pid").trim.toLong)
+            grandchildPid = Some(os.read(workspace / "grandchild.pid").trim.toLong)
+            assert(result.outcome == Outcome.TimedOut)
+            childPid.foreach(awaitDead)
+            grandchildPid.foreach(awaitDead)
+          } finally {
+            grandchildPid.foreach(forceAndAwaitDead)
+            childPid.foreach(forceAndAwaitDead)
+          }
+        }
+    }
+
+    test("RSS sampling does not grossly extend a short timeout") {
+      if shellUnavailable then ()
+      else
+        withWorkspace { workspace =>
+          val result = runShell(workspace, "sleep 30", timeout = 80.millis)
+          assert(result.outcome == Outcome.TimedOut)
+          assert(result.wallMillis < 1000L)
+        }
+    }
+
+    test("cleanup failure only overrides successful process outcome") {
+      assert(outcomeAfterCleanup(Outcome.Succeeded, clean = true) == Outcome.Succeeded)
+      assert(outcomeAfterCleanup(Outcome.Succeeded, clean = false) == Outcome.Failed)
+      assert(outcomeAfterCleanup(Outcome.Failed, clean = false) == Outcome.Failed)
+      assert(outcomeAfterCleanup(Outcome.TimedOut, clean = false) == Outcome.TimedOut)
+      assert(outcomeAfterCleanup(Outcome.Cancelled, clean = false) == Outcome.Cancelled)
+    }
+
+    test("interrupt cancels and cleans up the process tree") {
+      if shellUnavailable then ()
+      else
+        withWorkspace { workspace =>
+          val result                 = new AtomicReference[ProcessResult]()
+          val failure                = new AtomicReference[Throwable]()
+          val interruptRestored      = new AtomicBoolean(false)
+          var rootPid: Option[Long]  = None
+          var childPid: Option[Long] = None
+          val runner                 = new Thread(
+            () =>
+              try
+                result.set(runShell(workspace, "echo $$ > root.pid; sleep 30 & echo $! > child.pid; wait", 20.seconds))
+              catch case error: Throwable => failure.set(error)
+              finally interruptRestored.set(Thread.currentThread().isInterrupted),
+            "linker-process-cancellation-test"
+          )
+          try {
+            runner.start()
+            awaitExists(workspace / "child.pid")
+            rootPid = Some(os.read(workspace / "root.pid").trim.toLong)
+            childPid = Some(os.read(workspace / "child.pid").trim.toLong)
+            runner.interrupt()
+            runner.join(7000L)
+            assert(!runner.isAlive)
+            assert(failure.get() == null)
+            assert(result.get() != null)
+            assert(result.get().outcome == Outcome.Cancelled)
+            assert(interruptRestored.get())
+            rootPid.foreach(awaitDead)
+            childPid.foreach(awaitDead)
+          } finally {
+            childPid.foreach(forceAndAwaitDead)
+            rootPid.foreach(forceAndAwaitDead)
+            runner.interrupt()
+            runner.join(7000L)
+            assert(!runner.isAlive)
+          }
+        }
+    }
+
+    test("aggregate peak deduplicates pids per instant") {
+      val samples = Seq(
+        Seq(1L -> 100L, 1L -> 100L, 2L -> 200L),
+        Seq(1L -> 150L, 2L -> 250L, 2L -> 250L)
+      )
+      assert(peakAggregateRssKiB(samples) == 400L)
+      assert(peakAggregateRssKiB(Seq.empty) == 0L)
+    }
+
+    test("aggregate sampler measures a live process tree and starts a fresh strategy window") {
+      if shellUnavailable then ()
+      else
+        withWorkspace { workspace =>
+          val process = new ProcessBuilder(
+            Seq(shell.toString, "-c", "sleep 30 & echo $! > child.pid; wait").asJava
+          ).directory(workspace.toIO)
+            .redirectOutput(ProcessBuilder.Redirect.to((workspace / "aggregate.out").toIO))
+            .redirectError(ProcessBuilder.Redirect.to((workspace / "aggregate.err").toIO))
+            .start()
+          var sampler: AggregateRssSampler = null
+          try {
+            awaitExists(workspace / "child.pid")
+            val childPid       = os.read(workspace / "child.pid").trim.toLong
+            val root           = process.toHandle
+            val stream         = root.descendants()
+            val descendantPids =
+              try stream.iterator().asScala.map(_.pid()).toSet
+              finally stream.close()
+            assert(childPid != root.pid())
+            assert(descendantPids.contains(childPid))
+
+            sampler = AggregateRssSampler.start(root.pid(), () => Set(root), 20.millis)
+            val firstWindow = awaitPositiveSample(sampler)
+            val reset       = sampler.resetStrategyWindow()
+            assert(reset.wholeRunPeakKiB >= firstWindow.wholeRunPeakKiB)
+            assert(reset.strategyWindowPeakKiB >= firstWindow.strategyWindowPeakKiB)
+
+            val secondWindow = awaitPositiveSample(sampler)
+            assert(secondWindow.wholeRunPeakKiB >= firstWindow.wholeRunPeakKiB)
+            assert(secondWindow.strategyWindowPeakKiB > 0L)
+            assert(process.isAlive)
+            assert(processAlive(childPid))
+          } finally {
+            if sampler != null then sampler.close()
+            destroyTree(process)
+          }
+        }
+    }
+
+    test("aggregate sampler close is bounded and restores caller interruption") {
+      val failure  = new AtomicReference[Throwable]()
+      val restored = new AtomicBoolean(false)
+      val runner   = new Thread(
+        () =>
+          try {
+            val sampler = AggregateRssSampler.start(ProcessHandle.current().pid(), () => Set.empty, 20.millis)
+            Thread.currentThread().interrupt()
+            sampler.close()
+            restored.set(Thread.currentThread().isInterrupted)
+          } catch case error: Throwable => failure.set(error),
+        "aggregate-sampler-close-test"
+      )
+      runner.start()
+      runner.join(3000L)
+      try {
+        assert(!runner.isAlive)
+        assert(failure.get() == null)
+        assert(restored.get())
+      } finally {
+        runner.interrupt()
+        runner.join(3000L)
+        assert(!runner.isAlive)
+      }
+    }
+  }
+}

--- a/millbuildHelpers/test/src/millbuild/LinkerBenchmarkTests.scala
+++ b/millbuildHelpers/test/src/millbuild/LinkerBenchmarkTests.scala
@@ -1,0 +1,1411 @@
+package millbuild
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+import scala.concurrent.duration.*
+
+import upickle.default.*
+import utest.*
+
+object LinkerBenchmarkTests extends TestSuite {
+  import LinkerBenchmark.*
+
+  private val defaultResolvedConfiguration = hostedPreset("js-strategies").toOption.get
+
+  private def strategyTrial(
+      trial: Int,
+      wallMillis: Long,
+      outcome: Outcome = Outcome.Succeeded,
+      peakAggregateRssKiB: Long = 4096L,
+      strategy: Strategy = Strategy.Recycled,
+      profile: Profile = ciProfile
+  ): StrategyTrialRecord =
+    StrategyTrialRecord(
+      "run-1",
+      trial,
+      0,
+      Platform.ScalaJs,
+      strategy,
+      profile,
+      wallMillis,
+      peakAggregateRssKiB,
+      4L,
+      outcome
+    )
+
+  private def worker(
+      trial: Int,
+      lane: Int = 0,
+      startupMillis: Long = 100L,
+      peakRssKiB: Long = 2048L,
+      peakHeapBytes: Long = 512L,
+      gcMillis: Long = 20L,
+      outcome: Outcome = Outcome.Succeeded,
+      strategy: Strategy = Strategy.Recycled,
+      detail: Option[String] = None,
+      profile: Profile = ciProfile
+  ): WorkerRecord =
+    WorkerRecord(
+      "run-1",
+      trial,
+      0,
+      defaultEvaluationSettings,
+      Platform.ScalaJs,
+      strategy,
+      profile,
+      lane,
+      0,
+      Seq(s"target-$lane"),
+      startupMillis,
+      peakRssKiB,
+      Seq(PhaseMetrics("cold-link", 700L, 256L, peakHeapBytes, 2L, gcMillis, 6L, 1L)),
+      outcome,
+      detail
+    )
+
+  val tests = Tests {
+    test("CLI optional strings trim values and reject control characters without echoing them") {
+      assert(parseOptionalTrimmedString("", "target filter") == Right(None))
+      assert(parseOptionalTrimmedString("   ", "target filter") == Right(None))
+      assert(parseOptionalTrimmedString("  langkit  ", "target filter") == Right(Some("langkit")))
+
+      val payload = "secret\ninjected"
+      val message = parseOptionalTrimmedString(payload, "target filter").left.toOption.get
+      assert(message.contains("target filter"))
+      assert(!message.contains(payload))
+      assert(!message.exists(Character.isISOControl))
+    }
+
+    test("CLI numeric and continuation inputs preserve unset values and reject unsafe input") {
+      assert(parseZeroAsUnsetPositiveInt("0", "trials") == Right(None))
+      assert(parseZeroAsUnsetPositiveInt(" 3 ", "trials") == Right(Some(3)))
+      assert(parseZeroAsUnsetPositiveInt("-1", "trials").isLeft)
+      assert(parsePositiveInt("1", "artifact run attempt") == Right(1))
+      assert(parsePositiveInt("0", "artifact run attempt").isLeft)
+      assert(parseBoolean(" true ", "smoke") == Right(true))
+      assert(parseBoolean("false", "smoke") == Right(false))
+      assert(parseBoolean("TRUE", "smoke") == Right(true))
+      assert(parseBoolean(" False ", "smoke") == Right(false))
+      assert(parseOptionalLong("", "order seed") == Right(None))
+      assert(parseOptionalLong(" 42 ", "order seed") == Right(Some(42L)))
+      assert(parseContinuationChoice(" preset ") == Right(None))
+      assert(parseContinuationChoice("TRUE") == Right(Some(true)))
+      assert(parseContinuationChoice("False") == Right(Some(false)))
+
+      Seq("not-a-long", "secret\ninjected").foreach { payload =>
+        val message = parseOptionalLong(payload, "order seed").left.toOption.get
+        assert(message.contains("order seed"))
+        assert(!message.contains(payload))
+        assert(!message.exists(Character.isISOControl))
+      }
+      Seq("sometimes", "true\ninjected").foreach { payload =>
+        val message = parseContinuationChoice(payload).left.toOption.get
+        assert(message.contains("continue on failure"))
+        assert(!message.contains(payload))
+        assert(!message.exists(Character.isISOControl))
+      }
+      Seq("not-an-int", "123\ninjected", Int.MaxValue.toString + "0").foreach { payload =>
+        val message = parseZeroAsUnsetPositiveInt(payload, "trials").left.toOption.get
+        assert(message.contains("trials"))
+        assert(!message.contains(payload))
+        assert(!message.exists(Character.isISOControl))
+      }
+      Seq("sometimes", "true\ninjected").foreach { payload =>
+        val message = parseBoolean(payload, "smoke").left.toOption.get
+        assert(message.contains("smoke"))
+        assert(!message.contains(payload))
+        assert(!message.exists(Character.isISOControl))
+      }
+    }
+
+    test("direct CLI defaults and explicit legacy selections resolve identically") {
+      val local    = Profile("local", 32, 8, 8, 2, 2, 4, 30)
+      val defaults = resolveBenchmarkConfiguration("", "", local, BenchmarkOverrides()).toOption.get
+      assert(defaults == ResolvedBenchmarkConfiguration(
+        "direct",
+        local,
+        EvaluationSettings(3, 0L),
+        Platform.values.toSeq,
+        Strategy.values.toSeq,
+        None,
+        None,
+        continueOnFailure = false
+      ))
+
+      val explicit = resolveBenchmarkConfiguration(
+        "",
+        "local",
+        local,
+        BenchmarkOverrides(platforms = Some("wasm"), trials = Some(1))
+      ).toOption.get
+      assert(explicit.platforms == Seq(Platform.Wasm))
+      assert(explicit.settings == EvaluationSettings(1, 0L))
+      assert(explicit.profile == local)
+    }
+
+    test("hosted configuration rejects the direct-only profile input") {
+      val local   = Profile("local", 32, 8, 8, 2, 2, 4, 30)
+      val payload = "secret\ninjected"
+      val result  = resolveBenchmarkConfiguration("quick-smoke", payload, local, BenchmarkOverrides())
+      val message = result.left.toOption.get
+      assert(message.contains("profile"))
+      assert(!message.contains(payload))
+      assert(!message.exists(Character.isISOControl))
+      assert(resolveBenchmarkConfiguration("quick-smoke", "ci", local, BenchmarkOverrides()).isLeft)
+    }
+
+    test("hosted artifact names normalize unsafe separators and preserve unique run suffixes") {
+      assert(
+        hostedArtifactName("quick-smoke", "Feature/Ünicode Branch", "123", 2) ==
+          Right("linker-benchmark-quick-smoke-feature-nicode-branch-123-2")
+      )
+      assert(
+        hostedArtifactName("js-strategies", "release...candidate", "run.42", 1) ==
+          Right("linker-benchmark-js-strategies-release...candidate-run.42-1")
+      )
+
+      val longRef = "feature/" + ("long-name-" * 40)
+      val first   = hostedArtifactName("quick-smoke", longRef, "987654321", 3).toOption.get
+      val second  = hostedArtifactName("quick-smoke", longRef + "different", "987654322", 3).toOption.get
+      assert(first.length <= 120)
+      assert(second.length <= 120)
+      assert(first != second)
+      assert(first.endsWith("-987654321-3"))
+      assert(second.endsWith("-987654322-3"))
+      assert(first.matches("[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?"))
+    }
+
+    test("hosted artifact names reject missing, invalid, and secret-bearing inputs without echo") {
+      assert(hostedArtifactName("", "main", "1", 1).isLeft)
+      assert(hostedArtifactName("unknown", "main", "1", 1).isLeft)
+      assert(hostedArtifactName("quick-smoke", "", "1", 1).isLeft)
+      assert(hostedArtifactName("quick-smoke", "main", "", 1).isLeft)
+      assert(hostedArtifactName("quick-smoke", "main", "1", 0).isLeft)
+      assert(hostedArtifactName("quick-smoke", "main", "1", -1).isLeft)
+      assert(hostedArtifactName(" quick-smoke ", "main", "1", 1).isRight)
+      assert(hostedArtifactName("quick/smoke", "main", "1", 1).isLeft)
+      assert(hostedArtifactName("Quick-Smoke", "main", "1", 1).isLeft)
+      assert(hostedArtifactName("quick‐smoke", "main", "1", 1).isLeft)
+
+      val payload = "secret\ninjected"
+      val message = hostedArtifactName("quick-smoke", payload, "1", 1).left.toOption.get
+      assert(message.contains("artifact ref"))
+      assert(!message.contains(payload))
+      assert(!message.exists(Character.isISOControl))
+    }
+
+    test("hosted resource bounds accept their limits and reject larger values") {
+      val atLimits = BenchmarkOverrides(
+        trials = Some(maxHostedTrials),
+        targetLimit = Some(maxHostedTargetLimit),
+        memoryGiB = Some(maxHostedMemoryGiB),
+        reserveGiB = Some(maxHostedReserveGiB),
+        millJobs = Some(maxHostedMillJobs),
+        maxChildren = Some(maxHostedChildren),
+        batchSize = Some(maxHostedBatchSize),
+        timeoutMinutes = Some(maxHostedTimeoutMinutes)
+      )
+      assert(validateHostedOverrideBounds(atLimits).isRight)
+
+      val aboveLimits = Seq(
+        BenchmarkOverrides(trials = Some(maxHostedTrials + 1)),
+        BenchmarkOverrides(targetLimit = Some(maxHostedTargetLimit + 1)),
+        BenchmarkOverrides(memoryGiB = Some(maxHostedMemoryGiB + 1)),
+        BenchmarkOverrides(reserveGiB = Some(maxHostedReserveGiB + 1)),
+        BenchmarkOverrides(millJobs = Some(maxHostedMillJobs + 1)),
+        BenchmarkOverrides(maxChildren = Some(maxHostedChildren + 1)),
+        BenchmarkOverrides(batchSize = Some(maxHostedBatchSize + 1)),
+        BenchmarkOverrides(timeoutMinutes = Some(maxHostedTimeoutMinutes + 1))
+      )
+      val maximumValues = Seq(
+        BenchmarkOverrides(trials = Some(Int.MaxValue)),
+        BenchmarkOverrides(targetLimit = Some(Int.MaxValue)),
+        BenchmarkOverrides(memoryGiB = Some(Int.MaxValue)),
+        BenchmarkOverrides(reserveGiB = Some(Int.MaxValue)),
+        BenchmarkOverrides(millJobs = Some(Int.MaxValue)),
+        BenchmarkOverrides(maxChildren = Some(Int.MaxValue)),
+        BenchmarkOverrides(batchSize = Some(Int.MaxValue)),
+        BenchmarkOverrides(timeoutMinutes = Some(Int.MaxValue))
+      )
+      assert((aboveLimits ++ maximumValues).forall(validateHostedOverrideBounds(_).isLeft))
+    }
+
+    test("configuration JSON is sanitized and matches the configuration embedded in final results") {
+      val secret        = "super-secret-filter"
+      val configuration = defaultResolvedConfiguration.copy(targetFilter = Some(secret))
+      val environment   = Map("FILTER_SECRET" -> secret)
+      val standalone    = ujson.read(renderConfigurationJson(configuration, environment))
+      val result        = ujson.read(renderJson(BenchmarkResult(configuration, 0L, Seq.empty, Seq.empty), environment))
+
+      assert(standalone == result("configuration"))
+      assert(!standalone.render().contains(secret))
+    }
+
+    test("hosted presets resolve to their exact configurations") {
+      val expected = Map(
+        "quick-smoke" -> ResolvedBenchmarkConfiguration(
+          "quick-smoke",
+          ciProfile,
+          EvaluationSettings(1, 0L),
+          Platform.values.toSeq,
+          Strategy.values.toSeq,
+          None,
+          Some(1),
+          continueOnFailure = true
+        ),
+        "js-strategies" -> ResolvedBenchmarkConfiguration(
+          "js-strategies",
+          ciProfile,
+          EvaluationSettings(3, 0L),
+          Seq(Platform.ScalaJs),
+          Strategy.values.toSeq,
+          None,
+          None,
+          continueOnFailure = true
+        ),
+        "wasm-strategies" -> ResolvedBenchmarkConfiguration(
+          "wasm-strategies",
+          ciProfile,
+          EvaluationSettings(3, 0L),
+          Seq(Platform.Wasm),
+          Strategy.values.toSeq,
+          None,
+          None,
+          continueOnFailure = true
+        ),
+        "native-long-lived" -> ResolvedBenchmarkConfiguration(
+          "native-long-lived",
+          ciProfile.copy(timeoutMinutes = 40),
+          EvaluationSettings(1, 0L),
+          Seq(Platform.Native),
+          Seq(Strategy.LongLived),
+          None,
+          None,
+          continueOnFailure = true
+        ),
+        "native-fresh-recycled" -> ResolvedBenchmarkConfiguration(
+          "native-fresh-recycled",
+          ciProfile,
+          EvaluationSettings(3, 0L),
+          Seq(Platform.Native),
+          Seq(Strategy.Fresh, Strategy.Recycled),
+          None,
+          None,
+          continueOnFailure = true
+        )
+      )
+
+      assert(expected.map { case (token, value) => token -> hostedPreset(token) } ==
+        expected.view.mapValues(Right(_)).toMap)
+      assert(hostedPreset("unknown").isLeft)
+    }
+
+    test("hosted configuration applies concrete overrides and retains unset preset values") {
+      val overrides = BenchmarkOverrides(
+        platforms = Some("native,wasm"),
+        strategies = Some("fresh,recycled"),
+        trials = Some(2),
+        orderSeed = Some(7L),
+        targetFilter = Some("langkit"),
+        targetLimit = Some(3),
+        memoryGiB = Some(32),
+        reserveGiB = Some(4),
+        millJobs = Some(3),
+        maxChildren = Some(3),
+        batchSize = Some(2),
+        timeoutMinutes = Some(45),
+        continueOnFailure = Some(false)
+      )
+      val resolved = resolveHostedConfiguration("quick-smoke", overrides).toOption.get
+
+      assert(resolved.platforms == Seq(Platform.Native, Platform.Wasm))
+      assert(resolved.strategies == Seq(Strategy.Fresh, Strategy.Recycled))
+      assert(resolved.settings == EvaluationSettings(2, 7L))
+      assert(resolved.targetFilter.contains("langkit"))
+      assert(resolved.targetLimit.contains(3))
+      assert(resolved.profile == Profile("ci", 32, 4, 8, 3, 3, 2, 45))
+      assert(!resolved.continueOnFailure)
+      assert(resolveHostedConfiguration("native-long-lived", BenchmarkOverrides()).toOption.get ==
+        hostedPreset("native-long-lived").toOption.get)
+    }
+
+    test("hosted configuration rejects invalid overrides") {
+      val invalid = Seq(
+        BenchmarkOverrides(platforms = Some("native,native")),
+        BenchmarkOverrides(platforms = Some("native,,wasm")),
+        BenchmarkOverrides(platforms = Some("unknown")),
+        BenchmarkOverrides(strategies = Some("fresh,fresh")),
+        BenchmarkOverrides(strategies = Some("unknown")),
+        BenchmarkOverrides(trials = Some(0)),
+        BenchmarkOverrides(orderSeed = Some(-1L)),
+        BenchmarkOverrides(targetFilter = Some("   ")),
+        BenchmarkOverrides(targetLimit = Some(-1)),
+        BenchmarkOverrides(memoryGiB = Some(-1)),
+        BenchmarkOverrides(reserveGiB = Some(-1)),
+        BenchmarkOverrides(millJobs = Some(-1)),
+        BenchmarkOverrides(maxChildren = Some(-1)),
+        BenchmarkOverrides(batchSize = Some(-1)),
+        BenchmarkOverrides(timeoutMinutes = Some(-1)),
+        BenchmarkOverrides(memoryGiB = Some(8), reserveGiB = Some(4))
+      )
+
+      assert(invalid.forall(value => resolveHostedConfiguration("quick-smoke", value).isLeft))
+      assert(resolveHostedConfiguration("quick-smoke", BenchmarkOverrides(platforms = Some(""))).isLeft)
+      assert(read[BenchmarkOverrides](write(BenchmarkOverrides())) == BenchmarkOverrides())
+    }
+
+    test("hosted trials have a bounded reproducible range") {
+      val maximum = resolveHostedConfiguration(
+        "quick-smoke",
+        BenchmarkOverrides(trials = Some(maxHostedTrials))
+      )
+
+      assert(maximum.toOption.exists(_.settings.trials == maxHostedTrials))
+      assert(resolveHostedConfiguration(
+        "quick-smoke",
+        BenchmarkOverrides(trials = Some(maxHostedTrials + 1))
+      ).isLeft)
+      assert(resolveHostedConfiguration(
+        "quick-smoke",
+        BenchmarkOverrides(trials = Some(Int.MaxValue))
+      ).isLeft)
+    }
+
+    test("hosted selection errors do not echo untrusted override text") {
+      val cases = Seq(
+        ("platforms", "native\ninjected", BenchmarkOverrides(platforms = Some("native\ninjected"))),
+        ("platforms", "native\u001binjected", BenchmarkOverrides(platforms = Some("native\u001binjected"))),
+        ("strategies", "fresh\ninjected", BenchmarkOverrides(strategies = Some("fresh\ninjected"))),
+        ("strategies", "fresh\u001binjected", BenchmarkOverrides(strategies = Some("fresh\u001binjected"))),
+        ("platforms", "secret-platform-value", BenchmarkOverrides(platforms = Some("secret-platform-value"))),
+        ("strategies", "secret-strategy-value", BenchmarkOverrides(strategies = Some("secret-strategy-value"))),
+        ("platforms", "native,native", BenchmarkOverrides(platforms = Some("native,native"))),
+        ("strategies", "fresh,fresh", BenchmarkOverrides(strategies = Some("fresh,fresh")))
+      )
+
+      cases.foreach { case (field, payload, overrides) =>
+        val message = resolveHostedConfiguration("quick-smoke", overrides).left.toOption.get
+        assert(message.contains(field))
+        assert(!message.contains(payload))
+        assert(!message.exists(Character.isISOControl))
+      }
+    }
+
+    test("hosted preset errors do not echo untrusted tokens") {
+      val tokens = Seq("quick-smoke\ninjected", "quick-smoke\u001binjected", "secret-preset-value")
+
+      tokens.foreach { token =>
+        val message = hostedPreset(token).left.toOption.get
+        assert(message.contains("preset"))
+        assert(!message.contains(token))
+        assert(!message.exists(Character.isISOControl))
+      }
+    }
+
+    test("inventory target selection is stable and validates filters and limits") {
+      val targets = Seq("zeta", "alpha-two", "alpha-one", "zeta")
+
+      assert(selectInventoryTargets(targets, None, None, Platform.Native) ==
+        Right(Seq("alpha-one", "alpha-two", "zeta")))
+      assert(selectInventoryTargets(targets.reverse, Some("alpha"), Some(1), Platform.Native) ==
+        Right(Seq("alpha-one")))
+      assert(selectInventoryTargets(targets, Some("missing"), None, Platform.Native).isLeft)
+      assert(selectInventoryTargets(targets, None, Some(0), Platform.Native).isLeft)
+      assert(selectInventoryTargets(targets, Some("alpha\n"), None, Platform.Native).isLeft)
+      assert(selectInventoryTargets(Seq.empty, None, None, Platform.Native).isLeft)
+    }
+
+    test("smoke child scrubs inherited JVM and Mill sandbox options") {
+      assert(
+        smokeEnvironmentRemovals == Set(
+          "JAVA_OPTS",
+          "JDK_JAVA_OPTIONS",
+          "JAVA_TOOL_OPTIONS",
+          "_JAVA_OPTIONS",
+          "MILL_WORKSPACE_ROOT"
+        )
+      )
+    }
+
+    test("smoke workspace resolution accepts the Mill root or an aliased nested cwd") {
+      val root       = os.temp.dir(prefix = "linker-benchmark-workspace-")
+      val repository = root / "repository"
+      val alias      = root / "repository-alias"
+      try {
+        os.makeDir.all(repository / "scripts" / "ci")
+        os.write(repository / "mill", "launcher")
+        os.write(repository / ".mill-version", "1.2.0")
+        os.write(repository / "build.mill", "")
+        java.nio.file.Files.createSymbolicLink(alias.toNIO, repository.toNIO)
+
+        val physicalRepository = canonicalPhysicalPath(repository).map(os.Path(_))
+        assert(resolveSmokeWorkspace(Map("MILL_WORKSPACE_ROOT" -> repository.toString), root) == physicalRepository)
+        assert(
+          resolveSmokeWorkspace(
+            Map("MILL_WORKSPACE_ROOT" -> (root / "not-a-repository").toString),
+            alias / "scripts" / "ci"
+          ) == physicalRepository
+        )
+        assert(resolveSmokeWorkspace(Map.empty, root).isLeft)
+      } finally os.remove.all(root)
+    }
+
+    test("smoke marker and proof records round trip through uPickle") {
+      val record = SmokeRecord(
+        childPid = 42L,
+        javaVersion = "21",
+        pinnedMillVersion = "1.2.0",
+        requestedHeapBytes = 1024L,
+        effectiveMaxHeapBytes = 8192L,
+        requestedHeapHonored = false,
+        outputDirectoryIdentity = "lane-identity",
+        proofFilename = "worker-proof-42.json"
+      )
+      val proof = SmokeProof(record.childPid, record.outputDirectoryIdentity)
+
+      assert(read[SmokeRecord](write(record)) == record)
+      assert(read[SmokeProof](write(proof)) == proof)
+    }
+
+    test("recovery records preserve timeout and replacement evidence") {
+      val replacementWorker = SmokeRecord(
+        childPid = 43L,
+        javaVersion = "secret-value",
+        pinnedMillVersion = "1.2.0",
+        requestedHeapBytes = 1024L,
+        effectiveMaxHeapBytes = 8192L,
+        requestedHeapHonored = false,
+        outputDirectoryIdentity = "recovery-lane",
+        proofFilename = "worker-proof-43.json"
+      )
+      val record = RecoveryRecord(
+        first = RecoveryAttemptRecord(Outcome.TimedOut, 1L, None, None),
+        replacement = RecoveryAttemptRecord(Outcome.Succeeded, 2L, Some(0), Some(replacementWorker))
+      )
+
+      assert(read[RecoveryRecord](write(record)) == record)
+      assert(validateRecovery(record).isRight)
+      assert(validateRecovery(record.copy(first = record.first.copy(outcome = Outcome.Succeeded))).isLeft)
+      assert(validateRecovery(record.copy(replacement = record.replacement.copy(worker = None))).isLeft)
+      assert(!renderRecoveryJson(record, Map("API_TOKEN" -> "secret-value")).contains("secret-value"))
+    }
+
+    test("benchmark output roots fingerprint the complete configuration without exposing values") {
+      val base       = os.Path("/benchmark-output")
+      val first      = defaultResolvedConfiguration
+      val overridden = first.copy(settings = first.settings.copy(orderSeed = 1L), targetFilter = Some("secret/value"))
+      val firstId    = benchmarkOutputIdentity(first).toOption.get
+
+      assert(firstId == benchmarkOutputIdentity(first).toOption.get)
+      assert(firstId.matches("js-strategies-[a-f0-9]{16}"))
+      assert(firstId != benchmarkOutputIdentity(overridden).toOption.get)
+      assert(!benchmarkOutputIdentity(overridden).toOption.get.contains("secret"))
+      assert(
+        benchmarkOutputRoot(base, first, recoverySmoke = false, planOnly = false) ==
+          Right(base / firstId / "ci" / "scala-js")
+      )
+      assert(
+        benchmarkOutputRoot(base, first, recoverySmoke = true, planOnly = false) ==
+          Right(base / firstId / "ci" / "recovery-smoke")
+      )
+      assert(
+        benchmarkOutputRoot(base, first, recoverySmoke = false, planOnly = true) ==
+          Right(base / firstId / "ci" / "plan-only" / "scala-js")
+      )
+      assert(benchmarkOutputRoot(base, first.copy(platforms = Seq.empty), false, false).isLeft)
+      assert(benchmarkOutputIdentity(first.copy(preset = "../../escaped")).isLeft)
+    }
+
+    test("recovery proof validation binds identity and rejects symlink escapes") {
+      val root             = os.temp.dir(prefix = "linker-recovery-proof-")
+      val workspace        = root / "workspace"
+      val rootOutput       = workspace / "out"
+      val lane             = root / "external" / "lane"
+      val proofPath        = lane / "worker-proof-43.json"
+      val expectedIdentity = "expected-lane-identity"
+      val worker           = SmokeRecord(
+        childPid = 43L,
+        javaVersion = "21",
+        pinnedMillVersion = "1.2.0",
+        requestedHeapBytes = 1024L,
+        effectiveMaxHeapBytes = 8192L,
+        requestedHeapHonored = false,
+        outputDirectoryIdentity = expectedIdentity,
+        proofFilename = proofPath.last
+      )
+      val proof    = SmokeProof(worker.childPid, worker.outputDirectoryIdentity)
+      val recovery = RecoveryRecord(
+        RecoveryAttemptRecord(Outcome.TimedOut, 1L, None, None),
+        RecoveryAttemptRecord(Outcome.Succeeded, 2L, Some(0), Some(worker))
+      )
+      try {
+        os.makeDir.all(rootOutput)
+        os.makeDir.all(lane)
+        os.write(proofPath, write(proof))
+
+        val valid = validateRecoveryProof(
+          workspace,
+          rootOutput,
+          lane,
+          proofPath,
+          expectedIdentity,
+          worker,
+          proof
+        )
+        assert(valid.isRight)
+        assert(renderValidatedRecoveryJson(recovery, valid, Map.empty).isRight)
+
+        val wrongWorker = worker.copy(outputDirectoryIdentity = "self-consistent-wrong-identity")
+        val wrongProof  = SmokeProof(wrongWorker.childPid, wrongWorker.outputDirectoryIdentity)
+        assert(
+          validateRecoveryProof(
+            workspace,
+            rootOutput,
+            lane,
+            proofPath,
+            expectedIdentity,
+            wrongWorker,
+            wrongProof
+          ).isLeft
+        )
+
+        val escapedTarget = root / "escaped-proof.json"
+        val escapedPath   = lane / "escaped-proof.json"
+        val escapedWorker = worker.copy(proofFilename = escapedPath.last)
+        val escapedProof  = SmokeProof(escapedWorker.childPid, escapedWorker.outputDirectoryIdentity)
+        os.write(escapedTarget, write(escapedProof))
+        java.nio.file.Files.createSymbolicLink(escapedPath.toNIO, escapedTarget.toNIO)
+        val escaped = validateRecoveryProof(
+          workspace,
+          rootOutput,
+          lane,
+          escapedPath,
+          expectedIdentity,
+          escapedWorker,
+          escapedProof
+        )
+        assert(escaped.isLeft)
+        assert(renderValidatedRecoveryJson(recovery, escaped, Map.empty).isLeft)
+      } finally os.remove.all(root)
+    }
+
+    test("smoke temporary base preserves its lexical symlink spelling") {
+      val root         = os.temp.dir(prefix = "linker-benchmark-lexical-tmp-")
+      val physicalBase = root / "physical-tmp"
+      val lexicalBase  = root / "lexical-tmp"
+      try {
+        os.makeDir.all(physicalBase)
+        java.nio.file.Files.createSymbolicLink(lexicalBase.toNIO, physicalBase.toNIO)
+
+        assert(resolveSmokeTemporaryBase(lexicalBase.toString, root) == Right(lexicalBase))
+        assert(resolveSmokeTemporaryBase("", root).isLeft)
+        assert(resolveSmokeTemporaryBase((root / "missing").toString, root).isLeft)
+      } finally os.remove.all(root)
+    }
+
+    test("smoke temporary base prefers a physically equivalent TMPDIR spelling") {
+      val root         = os.temp.dir(prefix = "linker-benchmark-tmpdir-")
+      val physicalBase = root / "physical-tmp"
+      val lexicalBase  = root / "lexical-tmp"
+      val otherBase    = root / "other-tmp"
+      try {
+        os.makeDir.all(physicalBase)
+        os.makeDir.all(otherBase)
+        java.nio.file.Files.createSymbolicLink(lexicalBase.toNIO, physicalBase.toNIO)
+
+        assert(
+          resolveSmokeTemporaryBase(physicalBase.toString, Some(lexicalBase.toString), root) == Right(lexicalBase)
+        )
+        assert(resolveSmokeTemporaryBase(physicalBase.toString, None, root) == Right(physicalBase))
+        assert(resolveSmokeTemporaryBase(physicalBase.toString, Some(""), root).isLeft)
+        assert(resolveSmokeTemporaryBase(physicalBase.toString, Some((root / "missing").toString), root).isLeft)
+        assert(resolveSmokeTemporaryBase(physicalBase.toString, Some(otherBase.toString), root).isLeft)
+      } finally os.remove.all(root)
+    }
+
+    test("smoke child output value preserves its lexical lane spelling") {
+      val root         = os.temp.dir(prefix = "linker-benchmark-lexical-lane-")
+      val physicalBase = root / "physical-tmp"
+      val lexicalBase  = root / "lexical-tmp"
+      try {
+        os.makeDir.all(physicalBase / "morphir-linker-smoke-run" / "lane-0")
+        java.nio.file.Files.createSymbolicLink(lexicalBase.toNIO, physicalBase.toNIO)
+        val lane = lexicalBase / "morphir-linker-smoke-run" / "lane-0"
+
+        assert(smokeChildOutputDirectoryValue(lane) == lane.wrapped.toAbsolutePath.normalize().toString)
+        assert(!smokeChildOutputDirectoryValue(lane).contains("physical-tmp"))
+      } finally os.remove.all(root)
+    }
+
+    test("smoke run allocation ignores a canonicalizing path serializer") {
+      val root         = os.temp.dir(prefix = "linker-benchmark-serializer-")
+      val physicalBase = root / "physical-tmp"
+      val lexicalBase  = root / "lexical-tmp"
+      object CanonicalizingSerializer extends os.Path.Serializer {
+        override def serializeString(path: os.Path): String               = serializePath(path).toString
+        override def serializeFile(path: os.Path): java.io.File           = serializePath(path).toFile
+        override def serializePath(path: os.Path): java.nio.file.Path     = path.wrapped.toRealPath()
+        override def deserialize(value: String): java.nio.file.Path       = java.nio.file.Paths.get(value).toRealPath()
+        override def deserialize(value: java.io.File): java.nio.file.Path = value.toPath.toRealPath()
+        override def deserialize(value: java.nio.file.Path): java.nio.file.Path = value.toRealPath()
+        override def deserialize(value: java.net.URI): java.nio.file.Path       =
+          java.nio.file.Paths.get(value).toRealPath()
+      }
+      try {
+        os.makeDir.all(physicalBase)
+        java.nio.file.Files.createSymbolicLink(lexicalBase.toNIO, physicalBase.toNIO)
+
+        val allocated = os.Path.pathSerializer.withValue(CanonicalizingSerializer) {
+          createSmokeTemporaryRunRoot(lexicalBase)
+        }
+
+        assert(allocated.wrapped.getParent == lexicalBase.wrapped)
+        assert(allocated.last.startsWith("morphir-linker-smoke-"))
+        assert(java.nio.file.Files.isDirectory(allocated.wrapped))
+      } finally os.remove.all(root)
+    }
+
+    test("pinned eight GiB heap must win the one GiB probe") {
+      val gib = 1024L * 1024L * 1024L
+
+      assert(validatePinnedHeapProbe(gib, 8L * gib, requestedHeapHonored = false).isRight)
+      assert(validatePinnedHeapProbe(gib, 7L * gib, requestedHeapHonored = false).isRight)
+      assert(validatePinnedHeapProbe(gib, 9L * gib, requestedHeapHonored = false).isRight)
+      assert(validatePinnedHeapProbe(gib, gib, requestedHeapHonored = true).isLeft)
+      assert(validatePinnedHeapProbe(gib, gib, requestedHeapHonored = false).isLeft)
+      assert(validatePinnedHeapProbe(2L * gib, 8L * gib, requestedHeapHonored = false).isLeft)
+    }
+
+    test("smoke heap probe must also pass profile admission") {
+      val gib    = 1024L * 1024L * 1024L
+      val record = SmokeRecord(
+        childPid = 42L,
+        javaVersion = "21",
+        pinnedMillVersion = "1.2.0",
+        requestedHeapBytes = gib,
+        effectiveMaxHeapBytes = 8L * gib,
+        requestedHeapHonored = false,
+        outputDirectoryIdentity = "lane-identity",
+        proofFilename = "worker-proof-42.json"
+      )
+      val overcommitted = ciProfile.copy(memoryGiB = 11)
+
+      assert(validateSmokeHeapProbe(record, ciProfile) == Right(8))
+      assert(validateSmokeHeapProbe(record, overcommitted).isLeft)
+      assert(validateSmokeHeapProbe(record.copy(requestedHeapHonored = true), ciProfile).isLeft)
+    }
+
+    test("effective heap validation conservatively enforces the profile memory budget") {
+      val gib        = 1024L * 1024L * 1024L
+      val overcommit = ciProfile.copy(heapGiB = 4, maxChildren = 2)
+
+      assert(validateEffectiveHeap(ciProfile, 8L * gib) == Right(8))
+      assert(validateEffectiveHeap(ciProfile, 7L * gib + 1L) == Right(8))
+      assert(validateEffectiveHeap(overcommit, 8L * gib).isLeft)
+      assert(validateEffectiveHeap(ciProfile, 0L).isLeft)
+      assert(validateEffectiveHeap(ciProfile, -1L).isLeft)
+      assert(validateEffectiveHeap(ciProfile, Long.MaxValue).isLeft)
+    }
+
+    test("configured heap validation accepts inclusive tolerance boundaries") {
+      val gib       = 1024L * 1024L * 1024L
+      val tolerance = 256L * 1024L * 1024L
+
+      assert(validateConfiguredHeap(ciProfile, 8L * gib - tolerance) == Right(8))
+      assert(validateConfiguredHeap(ciProfile, 8L * gib + tolerance) == Right(9))
+      assert(validateConfiguredHeap(ciProfile, 8L * gib - tolerance - 1L).isLeft)
+      assert(validateConfiguredHeap(ciProfile, 8L * gib + tolerance + 1L).isLeft)
+      assert(validateConfiguredHeap(ciProfile.copy(heapGiB = 0), 8L * gib).isLeft)
+      assert(validateConfiguredHeap(ciProfile.copy(heapGiB = Int.MaxValue), Long.MaxValue).isLeft)
+    }
+
+    test("configured heap admission uses the observed rounded-up heap") {
+      val gib       = 1024L * 1024L * 1024L
+      val requested = Profile("ci", memoryGiB = 10, reserveGiB = 4, heapGiB = 6, 1, 1, 4, 30)
+
+      assert(validate(requested).isRight)
+      assert(validateConfiguredHeap(requested, 6L * gib) == Right(6))
+      assert(validateConfiguredHeap(requested, 6L * gib + 1L).isLeft)
+    }
+
+    test("benchmark child output directory must be isolated from the orchestrator") {
+      val root         = os.Path("/tmp/linker-benchmark-output-validation")
+      val orchestrator = root / "orchestrator"
+      val alias        = os.Path(s"$orchestrator/nested/..")
+      val child        = root / "lane-0"
+      val message      = "benchmark child output directory must differ from the orchestrator output directory"
+
+      assert(validateChildOutputDirectory(orchestrator, orchestrator) == Left(message))
+      assert(validateChildOutputDirectory(orchestrator, alias) == Left(message))
+      assert(validateChildOutputDirectory(orchestrator, child) == Right(child))
+    }
+
+    test("benchmark child output directory must be physically outside the workspace") {
+      val root          = os.temp.dir(prefix = "linker-benchmark-external-output-")
+      val workspace     = root / "workspace"
+      val workspaceLink = root / "workspace-link"
+      val externalLane  = root / "external-run" / "lane-0"
+      try {
+        os.makeDir.all(workspace / "inside")
+        os.makeDir.all(externalLane)
+        java.nio.file.Files.createSymbolicLink(workspaceLink.toNIO, workspace.toNIO)
+
+        assert(validateExternalChildOutputDirectory(workspace, workspace / "inside").isLeft)
+        assert(validateExternalChildOutputDirectory(workspace, workspaceLink / "inside").isLeft)
+        assert(validateExternalChildOutputDirectory(workspace, externalLane) == Right(externalLane))
+      } finally os.remove.all(root)
+    }
+
+    test("physical path validation rejects symlink aliases and containment escapes") {
+      val root     = os.temp.dir(prefix = "linker-benchmark-paths-")
+      val real     = root / "real"
+      val alias    = root / "alias"
+      val lane     = root / "lane"
+      val external = root / "external"
+      try {
+        os.makeDir.all(real / "out")
+        os.makeDir.all(lane)
+        os.makeDir.all(external)
+        java.nio.file.Files.createSymbolicLink(alias.toNIO, real.toNIO)
+        java.nio.file.Files.createSymbolicLink((lane / "escaped").toNIO, external.toNIO)
+
+        val collision = "benchmark child output directory must differ from the orchestrator output directory"
+        assert(validateChildOutputDirectory(real / "out", alias / "out") == Left(collision))
+        assert(validatePhysicalDescendant(lane, lane / "escaped" / "proof", "artifact escaped") ==
+          Left("artifact escaped"))
+      } finally os.remove.all(root)
+    }
+
+    test("smoke run validation rejects symlink deletion escapes and preserves external files") {
+      val root      = os.temp.dir(prefix = "linker-benchmark-delete-")
+      val workspace = root / "workspace"
+      val smokeBase = workspace / ".dev" / ".sdlc" / "mill-jvm-worker-pool" / "out" / "smoke"
+      val external  = root / "external"
+      val sentinel  = external / "sentinel"
+      try {
+        os.makeDir.all(smokeBase)
+        os.makeDir.all(external)
+        os.write(sentinel, "keep")
+        java.nio.file.Files.createSymbolicLink((smokeBase / "run").toNIO, external.toNIO)
+
+        val validated = validateSmokeRunDirectory(workspace, smokeBase, smokeBase / "run")
+        validated.foreach(path => os.remove.all(os.Path(path)))
+
+        assert(validated.isLeft)
+        assert(os.read(sentinel) == "keep")
+      } finally os.remove.all(root)
+    }
+
+    test("external smoke cleanup is constrained to its uniquely-created temp run root") {
+      val root          = os.temp.dir(prefix = "linker-benchmark-external-cleanup-")
+      val workspace     = root / "workspace"
+      val temporaryBase = root / "tmp"
+      val external      = root / "external"
+      val sentinel      = external / "sentinel"
+      try {
+        os.makeDir.all(workspace)
+        os.makeDir.all(temporaryBase)
+        os.makeDir.all(external)
+        os.write(sentinel, "keep")
+        val allocated = os.Path(
+          java.nio.file.Files.createTempDirectory(temporaryBase.toNIO, "morphir-linker-smoke-")
+        )
+        val escape = temporaryBase / "morphir-linker-smoke-escape"
+        java.nio.file.Files.createSymbolicLink(escape.toNIO, external.toNIO)
+
+        assert(validateExternalSmokeCleanupRoot(workspace, temporaryBase, allocated).isRight)
+        assert(validateExternalSmokeCleanupRoot(workspace, temporaryBase, allocated / "lane-0").isLeft)
+        val rejected = validateExternalSmokeCleanupRoot(workspace, temporaryBase, escape)
+        rejected.foreach(path => os.remove.all(os.Path(path)))
+
+        assert(rejected.isLeft)
+        assert(os.read(sentinel) == "keep")
+      } finally os.remove.all(root)
+    }
+
+    test("platforms expose stable tokens and exact linker selectors") {
+      assert(Platform.ScalaJs.token == "scala-js")
+      assert(Platform.ScalaJs.selector == "morphir.__.js.__.fastLinkJSTest")
+      assert(Platform.Wasm.token == "wasm")
+      assert(Platform.Wasm.selector == "morphir.__.wasm.fullLinkJS")
+      assert(Platform.Native.token == "native")
+      assert(Platform.Native.selector == "morphir.__.native.__.test.nativeLink")
+    }
+
+    test("strategies expose stable tokens") {
+      assert(Strategy.LongLived.token == "long-lived")
+      assert(Strategy.Fresh.token == "fresh")
+      assert(Strategy.Recycled.token == "recycled")
+    }
+
+    test("profile validation accepts the CI profile") {
+      assert(ciProfile == Profile("ci", 16, 4, 8, 2, 1, 4, 30))
+      assert(validate(ciProfile) == Right(ciProfile))
+      assert(validate(Profile("ci", 16, 4, 8, 4, 1, 2, 30)).isRight)
+    }
+
+    test("profile validation rejects invalid fields and excess memory") {
+      assert(validate(Profile("ci", 0, 4, 8, 2, 1, 4, 30)).isLeft)
+      assert(validate(Profile("ci", 16, -1, 8, 2, 1, 4, 30)).isLeft)
+      assert(validate(Profile("ci", 16, 4, 0, 2, 1, 4, 30)).isLeft)
+      assert(validate(Profile("ci", 16, 4, 8, 0, 1, 4, 30)).isLeft)
+      assert(validate(Profile("ci", 16, 4, 8, 2, 0, 4, 30)).isLeft)
+      assert(validate(Profile("ci", 16, 4, 8, 2, 1, 0, 30)).isLeft)
+      assert(validate(Profile("ci", 16, 4, 8, 2, 1, 4, 0)).isLeft)
+      assert(validate(Profile("ci", 16, 4, 8, 2, 1, 4, -1)).isLeft)
+      assert(validate(Profile("ci", 16, 9, 8, 4, 1, 2, 30)).isLeft)
+    }
+
+    test("local profile derives admitted children from host memory and processors") {
+      assert(localProfile(memoryGiB = 32, availableProcessors = 8) ==
+        Right(Profile("local", 32, 8, 8, 2, 2, 4, 30)))
+      assert(localProfile(memoryGiB = 16, availableProcessors = 8) ==
+        Right(Profile("local", 16, 4, 8, 1, 1, 4, 30)))
+      assert(localProfile(memoryGiB = 8, availableProcessors = 8).isLeft)
+      assert(localProfile(memoryGiB = 32, availableProcessors = 0).isLeft)
+    }
+
+    test("evaluation settings require at least one trial") {
+      assert(defaultEvaluationSettings == EvaluationSettings(3, 0L))
+      assert(validate(defaultEvaluationSettings) == Right(defaultEvaluationSettings))
+      assert(validate(EvaluationSettings(0, 0L)).isLeft)
+      assert(validate(EvaluationSettings(-1, 0L)).isLeft)
+    }
+
+    test("strategy orders rotate canonically and reproducibly") {
+      val input    = Seq(Strategy.Recycled, Strategy.LongLived, Strategy.Fresh, Strategy.LongLived)
+      val settings = EvaluationSettings(3, 0L)
+      val expected = Seq(
+        Seq(Strategy.LongLived, Strategy.Fresh, Strategy.Recycled),
+        Seq(Strategy.Fresh, Strategy.Recycled, Strategy.LongLived),
+        Seq(Strategy.Recycled, Strategy.LongLived, Strategy.Fresh)
+      )
+
+      assert(strategyOrders(input, settings) == expected)
+      assert(strategyOrders(input.reverse, settings) == expected)
+      assert(strategyOrders(input, settings) == strategyOrders(input, settings))
+      assert(strategyOrders(Seq.empty, settings).isEmpty)
+      assert(strategyOrders(input, EvaluationSettings(0, 0L)).isEmpty)
+    }
+
+    test("strategy order rotation supports negative seeds") {
+      val expected = Seq(Seq(Strategy.Recycled, Strategy.LongLived, Strategy.Fresh))
+      assert(strategyOrders(Strategy.values.toSeq, EvaluationSettings(1, -1L)) == expected)
+    }
+
+    test("strategy order rotation does not overflow at the maximum seed") {
+      val orders = strategyOrders(Strategy.values.toSeq, EvaluationSettings(3, Long.MaxValue))
+      assert(orders.map(_.head) == Seq(Strategy.Fresh, Strategy.Recycled, Strategy.LongLived))
+      assert(orders.map(_.head).distinct.size == 3)
+    }
+
+    test("plan normalizes and deterministically batches targets") {
+      val targets  = Seq("e", "c", "a", "b", "a", "d")
+      val expected = WorkPlan(
+        lanes = 2,
+        batches = Seq(
+          Batch(lane = 0, index = 0, targets = Seq("a")),
+          Batch(lane = 0, index = 2, targets = Seq("c")),
+          Batch(lane = 0, index = 4, targets = Seq("e")),
+          Batch(lane = 1, index = 1, targets = Seq("b")),
+          Batch(lane = 1, index = 3, targets = Seq("d"))
+        )
+      )
+
+      assert(plan(targets, lanes = 2, batchSize = 1) == Right(expected))
+      assert(plan(targets.reverse, lanes = 2, batchSize = 1) == Right(expected))
+      assert(expected.batches.flatMap(_.targets) == Seq("a", "c", "e", "b", "d"))
+    }
+
+    test("plan deduplicates and sorts targets deterministically") {
+      val targets = Seq("c", "a", "b", "a", "d")
+      val forward = plan(targets, lanes = 2, batchSize = 2)
+      val reverse = plan(targets.reverse, lanes = 2, batchSize = 2)
+
+      assert(forward == reverse)
+      val flattened = forward.toOption.toSeq.flatMap(_.batches).flatMap(_.targets)
+      assert(flattened == Seq("a", "b", "c", "d"))
+      assert(flattened.distinct.size == 4)
+    }
+
+    test("plan rejects invalid inputs") {
+      assert(plan(Seq.empty, lanes = 1, batchSize = 1).isLeft)
+      assert(plan(Seq("a"), lanes = 0, batchSize = 1).isLeft)
+      assert(plan(Seq("a"), lanes = 1, batchSize = 0).isLeft)
+    }
+
+    test("strategy plans use the required worker lifetimes") {
+      val targets = Seq("a", "b", "c", "d", "e")
+      val profile = ciProfile
+
+      val longLived = strategyPlan(Strategy.LongLived, targets, profile).toOption.get
+      val fresh     = strategyPlan(Strategy.Fresh, targets, profile).toOption.get
+      val recycled  = strategyPlan(Strategy.Recycled, targets, profile).toOption.get
+
+      assert(longLived == WorkPlan(1, Seq(Batch(0, 0, targets))))
+      assert(fresh.batches.forall(_.targets.size == 1))
+      assert(fresh.batches.map(_.lane).distinct.size == profile.maxChildren)
+      assert(recycled.batches.forall(_.targets.size <= profile.batchSize))
+      assert(recycled.batches.flatMap(_.targets).sorted == targets)
+    }
+
+    test("preparation lanes preserve strategy worker lifetimes and lane order") {
+      val targets = Seq("a", "b", "c", "d", "e")
+
+      val longLived = preparationLanes(strategyPlan(Strategy.LongLived, targets, ciProfile).toOption.get)
+      val fresh     = preparationLanes(strategyPlan(Strategy.Fresh, targets, ciProfile).toOption.get)
+      val recycled  = preparationLanes(strategyPlan(Strategy.Recycled, targets, ciProfile).toOption.get)
+
+      assert(longLived == Seq(PreparationLane(0, Seq(Batch(0, 0, targets)))))
+      assert(fresh == Seq(PreparationLane(
+        0,
+        targets.zipWithIndex.map { case (target, index) =>
+          Batch(0, index, Seq(target))
+        }
+      )))
+      assert(recycled == Seq(PreparationLane(0, Seq(Batch(0, 0, targets.take(4)), Batch(0, 1, targets.drop(4))))))
+
+      val twoLaneFresh = preparationLanes(plan(targets, lanes = 2, batchSize = 1).toOption.get)
+      assert(twoLaneFresh.map(_.lane) == Seq(0, 1))
+      assert(twoLaneFresh.flatMap(_.batches).map(_.index) == Seq(0, 2, 4, 1, 3))
+    }
+
+    test("child Mill arguments apply the profile job limit") {
+      assert(
+        millChildArguments(ciProfile, Seq("ci.linkerBenchmarkInventory")) ==
+          Seq("--ticker", "false", "--no-daemon", "-j", "2", "ci.linkerBenchmarkInventory")
+      )
+    }
+
+    test("preparation decisions skip unsafe measurements and honor continuation") {
+      assert(
+        preparationDecision(Seq(Outcome.Succeeded, Outcome.Succeeded), continueOnFailure = false) ==
+          PreparationDecision(measure = true, Outcome.Succeeded, failRun = false)
+      )
+      assert(
+        preparationDecision(Seq(Outcome.Succeeded, Outcome.Failed), continueOnFailure = false) ==
+          PreparationDecision(measure = false, Outcome.Failed, failRun = true)
+      )
+      assert(
+        preparationDecision(Seq(Outcome.Succeeded, Outcome.TimedOut), continueOnFailure = true) ==
+          PreparationDecision(measure = false, Outcome.TimedOut, failRun = false)
+      )
+      assert(preparationDecision(Seq.empty, continueOnFailure = true).measure == false)
+    }
+
+    test("concurrent lane failure interrupts and retires sibling work") {
+      val siblingStarted = CountDownLatch(1)
+      val siblingRetired = CountDownLatch(1)
+      val siblingBlock   = CountDownLatch(1)
+      val failure        = assertThrows[IllegalStateException] {
+        runConcurrentLanes(
+          parallelism = 2,
+          tasks = Seq(
+            () => {
+              assert(siblingStarted.await(5L, TimeUnit.SECONDS))
+              throw IllegalStateException("lane failed")
+            },
+            () => {
+              siblingStarted.countDown()
+              try siblingBlock.await()
+              finally siblingRetired.countDown()
+              1
+            }
+          ),
+          cleanupTimeout = 5.seconds
+        )
+      }
+
+      assert(failure.getMessage == "lane failed")
+      assert(siblingRetired.await(1L, TimeUnit.SECONDS))
+    }
+
+    test("atomic text failure removes its temporary file") {
+      val directory = os.temp.dir(prefix = "linker-benchmark-atomic-")
+      val target    = directory / "result.json"
+      val failingMove: (java.nio.file.Path, java.nio.file.Path) => Unit =
+        (_: java.nio.file.Path, _: java.nio.file.Path) => throw IllegalStateException("move failed")
+      try {
+        val failure = assertThrows[IllegalStateException] {
+          writeTextAtomically(target, "payload", failingMove)
+        }
+
+        assert(failure.getMessage == "move failed")
+        assert(!os.exists(target))
+        assert(os.list(directory).isEmpty)
+      } finally os.remove.all(directory)
+    }
+
+    test("model values have uPickle read writers") {
+      def roundTrip[A: ReadWriter](value: A): A = read[A](write(value))
+
+      assert(roundTrip(Platform.ScalaJs) == Platform.ScalaJs)
+      assert(roundTrip(Strategy.Recycled) == Strategy.Recycled)
+      assert(roundTrip(ciProfile) == ciProfile)
+      assert(roundTrip(Batch(1, 2, Seq("target"))) == Batch(1, 2, Seq("target")))
+      val workPlan = WorkPlan(2, Seq(Batch(0, 0, Seq("target"))))
+      assert(roundTrip(workPlan) == workPlan)
+      assert(roundTrip(defaultEvaluationSettings) == defaultEvaluationSettings)
+    }
+
+    test("outcomes round trip through uPickle") {
+      Outcome.values.foreach(outcome => assert(read[Outcome](write(outcome)) == outcome))
+    }
+
+    test("JVM snapshot deltas use phase completion values and nonnegative GC changes") {
+      val before = JvmSnapshot(heapUsedBytes = 100L, peakHeapBytes = 200L, gcCount = 12L, gcMillis = 40L)
+      val after  = JvmSnapshot(heapUsedBytes = 125L, peakHeapBytes = 260L, gcCount = 10L, gcMillis = 55L)
+
+      val metrics = JvmSnapshot.phaseDelta("cold-link", 900L, before, after, evaluated = 8L, cached = 2L)
+
+      assert(
+        metrics == PhaseMetrics(
+          name = "cold-link",
+          wallMillis = 900L,
+          heapUsedBytes = 125L,
+          peakHeapBytes = 260L,
+          gcCount = 0L,
+          gcMillis = 15L,
+          evaluated = 8L,
+          cached = 2L
+        )
+      )
+    }
+
+    test("JVM snapshots capture live nonnegative metrics") {
+      JvmSnapshot.resetPeakUsage()
+      val snapshot = JvmSnapshot.capture()
+      assert(snapshot.heapUsedBytes >= 0L)
+      assert(snapshot.peakHeapBytes >= 0L)
+      assert(snapshot.gcCount >= 0L)
+      assert(snapshot.gcMillis >= 0L)
+    }
+
+    test("JVM metric folding sums pools, ignores unsupported values, and saturates") {
+      assert(JvmSnapshot.sumNonnegative(Seq(10L, 20L, -1L)) == 30L)
+      assert(JvmSnapshot.sumNonnegative(Seq(Long.MaxValue - 5L, 10L)) == Long.MaxValue)
+      assert(JvmSnapshot.sumNonnegative(Seq(-1L, -20L)) == 0L)
+    }
+
+    test("worker and benchmark records round trip through uPickle") {
+      val phase  = PhaseMetrics("cold-link", 700L, 256L, 512L, 2L, 20L, 6L, 1L)
+      val worker = WorkerRecord(
+        runId = "run-1",
+        trial = 1,
+        strategyPosition = 2,
+        settings = defaultEvaluationSettings,
+        platform = Platform.ScalaJs,
+        strategy = Strategy.Recycled,
+        profile = ciProfile,
+        lane = 0,
+        batch = 3,
+        targets = Seq("morphir.foo.js.test.fastLinkJS"),
+        startupMillis = 100L,
+        peakRssKiB = 2048L,
+        phases = Seq(phase),
+        outcome = Outcome.Succeeded,
+        detail = Some("complete")
+      )
+      val strategyTrial = StrategyTrialRecord(
+        "run-1",
+        1,
+        2,
+        Platform.ScalaJs,
+        Strategy.Recycled,
+        ciProfile,
+        900L,
+        4096L,
+        1L,
+        Outcome.Succeeded
+      )
+      val result = BenchmarkResult(defaultResolvedConfiguration, 8192L, Seq(strategyTrial), Seq(worker))
+
+      assert(read[WorkerRecord](write(worker)) == worker)
+      assert(read[BenchmarkResult](write(result)) == result)
+      assert(write(worker).contains("512"))
+      val resultFields = ujson.read(write(result)).obj.keySet
+      assert(resultFields.contains("configuration"))
+      assert(!resultFields.contains("settings"))
+    }
+
+    test("aggregation summarizes successful strategy elapsed time") {
+      val cases   = Seq(strategyTrial(1, 1400L), strategyTrial(2, 900L), strategyTrial(3, 1000L))
+      val summary = aggregate(cases, cases.map(value => worker(value.trial))).head
+
+      assert(summary.wallMillis.contains(LongSummary(1000L, 900L, 1400L)))
+      assert(summary.peakAggregateRssKiB.contains(LongSummary(4096L, 4096L, 4096L)))
+      assert(summary.succeeded == 3)
+      assert(summary.failed == 0)
+    }
+
+    test("aggregation keeps distinct profiles that share a name") {
+      val otherProfile = ciProfile.copy(heapGiB = 4, maxChildren = 2)
+      val cases        = Seq(
+        strategyTrial(1, 900L),
+        strategyTrial(2, 1000L, profile = otherProfile)
+      )
+      val records = Seq(
+        worker(1),
+        worker(2, profile = otherProfile)
+      )
+      val summaries = aggregate(cases, records)
+
+      assert(summaries.size == 2)
+      assert(summaries.map(_.profile).toSet == Set(ciProfile, otherProfile))
+    }
+
+    test("aggregation collapses workers per trial before summarizing") {
+      val cases   = Seq(strategyTrial(1, 1000L), strategyTrial(2, 2000L))
+      val records = Seq(
+        worker(1, lane = 0, startupMillis = 100L, peakRssKiB = 1000L, peakHeapBytes = 300L, gcMillis = 10L),
+        worker(1, lane = 1, startupMillis = 200L, peakRssKiB = 1500L, peakHeapBytes = 400L, gcMillis = 20L),
+        worker(2, lane = 0, startupMillis = 500L, peakRssKiB = 2500L, peakHeapBytes = 800L, gcMillis = 100L)
+      )
+      val summary = aggregate(cases, records).head
+
+      assert(summary.startupShare.exists(value => math.abs(value.min - 3.0 / 17.0) < 0.0000001))
+      assert(summary.startupShare.exists(value => math.abs(value.max - 5.0 / 12.0) < 0.0000001))
+      assert(summary.throughputTargetsPerMinute.exists(value => value.min == 120.0 && value.max == 240.0))
+      assert(summary.peakChildRssKiB.contains(LongSummary(2000L, 1500L, 2500L)))
+      assert(summary.peakHeapBytes.contains(LongSummary(600L, 400L, 800L)))
+      assert(summary.gcShare.exists(value => math.abs(value.min - 3.0 / 140.0) < 0.0000001))
+      assert(summary.gcShare.exists(value => math.abs(value.max - 1.0 / 7.0) < 0.0000001))
+    }
+
+    test("aggregation excludes workers from another strategy position") {
+      val caseRecord    = strategyTrial(1, 1000L).copy(strategyPosition = 1)
+      val wrongPosition = worker(1, startupMillis = 500L).copy(strategyPosition = 2)
+      val summary       = aggregate(Seq(caseRecord), Seq(wrongPosition)).head
+
+      assert(summary.wallMillis.nonEmpty)
+      assert(summary.startupShare.isEmpty)
+      assert(summary.peakChildRssKiB.isEmpty)
+    }
+
+    test("aggregation and rendering collapse identical duplicate identities") {
+      val caseRecord   = strategyTrial(1, 1000L)
+      val workerRecord = worker(1)
+      val result       = BenchmarkResult(
+        defaultResolvedConfiguration,
+        8192L,
+        Seq(caseRecord, caseRecord),
+        Seq(workerRecord, workerRecord)
+      )
+      val summary = aggregate(result.cases, result.records).head
+      val report  = renderMarkdown(result)
+
+      assert(summary.succeeded == 1)
+      assert(report.linesIterator.count(_.startsWith("| 1 |")) == 2)
+    }
+
+    test("aggregation rejects conflicting duplicate case identities") {
+      val caseRecord = strategyTrial(1, 1000L)
+      val error      = assertThrows[IllegalArgumentException] {
+        aggregate(Seq(caseRecord, caseRecord.copy(wallMillis = 1200L)), Seq(worker(1)))
+      }
+
+      assert(error.getMessage.contains("strategy trial identity"))
+    }
+
+    test("aggregation rejects conflicting duplicate worker identities") {
+      val workerRecord = worker(1)
+      val error        = assertThrows[IllegalArgumentException] {
+        aggregate(Seq(strategyTrial(1, 1000L)), Seq(workerRecord, workerRecord.copy(startupMillis = 200L)))
+      }
+
+      assert(error.getMessage.contains("worker identity"))
+    }
+
+    test("even medians do not overflow") {
+      val cases = Seq(
+        strategyTrial(1, Long.MaxValue - 1L, peakAggregateRssKiB = Long.MaxValue - 1L),
+        strategyTrial(2, Long.MaxValue, peakAggregateRssKiB = Long.MaxValue)
+      )
+      val summary = aggregate(cases, Seq(worker(1), worker(2))).head
+
+      assert(summary.wallMillis.exists(_.median == Long.MaxValue - 1L))
+      assert(summary.peakAggregateRssKiB.exists(_.median == Long.MaxValue - 1L))
+    }
+
+    test("failed-only groups retain outcomes without numeric summaries") {
+      val summary = aggregate(
+        Seq(strategyTrial(1, 900L, Outcome.Failed), strategyTrial(2, 1000L, Outcome.TimedOut)),
+        Seq(worker(1, outcome = Outcome.Failed), worker(2, outcome = Outcome.TimedOut))
+      ).head
+
+      assert(summary.failed == 1)
+      assert(summary.timedOut == 1)
+      assert(summary.wallMillis.isEmpty)
+      assert(summary.peakAggregateRssKiB.isEmpty)
+      assert(summary.startupShare.isEmpty)
+    }
+
+    test("worker-time shares are unavailable for nonpositive denominators") {
+      val zeroWorker = worker(1, startupMillis = 0L).copy(
+        phases = Seq(PhaseMetrics("zero", 0L, 0L, 0L, 0L, 10L, 0L, 0L))
+      )
+      val summary = aggregate(Seq(strategyTrial(1, 1000L)), Seq(zeroWorker)).head
+
+      assert(summary.startupShare.isEmpty)
+      assert(summary.gcShare.isEmpty)
+      assert(summary.peakChildRssKiB.nonEmpty)
+    }
+
+    test("double summaries ignore non-finite values and average without overflow") {
+      assert(summarizeDoubles(Seq(Double.NaN, Double.PositiveInfinity, Double.NegativeInfinity)).isEmpty)
+      val summary = summarizeDoubles(Seq(Double.MaxValue, Double.MaxValue)).get
+      assert(summary.median == Double.MaxValue)
+      assert(summary.min == Double.MaxValue)
+      assert(summary.max == Double.MaxValue)
+    }
+
+    test("redaction removes home identities and secret assignment values") {
+      val redacted = redact(
+        "mac=/Users/example/project linux=/home/example/project SECRET_TOKEN=needle PASSWORD=hunter2 api_token=lower Mixed_Secret=mixed"
+      )
+
+      assert(!redacted.contains("example"))
+      assert(!redacted.contains("needle"))
+      assert(!redacted.contains("hunter2"))
+      assert(!redacted.contains("lower"))
+      assert(!redacted.contains("mixed"))
+      assert(redacted.contains("SECRET_TOKEN"))
+    }
+
+    test("redaction removes bare environment secrets from an explicit map") {
+      val redacted = redact(
+        "long=abcdef short=abc ordinary=visible",
+        Map(
+          "DB_SECRET"      -> "abcdef",
+          "api_token"      -> "abc",
+          "ordinary"       -> "visible",
+          "EMPTY_PASSWORD" -> ""
+        )
+      )
+
+      assert(!redacted.contains("abcdef"))
+      assert(!redacted.contains("abc"))
+      assert(redacted == "long=<redacted> short=<redacted> ordinary=visible")
+    }
+
+    test("markdown reports are redacted and contain raw and aggregate metrics") {
+      val unsafeProfile = ciProfile.copy(name = "/Users/report-user SECRET_TOKEN=profile-secret")
+      val caseRecord    = strategyTrial(1, 900L, profile = unsafeProfile)
+      val record        = worker(
+        1,
+        detail = Some("SECRET_TOKEN=report-secret /Users/report-user/private"),
+        profile = unsafeProfile
+      ).copy(targets = Seq("/home/report-user/SECRET_TOKEN=target-secret"))
+      val preparation = PreparationRecord(
+        "run-1",
+        1,
+        Platform.ScalaJs,
+        Strategy.Recycled,
+        unsafeProfile,
+        0,
+        450L,
+        Seq("target-0"),
+        Outcome.Succeeded
+      )
+      val report = renderMarkdown(
+        BenchmarkResult(defaultResolvedConfiguration, 8192L, Seq(caseRecord), Seq(record), Seq(preparation))
+      )
+
+      assert(report.contains("Preset: js-strategies"))
+      assert(report.contains("Profile: ci; memory: 16 GiB; reserve: 4 GiB; heap: 8 GiB"))
+      assert(report.contains("Platforms: scala-js"))
+      assert(report.contains("Strategies: long-lived, fresh, recycled"))
+      assert(report.contains("Trials: 3; order seed: 0"))
+      assert(report.contains("Target filter: none; target limit: none"))
+      assert(report.contains("Continue on failure: true"))
+      assert(report.contains("recycled"))
+      assert(report.contains("Whole-run peak aggregate RSS: 8192 KiB"))
+      assert(report.contains("## Strategy trials"))
+      assert(report.contains("## Preparation"))
+      assert(report.contains("Worker phase wall"))
+      assert(report.contains("Successful wall ms"))
+      assert(report.contains("Targets/min"))
+      assert(report.contains("Worker-time startup share"))
+      assert(report.contains("Worker-time GC share"))
+      assert(!report.contains("profile-secret"))
+      assert(!report.contains("report-user"))
+      assert(report.endsWith("\n"))
+    }
+
+    test("worker runtime metadata round trips") {
+      val runtime = RuntimeMetadata("21", "1.2.0", "Mac OS X", "aarch64", 8, 8589934592L, "lane-id")
+      val record  = worker(1).copy(runtime = runtime)
+
+      assert(read[WorkerRecord](write(record)).runtime == runtime)
+    }
+
+    test("sanitized JSON redacts every free-text field") {
+      val environment   = Map("API_TOKEN" -> "bare-environment-secret")
+      val unsafeProfile = ciProfile.copy(
+        name = "profile /Users/profile-user SECRET_TOKEN=profile-secret"
+      )
+      val caseRecord = strategyTrial(1, 900L, profile = unsafeProfile).copy(
+        runId = "/home/run-user/bare-environment-secret"
+      )
+      val record = worker(
+        1,
+        detail = Some("Mixed_Password=detail-secret"),
+        profile = unsafeProfile
+      ).copy(
+        runId = caseRecord.runId,
+        targets = Seq("/home/target-user API_KEY=target-secret"),
+        phases = Seq(PhaseMetrics("/Users/phase-user api_token=phase-secret", 1L, 2L, 3L, 4L, 5L, 6L, 7L))
+      )
+      val json = renderJson(
+        BenchmarkResult(defaultResolvedConfiguration, 8192L, Seq(caseRecord), Seq(record)),
+        environment
+      )
+
+      Seq(
+        "profile-user",
+        "profile-secret",
+        "run-user",
+        "bare-environment-secret",
+        "target-user",
+        "target-secret",
+        "phase-user",
+        "phase-secret",
+        "detail-secret"
+      ).foreach(secret => assert(!json.contains(secret)))
+      assert(read[BenchmarkResult](json).records.head.detail.exists(_.contains("<redacted>")))
+    }
+
+    test("markdown escapes profile table delimiters and line breaks") {
+      val unsafeProfile = ciProfile.copy(name = "profile|row\nbreak\\slash /Users/table-user")
+      val caseRecord    = strategyTrial(1, 900L, profile = unsafeProfile)
+      val record        = worker(1, profile = unsafeProfile)
+      val report  = renderMarkdown(BenchmarkResult(defaultResolvedConfiguration, 8192L, Seq(caseRecord), Seq(record)))
+      val rawRows = report.linesIterator.filter(_.startsWith("| 1 |")).toSeq
+
+      assert(rawRows.size == 2)
+      assert(rawRows.forall(_.contains("profile\\|row break\\\\slash")))
+      assert(!report.contains("table-user"))
+    }
+
+    test("markdown raw rows use deterministic benchmark order") {
+      val first  = worker(2, lane = 1, strategy = Strategy.Fresh).copy(strategyPosition = 1, batch = 2)
+      val second = worker(1, lane = 1, strategy = Strategy.Recycled).copy(strategyPosition = 2, batch = 1)
+      val third  = worker(1, lane = 0, strategy = Strategy.LongLived).copy(strategyPosition = 0, batch = 3)
+      val result = BenchmarkResult(
+        defaultResolvedConfiguration,
+        8192L,
+        Seq(
+          strategyTrial(2, 900L, strategy = Strategy.Fresh).copy(strategyPosition = 1),
+          strategyTrial(1, 900L, strategy = Strategy.Recycled).copy(strategyPosition = 2),
+          strategyTrial(1, 900L, strategy = Strategy.LongLived).copy(strategyPosition = 0)
+        ),
+        Seq(first, second, third)
+      )
+      val report = renderMarkdown(result)
+
+      assert(report.indexOf("| 1 | 0 |") < report.indexOf("| 1 | 2 |"))
+      assert(report.indexOf("| 1 | 2 |") < report.indexOf("| 2 | 1 |"))
+      assert(renderMarkdown(result.copy(records = result.records.reverse)) == report)
+    }
+  }
+}

--- a/millbuildHelpers/test/src/millbuild/LinkerBenchmarkTests.scala
+++ b/millbuildHelpers/test/src/millbuild/LinkerBenchmarkTests.scala
@@ -195,6 +195,8 @@ object LinkerBenchmarkTests extends TestSuite {
     }
 
     test("hosted resource bounds accept their limits and reject larger values") {
+      assert(maxHostedMemoryGiB == 16)
+      assert(maxHostedReserveGiB == 15)
       val atLimits = BenchmarkOverrides(
         trials = Some(maxHostedTrials),
         targetLimit = Some(maxHostedTargetLimit),
@@ -228,6 +230,17 @@ object LinkerBenchmarkTests extends TestSuite {
         BenchmarkOverrides(timeoutMinutes = Some(Int.MaxValue))
       )
       assert((aboveLimits ++ maximumValues).forall(validateHostedOverrideBounds(_).isLeft))
+    }
+
+    test("hosted order seeds are nonnegative while direct mode retains signed seeds") {
+      val local     = Profile("local", 32, 8, 8, 2, 2, 4, 30)
+      val overrides = BenchmarkOverrides(orderSeed = Some(-1L))
+
+      assert(resolveHostedConfiguration("quick-smoke", overrides).isLeft)
+      assert(
+        resolveBenchmarkConfiguration("", "local", local, overrides).toOption.map(_.settings.orderSeed) ==
+          Some(-1L)
+      )
     }
 
     test("configuration JSON is sanitized and matches the configuration embedded in final results") {
@@ -308,10 +321,10 @@ object LinkerBenchmarkTests extends TestSuite {
         orderSeed = Some(7L),
         targetFilter = Some("langkit"),
         targetLimit = Some(3),
-        memoryGiB = Some(32),
+        memoryGiB = Some(16),
         reserveGiB = Some(4),
         millJobs = Some(3),
-        maxChildren = Some(3),
+        maxChildren = Some(1),
         batchSize = Some(2),
         timeoutMinutes = Some(45),
         continueOnFailure = Some(false)
@@ -323,7 +336,7 @@ object LinkerBenchmarkTests extends TestSuite {
       assert(resolved.settings == EvaluationSettings(2, 7L))
       assert(resolved.targetFilter.contains("langkit"))
       assert(resolved.targetLimit.contains(3))
-      assert(resolved.profile == Profile("ci", 32, 4, 8, 3, 3, 2, 45))
+      assert(resolved.profile == Profile("ci", 16, 4, 8, 3, 1, 2, 45))
       assert(!resolved.continueOnFailure)
       assert(resolveHostedConfiguration("native-long-lived", BenchmarkOverrides()).toOption.get ==
         hostedPreset("native-long-lived").toOption.get)
@@ -991,6 +1004,227 @@ object LinkerBenchmarkTests extends TestSuite {
           PreparationDecision(measure = false, Outcome.TimedOut, failRun = false)
       )
       assert(preparationDecision(Seq.empty, continueOnFailure = true).measure == false)
+    }
+
+    test("evaluation schedule is flattened by trial, strategy position, then platform") {
+      val orders = Seq(
+        Seq(Strategy.Fresh, Strategy.Recycled),
+        Seq(Strategy.Recycled, Strategy.Fresh)
+      )
+
+      assert(
+        evaluationSchedule(orders, Seq(Platform.ScalaJs, Platform.Wasm)) == Seq(
+          EvaluationCase(0, 0, Platform.ScalaJs, Strategy.Fresh),
+          EvaluationCase(0, 0, Platform.Wasm, Strategy.Fresh),
+          EvaluationCase(0, 1, Platform.ScalaJs, Strategy.Recycled),
+          EvaluationCase(0, 1, Platform.Wasm, Strategy.Recycled),
+          EvaluationCase(1, 0, Platform.ScalaJs, Strategy.Recycled),
+          EvaluationCase(1, 0, Platform.Wasm, Strategy.Recycled),
+          EvaluationCase(1, 1, Platform.ScalaJs, Strategy.Fresh),
+          EvaluationCase(1, 1, Platform.Wasm, Strategy.Fresh)
+        )
+      )
+    }
+
+    test("evaluation stops scheduling after the first failed case unless continuation is enabled") {
+      val scheduled                                                   = Seq("first", "failing", "never")
+      def execute(continueOnFailure: Boolean): Seq[(String, Outcome)] =
+        runEvaluationSchedule(scheduled, continueOnFailure) { value =>
+          if value == "failing" then Outcome.Failed else Outcome.Succeeded
+        }
+
+      assert(execute(continueOnFailure = false).map(_._1) == Seq("first", "failing"))
+      assert(execute(continueOnFailure = true).map(_._1) == scheduled)
+    }
+
+    test("worker identity validation rejects every mismatched identity family") {
+      val actual = worker(trial = 2, lane = 3).copy(
+        runId = "run-expected",
+        strategyPosition = 4,
+        settings = EvaluationSettings(5, 6L),
+        platform = Platform.Wasm,
+        strategy = Strategy.Fresh,
+        profile = ciProfile.copy(name = "expected-profile"),
+        batch = 7,
+        targets = Seq("one", "two")
+      )
+      val expected  = WorkerIdentity.from(actual)
+      val mutations = Seq(
+        actual.copy(runId = "wrong"),
+        actual.copy(settings = actual.settings.copy(orderSeed = 99L)),
+        actual.copy(platform = Platform.Native),
+        actual.copy(strategy = Strategy.Recycled),
+        actual.copy(profile = actual.profile.copy(timeoutMinutes = 99)),
+        actual.copy(trial = 99),
+        actual.copy(strategyPosition = 99),
+        actual.copy(lane = 99),
+        actual.copy(batch = 99),
+        actual.copy(targets = actual.targets.reverse)
+      )
+
+      assert(validateWorkerRecordIdentity(actual, expected) == Right(actual))
+      assert(mutations.forall(validateWorkerRecordIdentity(_, expected).isLeft))
+    }
+
+    test("worker profile arguments preserve every validated profile field") {
+      val altered = ciProfile.copy(
+        memoryGiB = 16,
+        reserveGiB = 5,
+        heapGiB = 8,
+        millJobs = 3,
+        maxChildren = 1,
+        batchSize = 2,
+        timeoutMinutes = 45
+      )
+
+      assert(
+        workerProfileArguments(altered) == Seq(
+          "--profile",
+          "ci",
+          "--memoryGib",
+          "16",
+          "--reserveGib",
+          "5",
+          "--heapGib",
+          "8",
+          "--millJobs",
+          "3",
+          "--maxChildren",
+          "1",
+          "--batchSize",
+          "2",
+          "--timeoutMinutes",
+          "45"
+        )
+      )
+      val reconstructed = reconstructWorkerProfile(
+        ciProfile,
+        altered.memoryGiB,
+        altered.reserveGiB,
+        altered.heapGiB,
+        altered.millJobs,
+        altered.maxChildren,
+        altered.batchSize,
+        altered.timeoutMinutes
+      )
+      assert(reconstructed == Right(altered))
+      assert(
+        reconstructWorkerProfile(ciProfile, 16, 9, 8, 3, 1, 2, 45).isLeft
+      )
+
+      val actual = worker(trial = 1, profile = reconstructed.toOption.get)
+      assert(validateWorkerRecordIdentity(actual, WorkerIdentity.from(actual)) == Right(actual))
+    }
+
+    test("worker command arguments match the exact Mill Task.Command signature") {
+      val record = worker(trial = 2, lane = 3).copy(
+        runId = "run-exact",
+        strategyPosition = 4,
+        settings = EvaluationSettings(5, 6L),
+        platform = Platform.Wasm,
+        strategy = Strategy.Fresh,
+        profile = ciProfile.copy(reserveGiB = 5, millJobs = 3, batchSize = 2, timeoutMinutes = 45),
+        batch = 7,
+        targets = Seq("one", "two")
+      )
+
+      assert(
+        workerCommandArguments("/output/record.json", "/output/started", WorkerIdentity.from(record)) == Seq(
+          "ci.linkerBenchmarkWorker",
+          "--record",
+          "/output/record.json",
+          "--started",
+          "/output/started",
+          "--runId",
+          "run-exact",
+          "--platform",
+          "wasm",
+          "--strategy",
+          "fresh",
+          "--profile",
+          "ci",
+          "--memoryGib",
+          "16",
+          "--reserveGib",
+          "5",
+          "--heapGib",
+          "8",
+          "--millJobs",
+          "3",
+          "--maxChildren",
+          "1",
+          "--batchSize",
+          "2",
+          "--timeoutMinutes",
+          "45",
+          "--trials",
+          "5",
+          "--orderSeed",
+          "6",
+          "--trial",
+          "2",
+          "--strategyPosition",
+          "4",
+          "--lane",
+          "3",
+          "--batch",
+          "7",
+          "--targets",
+          "one,two"
+        )
+      )
+    }
+
+    test("worker launch cleanup removes stale regular markers and rejects symbolic links") {
+      val directory = os.temp.dir(prefix = "linker-worker-markers-")
+      val external  = os.temp(prefix = "linker-worker-external-", contents = "keep")
+      try {
+        os.write(directory / "record.json", "stale")
+        os.write(directory / "started", "stale")
+        assert(clearWorkerLaunchMarkers(directory).isRight)
+        assert(!os.exists(directory / "record.json"))
+        assert(!os.exists(directory / "started"))
+
+        java.nio.file.Files.createSymbolicLink((directory / "record.json").toNIO, external.toNIO)
+        assert(clearWorkerLaunchMarkers(directory).isLeft)
+        assert(os.read(external) == "keep")
+      } finally {
+        os.remove.all(directory)
+        os.remove(external)
+      }
+    }
+
+    test("worker output preparation rejects a symlink ancestor before external mutation") {
+      val root       = os.temp.dir(prefix = "linker-worker-output-")
+      val outputRoot = root / "output"
+      val external   = root / "external"
+      try {
+        os.makeDir.all(outputRoot)
+        os.makeDir.all(external)
+        java.nio.file.Files.createSymbolicLink((outputRoot / "ci").toNIO, external.toNIO)
+        val requested = outputRoot / "ci" / "trial-0" / "recycled" / "wasm" / "lane-0" / "batch-0"
+
+        assert(prepareWorkerOutputDirectory(outputRoot, requested).isLeft)
+        assert(os.list(external).isEmpty)
+        assert(!os.exists(external / "trial-0"))
+        assert(!os.exists(external / "record.json"))
+        assert(!os.exists(external / "started"))
+      } finally os.remove.all(root)
+    }
+
+    test("interrupted batch execution does not launch later batches") {
+      val invoked = Seq.newBuilder[Int]
+      try {
+        val completed = runBatchesUntilInterrupted(Seq(1, 2, 3)) { batch =>
+          invoked += batch
+          if batch == 1 then Thread.currentThread().interrupt()
+          batch
+        }
+
+        assert(completed == Seq(1))
+        assert(invoked.result() == Seq(1))
+        assert(Thread.currentThread().isInterrupted)
+      } finally Thread.interrupted()
     }
 
     test("concurrent lane failure interrupts and retires sibling work") {

--- a/millbuildHelpers/test/src/millbuild/LinkerBenchmarkTests.scala
+++ b/millbuildHelpers/test/src/millbuild/LinkerBenchmarkTests.scala
@@ -197,6 +197,7 @@ object LinkerBenchmarkTests extends TestSuite {
     test("hosted resource bounds accept their limits and reject larger values") {
       assert(maxHostedMemoryGiB == 16)
       assert(maxHostedReserveGiB == 15)
+      assert(maxHostedTimeoutMinutes == 330)
       val atLimits = BenchmarkOverrides(
         trials = Some(maxHostedTrials),
         targetLimit = Some(maxHostedTargetLimit),
@@ -1035,6 +1036,13 @@ object LinkerBenchmarkTests extends TestSuite {
 
       assert(execute(continueOnFailure = false).map(_._1) == Seq("first", "failing"))
       assert(execute(continueOnFailure = true).map(_._1) == scheduled)
+    }
+
+    test("evaluation fails after evidence collection when any scheduled case fails") {
+      assert(!evaluationFailed(Seq(Outcome.Succeeded, Outcome.Succeeded)))
+      assert(evaluationFailed(Seq(Outcome.Succeeded, Outcome.Failed)))
+      assert(evaluationFailed(Seq(Outcome.Succeeded, Outcome.TimedOut)))
+      assert(evaluationFailed(Seq(Outcome.Succeeded, Outcome.Cancelled)))
     }
 
     test("worker identity validation rejects every mismatched identity family") {

--- a/millbuildHelpers/test/src/millbuild/NativeTestSelectorsTests.scala
+++ b/millbuildHelpers/test/src/millbuild/NativeTestSelectorsTests.scala
@@ -1,0 +1,52 @@
+package millbuild
+
+import utest.*
+
+object NativeTestSelectorsTests extends TestSuite {
+  val tests = Tests {
+    test("selectShard partitions every target exactly once") {
+      val resolved = Seq(
+        "morphir.prelude.native.test",
+        "morphir.langkit.core.native.test",
+        "morphir.buildkit.core.native.test",
+        "morphir.kit.kyo.native.test",
+        "morphir.langkit.markdown.native.test"
+      )
+
+      val shards = (0 until 3).map { shard =>
+        NativeTestSelectors.selectShard(resolved, shard, 3, "ci.testNative")
+      }
+
+      assert(shards.forall(_.isRight))
+      val selected = shards.flatMap(_.toOption.toSeq.flatten)
+      assert(selected.size == resolved.distinct.size)
+      assert(selected.toSet == resolved.toSet)
+    }
+
+    test("selectShard is deterministic") {
+      val resolved = Seq(
+        "morphir.prelude.native.test",
+        "morphir.langkit.core.native.test",
+        "morphir.buildkit.core.native.test",
+        "morphir.langkit.core.native.test"
+      )
+
+      val forward = NativeTestSelectors.selectShard(resolved, 0, 2, "ci.testNative")
+      val reverse = NativeTestSelectors.selectShard(resolved.reverse, 0, 2, "ci.testNative")
+
+      assert(forward == reverse)
+    }
+
+    test("selectShard rejects invalid and empty shards") {
+      val resolved = Seq("morphir.prelude.native.test", "morphir.langkit.core.native.test")
+
+      assert(NativeTestSelectors.selectShard(resolved, 0, 0, "ci.testNative").isLeft)
+      assert(NativeTestSelectors.selectShard(resolved, -1, 2, "ci.testNative").isLeft)
+      assert(NativeTestSelectors.selectShard(resolved, 2, 2, "ci.testNative").isLeft)
+
+      val empty = NativeTestSelectors.selectShard(resolved, 2, 3, "ci.testNative")
+      assert(empty.isLeft)
+      assert(empty.swap.exists(_.contains("no targets")))
+    }
+  }
+}

--- a/scripts/ci/LinkerBenchmark.scala
+++ b/scripts/ci/LinkerBenchmark.scala
@@ -289,54 +289,63 @@ private object LinkerBenchmarkOrchestrator {
       ProcessHandle.current().pid(),
       () => activeRoots.asScala
     )
-    val records = Seq.newBuilder[WorkerRecord]
-    val cases   = Seq.newBuilder[StrategyTrialRecord]
-    var failed  = skippedCases.nonEmpty
+    val records             = Seq.newBuilder[WorkerRecord]
+    val cases               = Seq.newBuilder[StrategyTrialRecord]
+    val inventoryByPlatform = inventory.map(entry => entry.platform -> entry).toMap
+    val schedule            = LinkerBenchmark.evaluationSchedule(orders, inventory.map(_.platform))
+    var failed              = skippedCases.nonEmpty
     try
-      orders.zipWithIndex.foreach { case (order, trial) =>
-        inventory.foreach { entry =>
-          order.zipWithIndex.foreach { case (strategy, position) =>
-            val preparation = preparationDecisionFor(trial, entry.platform, strategy)
-            if !preparation.measure then
-              cases += skippedCase(trial, position, entry.platform, strategy, preparation.outcome)
-            else {
-              sampler.resetStrategyWindow()
-              val startedAt     = System.nanoTime()
-              val plan          = plans(entry.platform -> strategy)
-              val windowRecords = runPlan(
-                workspace,
-                externalRoot,
-                outputRoot,
-                runId,
-                settings,
-                profile,
-                entry.platform,
-                strategy,
-                trial,
-                position,
-                plan
-              )
-              records ++= windowRecords
-              val windowMillis = math.max(0L, (System.nanoTime() - startedAt) / 1000000L)
-              val snapshot     = sampler.snapshot()
-              val outcome      = combineOutcomes(windowRecords.map(_.outcome))
-              val completed    = windowRecords.filter(_.outcome == Outcome.Succeeded).flatMap(_.targets).distinct.size
-              cases += StrategyTrialRecord(
-                runId,
-                trial,
-                position,
-                entry.platform,
-                strategy,
-                profile,
-                windowMillis,
-                snapshot.strategyWindowPeakKiB,
-                completed,
-                outcome
-              )
-              failed ||= outcome != Outcome.Succeeded
-            }
+      LinkerBenchmark.runEvaluationSchedule(schedule, configuration.continueOnFailure) { scheduled =>
+        val entry       = inventoryByPlatform(scheduled.platform)
+        val preparation = preparationDecisionFor(scheduled.trial, entry.platform, scheduled.strategy)
+        val outcome     =
+          if !preparation.measure then {
+            cases += skippedCase(
+              scheduled.trial,
+              scheduled.strategyPosition,
+              entry.platform,
+              scheduled.strategy,
+              preparation.outcome
+            )
+            preparation.outcome
+          } else {
+            sampler.resetStrategyWindow()
+            val startedAt     = System.nanoTime()
+            val plan          = plans(entry.platform -> scheduled.strategy)
+            val windowRecords = runPlan(
+              workspace,
+              externalRoot,
+              outputRoot,
+              runId,
+              settings,
+              profile,
+              entry.platform,
+              scheduled.strategy,
+              scheduled.trial,
+              scheduled.strategyPosition,
+              plan
+            )
+            records ++= windowRecords
+            val windowMillis = math.max(0L, (System.nanoTime() - startedAt) / 1000000L)
+            val snapshot     = sampler.snapshot()
+            val caseOutcome  = combineOutcomes(windowRecords.map(_.outcome))
+            val completed    = windowRecords.filter(_.outcome == Outcome.Succeeded).flatMap(_.targets).distinct.size
+            cases += StrategyTrialRecord(
+              runId,
+              scheduled.trial,
+              scheduled.strategyPosition,
+              entry.platform,
+              scheduled.strategy,
+              profile,
+              windowMillis,
+              snapshot.strategyWindowPeakKiB,
+              completed,
+              caseOutcome
+            )
+            caseOutcome
           }
-        }
+        failed ||= outcome != Outcome.Succeeded
+        outcome
       }
     finally sampler.stop()
     val result = BenchmarkResult(
@@ -433,7 +442,7 @@ private object LinkerBenchmarkOrchestrator {
         val lane = externalRoot / profile.name / s"trial-$trial" / strategy.token / platform.token /
           s"lane-$laneIndex"
         os.makeDir.all(lane)
-        batches.sortBy(_.index).map { batch =>
+        LinkerBenchmark.runBatchesUntilInterrupted(batches.sortBy(_.index)) { batch =>
           runWorker(
             workspace,
             lane,
@@ -468,76 +477,89 @@ private object LinkerBenchmarkOrchestrator {
       position: Int,
       batch: Batch
   ): WorkerRecord = {
-    val directory = outputRoot / profile.name / s"trial-$trial" / strategy.token / platform.token /
-      s"lane-${batch.lane}" / s"batch-${batch.index}"
-    os.makeDir.all(directory)
-    val record  = directory / "record.json"
-    val started = directory / "started"
-    val gcLog   = directory / "gc.log"
-    val result  = runMill(
-      profile,
-      workspace,
-      lane,
-      started,
-      directory / "stdout.log",
-      directory / "stderr.log",
-      profile.timeoutMinutes.minutes,
-      Seq(
-        "ci.linkerBenchmarkWorker",
-        "--record",
-        physicalPath(record).toString,
-        "--started",
-        physicalPath(started).toString,
-        "--run-id",
+    def failedWorkerRecord(detail: String, outcome: Outcome = Outcome.Failed): WorkerRecord =
+      WorkerRecord(
         runId,
-        "--platform",
-        platform.token,
-        "--strategy",
-        strategy.token,
-        "--profile",
-        profile.name,
-        "--trials",
-        settings.trials.toString,
-        "--order-seed",
-        settings.orderSeed.toString,
-        "--trial",
-        trial.toString,
-        "--strategy-position",
-        position.toString,
-        "--lane",
-        batch.lane.toString,
-        "--batch",
-        batch.index.toString,
-        "--targets",
-        batch.targets.mkString(",")
-      ),
-      Map("JDK_JAVA_OPTIONS" -> s"-Xlog:gc:file=${physicalPath(gcLog)}")
-    )
-    val childRecord =
-      if os.isFile(record) then read[WorkerRecord](os.read(record))
-      else
-        WorkerRecord(
+        trial,
+        position,
+        settings,
+        platform,
+        strategy,
+        profile,
+        batch.lane,
+        batch.index,
+        batch.targets,
+        0L,
+        0L,
+        Seq.empty,
+        outcome,
+        Some(detail)
+      )
+
+    val requestedDirectory = outputRoot / profile.name / s"trial-$trial" / strategy.token / platform.token /
+      s"lane-${batch.lane}" / s"batch-${batch.index}"
+    val preparedDirectory = LinkerBenchmark.prepareWorkerOutputDirectory(outputRoot, requestedDirectory)
+
+    preparedDirectory.fold(
+      detail => failedWorkerRecord(detail),
+      directory => {
+        val record           = directory / "record.json"
+        val started          = directory / "started"
+        val gcLog            = directory / "gc.log"
+        val expectedIdentity = WorkerIdentity(
           runId,
-          trial,
-          position,
           settings,
           platform,
           strategy,
           profile,
+          trial,
+          position,
           batch.lane,
           batch.index,
-          batch.targets,
-          result.startupMillis.getOrElse(0L),
-          result.peakRssKiB,
-          Seq.empty,
-          result.outcome,
-          Some(result.detail)
+          batch.targets
         )
-    childRecord.copy(
-      startupMillis = result.startupMillis.getOrElse(childRecord.startupMillis),
-      peakRssKiB = math.max(childRecord.peakRssKiB, result.peakRssKiB),
-      outcome = if result.outcome == Outcome.Succeeded then childRecord.outcome else result.outcome,
-      detail = childRecord.detail.orElse(Some(result.detail))
+        val result = runMill(
+          profile,
+          workspace,
+          lane,
+          started,
+          directory / "stdout.log",
+          directory / "stderr.log",
+          profile.timeoutMinutes.minutes,
+          LinkerBenchmark.workerCommandArguments(
+            physicalPath(record).toString,
+            physicalPath(started).toString,
+            expectedIdentity
+          ),
+          Map("JDK_JAVA_OPTIONS" -> s"-Xlog:gc:file=${physicalPath(gcLog)}")
+        )
+        val loadedRecord =
+          if !Files.isRegularFile(record.toNIO, java.nio.file.LinkOption.NOFOLLOW_LINKS) then
+            Left("worker record is missing or is not a regular file")
+          else
+            try LinkerBenchmark.validateWorkerRecordIdentity(read[WorkerRecord](os.read(record)), expectedIdentity)
+            catch {
+              case NonFatal(_) => Left("worker record is invalid")
+            }
+
+        loadedRecord.fold(
+          detail =>
+            failedWorkerRecord(
+              detail,
+              if result.outcome == Outcome.Succeeded then Outcome.Failed else result.outcome
+            ).copy(
+              startupMillis = result.startupMillis.getOrElse(0L),
+              peakRssKiB = result.peakRssKiB
+            ),
+          childRecord =>
+            childRecord.copy(
+              startupMillis = result.startupMillis.getOrElse(childRecord.startupMillis),
+              peakRssKiB = math.max(childRecord.peakRssKiB, result.peakRssKiB),
+              outcome = if result.outcome == Outcome.Succeeded then childRecord.outcome else result.outcome,
+              detail = childRecord.detail.orElse(Some(result.detail))
+            )
+        )
+      }
     )
   }
 

--- a/scripts/ci/LinkerBenchmark.scala
+++ b/scripts/ci/LinkerBenchmark.scala
@@ -1,0 +1,983 @@
+//| moduleDeps: [//millbuildHelpers]
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+import scala.util.control.NonFatal
+
+import millbuild.{LinkerBenchmark, LinkerBenchmarkProcess}
+import millbuild.LinkerBenchmark.*
+import upickle.default.{read, write}
+
+def main(
+    preset: String = "",
+    profile: String = "",
+    strategies: String = "",
+    platforms: String = "",
+    trials: String = "0",
+    orderSeed: String = "",
+    continueOnFailure: String = "preset",
+    targetFilter: String = "",
+    targetLimit: String = "0",
+    memoryGib: String = "0",
+    reserveGib: String = "0",
+    millJobs: String = "0",
+    maxChildren: String = "0",
+    batchSize: String = "0",
+    timeoutMinutes: String = "0",
+    output: String = ".dev/.sdlc/mill-jvm-worker-pool/out/run",
+    smoke: String = "false",
+    recoverySmoke: String = "false",
+    planOnly: String = "false",
+    artifactNameOnly: String = "false",
+    artifactRef: String = "",
+    artifactRunId: String = "",
+    artifactRunAttempt: String = "0"
+): Unit = {
+  val smokeEnabled         = requiredBoolean(smoke, "smoke")
+  val recoverySmokeEnabled = requiredBoolean(recoverySmoke, "recovery smoke")
+  val planOnlyEnabled      = requiredBoolean(planOnly, "plan only")
+  val artifactNameEnabled  = requiredBoolean(artifactNameOnly, "artifact name only")
+  val parsedTrials         = requiredPositive(trials, "trials")
+  val parsedTargetLimit    = requiredPositive(targetLimit, "target limit")
+  val parsedMemoryGiB      = requiredPositive(memoryGib, "memory GiB")
+  val parsedReserveGiB     = requiredPositive(reserveGib, "reserve GiB")
+  val parsedMillJobs       = requiredPositive(millJobs, "Mill jobs")
+  val parsedMaxChildren    = requiredPositive(maxChildren, "max children")
+  val parsedBatchSize      = requiredPositive(batchSize, "batch size")
+  val parsedTimeout        = requiredPositive(timeoutMinutes, "timeout minutes")
+  val parsedRunAttempt     = requiredPositive(artifactRunAttempt, "artifact run attempt")
+  val specialModes = Seq(smokeEnabled, recoverySmokeEnabled, planOnlyEnabled, artifactNameEnabled).count(identity)
+  if specialModes > 1 then
+    throw new IllegalArgumentException("smoke, recovery-smoke, plan-only, and artifact-name-only are exclusive")
+  if artifactNameEnabled then
+    println(
+      LinkerBenchmark
+        .hostedArtifactName(
+          preset,
+          artifactRef,
+          artifactRunId,
+          parsedRunAttempt.getOrElse(
+            throw new IllegalArgumentException("artifact run attempt must be greater than zero")
+          )
+        )
+        .fold(message => throw new IllegalArgumentException(message), identity)
+    )
+  else if smokeEnabled then LinkerBenchmarkSmoke.run()
+  else {
+    val localProfile =
+      if preset.trim.isEmpty then
+        LinkerBenchmark.detectedLocalProfile().fold(message => throw new IllegalArgumentException(message), identity)
+      else LinkerBenchmark.ciProfile
+    val overrides = BenchmarkOverrides(
+      platforms = requiredOptional(platforms, "platforms"),
+      strategies = requiredOptional(strategies, "strategies"),
+      trials = parsedTrials,
+      orderSeed = LinkerBenchmark
+        .parseOptionalLong(orderSeed, "order seed")
+        .fold(message => throw new IllegalArgumentException(message), identity),
+      targetFilter = requiredOptional(targetFilter, "target filter"),
+      targetLimit = parsedTargetLimit,
+      memoryGiB = parsedMemoryGiB,
+      reserveGiB = parsedReserveGiB,
+      millJobs = parsedMillJobs,
+      maxChildren = parsedMaxChildren,
+      batchSize = parsedBatchSize,
+      timeoutMinutes = parsedTimeout,
+      continueOnFailure = LinkerBenchmark
+        .parseContinuationChoice(continueOnFailure)
+        .fold(message => throw new IllegalArgumentException(message), identity)
+    )
+    val configuration = LinkerBenchmark
+      .resolveBenchmarkConfiguration(preset, profile, localProfile, overrides)
+      .fold(message => throw new IllegalArgumentException(message), identity)
+    LinkerBenchmarkOrchestrator.run(
+      configuration,
+      output,
+      recoverySmokeEnabled,
+      planOnlyEnabled
+    )
+  }
+}
+
+private def requiredOptional(value: String, field: String): Option[String] =
+  LinkerBenchmark
+    .parseOptionalTrimmedString(value, field)
+    .fold(message => throw new IllegalArgumentException(message), identity)
+
+private def requiredPositive(value: String, field: String): Option[Int] =
+  LinkerBenchmark
+    .parseZeroAsUnsetPositiveInt(value, field)
+    .fold(message => throw new IllegalArgumentException(message), identity)
+
+private def requiredBoolean(value: String, field: String): Boolean =
+  LinkerBenchmark
+    .parseBoolean(value, field)
+    .fold(message => throw new IllegalArgumentException(message), identity)
+
+private object LinkerBenchmarkOrchestrator {
+  private val OutputIdentityEnv = "MORPHIR_LINKER_BENCHMARK_OUTPUT_IDENTITY"
+
+  def run(
+      configuration: ResolvedBenchmarkConfiguration,
+      output: String,
+      recoverySmoke: Boolean,
+      planOnly: Boolean
+  ): Unit = {
+    val workspace = LinkerBenchmark
+      .resolveSmokeWorkspace(sys.env, os.pwd)
+      .fold(message => throw new Exception(message), identity)
+    val profile    = configuration.profile
+    val settings   = configuration.settings
+    val strategies = configuration.strategies
+    val platforms  = configuration.platforms
+    val orders     = LinkerBenchmark.strategyOrders(strategies, settings)
+    val outputRoot = LinkerBenchmark
+      .benchmarkOutputRoot(os.Path(output, workspace), configuration, recoverySmoke, planOnly)
+      .fold(message => throw new Exception(message), identity)
+    os.makeDir.all(outputRoot)
+    val renderedConfiguration = LinkerBenchmark.renderConfigurationJson(configuration)
+    writeAtomically(outputRoot / "configuration.json", renderedConfiguration)
+    println(renderedConfiguration)
+    val temporaryBase = LinkerBenchmark
+      .resolveSmokeTemporaryBase(System.getProperty("java.io.tmpdir"), sys.env.get("TMPDIR"), workspace)
+      .fold(message => throw new Exception(message), identity)
+    val externalRunRoot           = LinkerBenchmark.createSmokeTemporaryRunRoot(temporaryBase)
+    var primaryFailure: Throwable = null
+    try {
+      LinkerBenchmark
+        .validateExternalSmokeCleanupRoot(workspace, temporaryBase, externalRunRoot)
+        .fold(message => throw new Exception(message), _ => ())
+      val inventory = discoverInventory(workspace, externalRunRoot, outputRoot, profile, platforms)
+      LinkerBenchmark
+        .validateConfiguredHeap(profile, inventory.effectiveMaxHeapBytes)
+        .fold(message => throw new Exception(s"linker benchmark admission failed: $message"), _ => ())
+      val selected = inventory.inventories.map { entry =>
+        val targets = LinkerBenchmark
+          .selectInventoryTargets(
+            entry.targets,
+            configuration.targetFilter,
+            configuration.targetLimit,
+            entry.platform
+          )
+          .fold(message => throw new Exception(message), identity)
+        entry.copy(targets = targets)
+      }
+      val plans = selected.flatMap { entry =>
+        strategies.map(strategy =>
+          (entry.platform, strategy) ->
+            LinkerBenchmark
+              .strategyPlan(strategy, entry.targets, profile)
+              .fold(message => throw new Exception(message), identity)
+        )
+      }.toMap
+
+      if planOnly then println(renderPlans(configuration, orders, selected, plans))
+      else if recoverySmoke then runRecoverySmoke(workspace, externalRunRoot, outputRoot, profile)
+      else {
+        runEvaluation(
+          workspace,
+          externalRunRoot,
+          outputRoot,
+          configuration,
+          orders,
+          selected,
+          plans
+        )
+      }
+    } catch {
+      case error: Throwable =>
+        primaryFailure = error
+        throw error
+    } finally
+      try clearExternalRunDirectory(workspace, temporaryBase, externalRunRoot)
+      catch {
+        case NonFatal(cleanupError) if primaryFailure != null => primaryFailure.addSuppressed(cleanupError)
+      }
+  }
+
+  private def discoverInventory(
+      workspace: os.Path,
+      externalRoot: os.Path,
+      outputRoot: os.Path,
+      profile: Profile,
+      platforms: Seq[Platform]
+  ): InventoryRecord = {
+    val directory = outputRoot / "inventory"
+    val record    = directory / "inventory.json"
+    val started   = directory / "started"
+    os.makeDir.all(directory)
+    val lane = externalRoot / "inventory"
+    os.makeDir.all(lane)
+    val result = runMill(
+      profile,
+      workspace,
+      lane,
+      started,
+      directory / "stdout.log",
+      directory / "stderr.log",
+      10.minutes,
+      Seq(
+        "ci.linkerBenchmarkInventory",
+        "--record",
+        physicalPath(record).toString,
+        "--platforms",
+        platforms.map(platformArgument).mkString(",")
+      )
+    )
+    if result.outcome != Outcome.Succeeded then
+      throw new Exception(s"linker inventory failed: ${result.detail}; see ${directory / "stderr.log"}")
+    read[InventoryRecord](os.read(record))
+  }
+
+  private def runEvaluation(
+      workspace: os.Path,
+      externalRoot: os.Path,
+      outputRoot: os.Path,
+      configuration: ResolvedBenchmarkConfiguration,
+      orders: Seq[Seq[Strategy]],
+      inventory: Seq[PlatformInventory],
+      plans: Map[(Platform, Strategy), WorkPlan]
+  ): Unit = {
+    val profile      = configuration.profile
+    val settings     = configuration.settings
+    val runId        = s"run-${System.currentTimeMillis()}-${ProcessHandle.current().pid()}"
+    val preparations = prepareLanes(workspace, externalRoot, outputRoot, runId, profile, settings, inventory, plans)
+
+    def preparationDecisionFor(trial: Int, platform: Platform, strategy: Strategy): PreparationDecision =
+      LinkerBenchmark.preparationDecision(
+        preparations
+          .filter(record => record.trial == trial && record.platform == platform && record.strategy == strategy)
+          .map(_.outcome),
+        configuration.continueOnFailure
+      )
+
+    def skippedCase(
+        trial: Int,
+        position: Int,
+        platform: Platform,
+        strategy: Strategy,
+        outcome: Outcome
+    ): StrategyTrialRecord =
+      StrategyTrialRecord(runId, trial, position, platform, strategy, profile, 0L, 0L, 0L, outcome)
+
+    val skippedCases = orders.zipWithIndex.flatMap { case (order, trial) =>
+      inventory.flatMap { entry =>
+        order.zipWithIndex.flatMap { case (strategy, position) =>
+          val decision = preparationDecisionFor(trial, entry.platform, strategy)
+          Option.when(!decision.measure)(skippedCase(trial, position, entry.platform, strategy, decision.outcome))
+        }
+      }
+    }
+    val mustFailForPreparation = orders.zipWithIndex.exists { case (order, trial) =>
+      inventory.exists(entry =>
+        order.exists(strategy => preparationDecisionFor(trial, entry.platform, strategy).failRun)
+      )
+    }
+    if mustFailForPreparation then {
+      val result = BenchmarkResult(configuration, 0L, skippedCases, Seq.empty, preparations)
+      writeAtomically(outputRoot / "results.json", LinkerBenchmark.renderJson(result))
+      writeAtomically(outputRoot / "summary.md", LinkerBenchmark.renderMarkdown(result))
+      throw new Exception("one or more linker benchmark preparations failed; reports were written")
+    }
+    val activeRoots = ConcurrentHashMap.newKeySet[ProcessHandle]()
+    val sampler     = LinkerBenchmarkProcess.AggregateRssSampler.start(
+      ProcessHandle.current().pid(),
+      () => activeRoots.asScala
+    )
+    val records = Seq.newBuilder[WorkerRecord]
+    val cases   = Seq.newBuilder[StrategyTrialRecord]
+    var failed  = skippedCases.nonEmpty
+    try
+      orders.zipWithIndex.foreach { case (order, trial) =>
+        inventory.foreach { entry =>
+          order.zipWithIndex.foreach { case (strategy, position) =>
+            val preparation = preparationDecisionFor(trial, entry.platform, strategy)
+            if !preparation.measure then
+              cases += skippedCase(trial, position, entry.platform, strategy, preparation.outcome)
+            else {
+              sampler.resetStrategyWindow()
+              val startedAt     = System.nanoTime()
+              val plan          = plans(entry.platform -> strategy)
+              val windowRecords = runPlan(
+                workspace,
+                externalRoot,
+                outputRoot,
+                runId,
+                settings,
+                profile,
+                entry.platform,
+                strategy,
+                trial,
+                position,
+                plan
+              )
+              records ++= windowRecords
+              val windowMillis = math.max(0L, (System.nanoTime() - startedAt) / 1000000L)
+              val snapshot     = sampler.snapshot()
+              val outcome      = combineOutcomes(windowRecords.map(_.outcome))
+              val completed    = windowRecords.filter(_.outcome == Outcome.Succeeded).flatMap(_.targets).distinct.size
+              cases += StrategyTrialRecord(
+                runId,
+                trial,
+                position,
+                entry.platform,
+                strategy,
+                profile,
+                windowMillis,
+                snapshot.strategyWindowPeakKiB,
+                completed,
+                outcome
+              )
+              failed ||= outcome != Outcome.Succeeded
+            }
+          }
+        }
+      }
+    finally sampler.stop()
+    val result = BenchmarkResult(
+      configuration,
+      sampler.snapshot().wholeRunPeakKiB,
+      cases.result(),
+      records.result(),
+      preparations
+    )
+    writeAtomically(outputRoot / "results.json", LinkerBenchmark.renderJson(result))
+    writeAtomically(outputRoot / "summary.md", LinkerBenchmark.renderMarkdown(result))
+    if failed && !configuration.continueOnFailure then
+      throw new Exception("one or more linker benchmark cases failed; reports were written")
+  }
+
+  private def prepareLanes(
+      workspace: os.Path,
+      externalRoot: os.Path,
+      outputRoot: os.Path,
+      runId: String,
+      profile: Profile,
+      settings: EvaluationSettings,
+      inventory: Seq[PlatformInventory],
+      plans: Map[(Platform, Strategy), WorkPlan]
+  ): Seq[PreparationRecord] = {
+    val records = Seq.newBuilder[PreparationRecord]
+    (0 until settings.trials).foreach { trial =>
+      inventory.foreach { entry =>
+        Strategy.values.foreach { strategy =>
+          plans.get(entry.platform -> strategy).foreach { plan =>
+            val tasks = LinkerBenchmark.preparationLanes(plan).map { preparationLane => () =>
+              val laneIndex = preparationLane.lane
+              val lane      = externalRoot / profile.name / s"trial-$trial" / strategy.token / entry.platform.token /
+                s"lane-$laneIndex"
+              val directory = outputRoot / profile.name / s"trial-$trial" / strategy.token /
+                entry.platform.token / s"lane-$laneIndex" / "prepare"
+              os.makeDir.all(directory)
+              val results = preparationLane.batches.map { batch =>
+                val batchDirectory = directory / s"batch-${batch.index}"
+                os.makeDir.all(batchDirectory)
+                runMill(
+                  profile,
+                  workspace,
+                  lane,
+                  batchDirectory / "started",
+                  batchDirectory / "stdout.log",
+                  batchDirectory / "stderr.log",
+                  profile.timeoutMinutes.minutes,
+                  Seq(
+                    "ci.linkerBenchmarkPrepare",
+                    "--platform",
+                    entry.platform.token,
+                    "--targets",
+                    batch.targets.mkString(",")
+                  )
+                )
+              }
+              PreparationRecord(
+                runId,
+                trial,
+                entry.platform,
+                strategy,
+                profile,
+                laneIndex,
+                results.map(_.wallMillis).sum,
+                preparationLane.batches.flatMap(_.targets).distinct.sorted,
+                combineOutcomes(results.map(_.outcome))
+              )
+            }
+            records ++= LinkerBenchmark.runConcurrentLanes(plan.lanes, tasks, cleanupTimeout = 15.seconds)
+          }
+        }
+      }
+    }
+    records.result()
+  }
+
+  private def runPlan(
+      workspace: os.Path,
+      externalRoot: os.Path,
+      outputRoot: os.Path,
+      runId: String,
+      settings: EvaluationSettings,
+      profile: Profile,
+      platform: Platform,
+      strategy: Strategy,
+      trial: Int,
+      position: Int,
+      plan: WorkPlan
+  ): Seq[WorkerRecord] = {
+    val lanes = plan.batches.groupBy(_.lane).toSeq.sortBy(_._1)
+    val tasks = lanes.map { case (laneIndex, batches) =>
+      () =>
+        val lane = externalRoot / profile.name / s"trial-$trial" / strategy.token / platform.token /
+          s"lane-$laneIndex"
+        os.makeDir.all(lane)
+        batches.sortBy(_.index).map { batch =>
+          runWorker(
+            workspace,
+            lane,
+            outputRoot,
+            runId,
+            settings,
+            profile,
+            platform,
+            strategy,
+            trial,
+            position,
+            batch
+          )
+        }
+    }
+    LinkerBenchmark
+      .runConcurrentLanes(plan.lanes, tasks, cleanupTimeout = 15.seconds)
+      .flatten
+      .sortBy(record => (record.lane, record.batch))
+  }
+
+  private def runWorker(
+      workspace: os.Path,
+      lane: os.Path,
+      outputRoot: os.Path,
+      runId: String,
+      settings: EvaluationSettings,
+      profile: Profile,
+      platform: Platform,
+      strategy: Strategy,
+      trial: Int,
+      position: Int,
+      batch: Batch
+  ): WorkerRecord = {
+    val directory = outputRoot / profile.name / s"trial-$trial" / strategy.token / platform.token /
+      s"lane-${batch.lane}" / s"batch-${batch.index}"
+    os.makeDir.all(directory)
+    val record  = directory / "record.json"
+    val started = directory / "started"
+    val gcLog   = directory / "gc.log"
+    val result  = runMill(
+      profile,
+      workspace,
+      lane,
+      started,
+      directory / "stdout.log",
+      directory / "stderr.log",
+      profile.timeoutMinutes.minutes,
+      Seq(
+        "ci.linkerBenchmarkWorker",
+        "--record",
+        physicalPath(record).toString,
+        "--started",
+        physicalPath(started).toString,
+        "--run-id",
+        runId,
+        "--platform",
+        platform.token,
+        "--strategy",
+        strategy.token,
+        "--profile",
+        profile.name,
+        "--trials",
+        settings.trials.toString,
+        "--order-seed",
+        settings.orderSeed.toString,
+        "--trial",
+        trial.toString,
+        "--strategy-position",
+        position.toString,
+        "--lane",
+        batch.lane.toString,
+        "--batch",
+        batch.index.toString,
+        "--targets",
+        batch.targets.mkString(",")
+      ),
+      Map("JDK_JAVA_OPTIONS" -> s"-Xlog:gc:file=${physicalPath(gcLog)}")
+    )
+    val childRecord =
+      if os.isFile(record) then read[WorkerRecord](os.read(record))
+      else
+        WorkerRecord(
+          runId,
+          trial,
+          position,
+          settings,
+          platform,
+          strategy,
+          profile,
+          batch.lane,
+          batch.index,
+          batch.targets,
+          result.startupMillis.getOrElse(0L),
+          result.peakRssKiB,
+          Seq.empty,
+          result.outcome,
+          Some(result.detail)
+        )
+    childRecord.copy(
+      startupMillis = result.startupMillis.getOrElse(childRecord.startupMillis),
+      peakRssKiB = math.max(childRecord.peakRssKiB, result.peakRssKiB),
+      outcome = if result.outcome == Outcome.Succeeded then childRecord.outcome else result.outcome,
+      detail = childRecord.detail.orElse(Some(result.detail))
+    )
+  }
+
+  private def runMill(
+      profile: Profile,
+      workspace: os.Path,
+      lane: os.Path,
+      started: os.Path,
+      stdout: os.Path,
+      stderr: os.Path,
+      timeout: FiniteDuration,
+      arguments: Seq[String],
+      additionalEnvironment: Map[String, String] = Map.empty
+  ): LinkerBenchmarkProcess.ProcessResult = {
+    os.makeDir.all(lane)
+    val environment = Map(
+      "MILL_OUTPUT_DIR"              -> LinkerBenchmark.smokeChildOutputDirectoryValue(lane),
+      "OS_LIB_PATH_RELATIVIZER_BASE" -> "",
+      OutputIdentityEnv              -> sha256(physicalPath(lane).toString)
+    ) ++ additionalEnvironment
+    LinkerBenchmark.validateExternalChildOutputDirectory(workspace, lane).fold(
+      message => throw new Exception(message),
+      _ => ()
+    )
+    os.Path.pathSerializer.withValue(PhysicalPathSerializer) {
+      LinkerBenchmarkProcess.run(
+        physicalPath(workspace / "mill").toString +: LinkerBenchmark.millChildArguments(profile, arguments),
+        workspace,
+        environment,
+        timeout,
+        started,
+        stdout,
+        stderr,
+        LinkerBenchmark.smokeEnvironmentRemovals
+      )
+    }
+  }
+
+  private def runRecoverySmoke(
+      workspace: os.Path,
+      externalRoot: os.Path,
+      outputRoot: os.Path,
+      profile: Profile
+  ): Unit = {
+    val directory = outputRoot
+    os.makeDir.all(directory)
+    val recoveryRecord = directory / "recovery.json"
+    if os.exists(recoveryRecord) then os.remove(recoveryRecord)
+    val lane  = externalRoot / "recovery"
+    val first = runMill(
+      profile,
+      workspace,
+      lane,
+      directory / "first.started",
+      directory / "first.out",
+      directory / "first.err",
+      1.millis,
+      Seq("ci.linkerBenchmarkWorkerSmoke", "--marker", physicalPath(directory / "first.started").toString)
+    )
+    val replacement = runMill(
+      profile,
+      workspace,
+      lane,
+      directory / "replacement.started",
+      directory / "replacement.out",
+      directory / "replacement.err",
+      5.minutes,
+      Seq("ci.linkerBenchmarkWorkerSmoke", "--marker", physicalPath(directory / "replacement.started").toString)
+    )
+    val record = RecoveryRecord(
+      first = RecoveryAttemptRecord(
+        first.outcome,
+        first.wallMillis,
+        first.exitCode,
+        readSmokeRecord(directory / "first.started")
+      ),
+      replacement = RecoveryAttemptRecord(
+        replacement.outcome,
+        replacement.wallMillis,
+        replacement.exitCode,
+        readSmokeRecord(directory / "replacement.started")
+      )
+    )
+    LinkerBenchmark.validateRecovery(record).fold(
+      message => throw new Exception(s"recovery smoke failed: $message"),
+      _ => ()
+    )
+    val worker          = record.replacement.worker.get
+    val proofValidation = verifyRecoveryProof(
+      workspace,
+      workspace / "out",
+      lane,
+      sha256(physicalPath(lane).toString),
+      worker
+    )
+    val json = LinkerBenchmark
+      .renderValidatedRecoveryJson(record, proofValidation, sys.env)
+      .fold(message => throw new Exception(s"recovery smoke failed: $message"), identity)
+    writeAtomically(recoveryRecord, json)
+  }
+
+  private def readSmokeRecord(marker: os.Path): Option[SmokeRecord] =
+    Option.when(os.isFile(marker))(read[SmokeRecord](os.read(marker)))
+
+  private def verifyRecoveryProof(
+      workspace: os.Path,
+      rootOutput: os.Path,
+      lane: os.Path,
+      expectedOutputIdentity: String,
+      worker: SmokeRecord
+  ): Either[String, Path] = {
+    val matchingProofs = os.walk(lane).filter(_.last == worker.proofFilename)
+    if matchingProofs.size != 1 then Left("replacement recovery worker proof is not unique")
+    else
+      LinkerBenchmark
+        .validateRecoveryProofPath(
+          workspace,
+          rootOutput,
+          lane,
+          matchingProofs.head,
+          expectedOutputIdentity,
+          worker
+        )
+        .flatMap { canonicalProof =>
+          val proof =
+            try Right(read[SmokeProof](Files.readString(canonicalProof, StandardCharsets.UTF_8)))
+            catch {
+              case error: Exception =>
+                Left(s"replacement recovery worker proof is invalid: ${error.getClass.getSimpleName}")
+            }
+          proof.flatMap(value =>
+            LinkerBenchmark.validateRecoveryProof(
+              workspace,
+              rootOutput,
+              lane,
+              matchingProofs.head,
+              expectedOutputIdentity,
+              worker,
+              value
+            )
+          )
+        }
+  }
+
+  private def renderPlans(
+      configuration: ResolvedBenchmarkConfiguration,
+      orders: Seq[Seq[Strategy]],
+      inventory: Seq[PlatformInventory],
+      plans: Map[(Platform, Strategy), WorkPlan]
+  ): String = {
+    val json = ujson.Obj(
+      "configuration" -> ujson.read(LinkerBenchmark.renderConfigurationJson(configuration)),
+      "trialOrders"   -> ujson.Arr.from(orders.map(order => ujson.Arr.from(order.map(_.token)))),
+      "inventories"   -> ujson.Arr.from(inventory.map(entry => ujson.read(write(entry)))),
+      "plans"         -> ujson.Arr.from(
+        plans.toSeq.sortBy { case ((platform, strategy), _) => (platform.token, strategy.token) }.map {
+          case ((platform, strategy), plan) =>
+            ujson.Obj(
+              "platform" -> platform.token,
+              "strategy" -> strategy.token,
+              "plan"     -> ujson.read(write(plan))
+            )
+        }
+      )
+    )
+    json.render(indent = 2)
+  }
+
+  private def platformArgument(platform: Platform): String =
+    if platform == Platform.ScalaJs then "js" else platform.token
+
+  private def combineOutcomes(outcomes: Seq[Outcome]): Outcome =
+    if outcomes.contains(Outcome.Cancelled) then Outcome.Cancelled
+    else if outcomes.contains(Outcome.TimedOut) then Outcome.TimedOut
+    else if outcomes.contains(Outcome.Failed) then Outcome.Failed
+    else Outcome.Succeeded
+
+  private def clearExternalRunDirectory(workspace: os.Path, temporaryBase: os.Path, externalRoot: os.Path): Unit = {
+    val validated = LinkerBenchmark
+      .validateExternalSmokeCleanupRoot(workspace, temporaryBase, externalRoot)
+      .fold(message => throw new Exception(message), identity)
+    os.remove.all(os.Path(validated))
+  }
+
+  private def physicalPath(path: os.Path): Path =
+    LinkerBenchmark.canonicalPhysicalPath(path).fold(message => throw new Exception(message), identity)
+
+  private def sha256(value: String): String =
+    MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)).map(byte =>
+      f"${byte & 0xff}%02x"
+    ).mkString
+
+  private def writeAtomically(path: os.Path, value: String): Unit =
+    LinkerBenchmark.writeTextAtomically(path, value)
+
+  private object PhysicalPathSerializer extends os.Path.Serializer {
+    override def serializeString(path: os.Path): String     = path.wrapped.toString
+    override def serializeFile(path: os.Path): java.io.File = path.wrapped.toFile
+    override def serializePath(path: os.Path): Path         = path.wrapped
+    override def deserialize(value: String): Path           = java.nio.file.Paths.get(value)
+    override def deserialize(value: java.io.File): Path     = value.toPath
+    override def deserialize(value: Path): Path             = value
+    override def deserialize(value: java.net.URI): Path     = java.nio.file.Paths.get(value)
+  }
+}
+
+private object LinkerBenchmarkSmoke {
+  private val RequestedHeapBytes = 1024L * 1024L * 1024L
+  private val OutputIdentityEnv  = "MORPHIR_LINKER_BENCHMARK_OUTPUT_IDENTITY"
+  private val CollisionMessage   =
+    "benchmark child output directory must differ from the orchestrator output directory"
+
+  def run(): Unit = {
+    val workspace = LinkerBenchmark
+      .resolveSmokeWorkspace(sys.env, os.pwd)
+      .fold(message => throw new Exception(message), identity)
+    val mill          = physicalPath(workspace / "mill")
+    val smokeBase     = workspace / ".dev" / ".sdlc" / "mill-jvm-worker-pool" / "out" / "smoke"
+    val smokeRun      = smokeBase / "run"
+    val rootOutput    = workspace / "out"
+    val temporaryBase = LinkerBenchmark
+      .resolveSmokeTemporaryBase(System.getProperty("java.io.tmpdir"), sys.env.get("TMPDIR"), workspace)
+      .fold(message => throw new Exception(message), identity)
+
+    verifyPinnedLauncher(mill, workspace)
+    verifyMissingOutputDirectoryProbe(rootOutput)
+    clearSmokeRunDirectory(workspace, smokeBase, smokeRun)
+    val normalTaskOutputBefore    = fileState(rootOutput / "ci" / "linkerBenchmarkWorkerSmoke.json")
+    val externalRunRoot           = LinkerBenchmark.createSmokeTemporaryRunRoot(temporaryBase)
+    var primaryFailure: Throwable = null
+    try {
+      LinkerBenchmark
+        .validateExternalSmokeCleanupRoot(workspace, temporaryBase, externalRunRoot)
+        .fold(message => throw new Exception(message), _ => ())
+      val lane = LinkerBenchmark
+        .validateChildOutputDirectory(rootOutput, externalRunRoot / "lane-0")
+        .flatMap(_ => LinkerBenchmark.validateExternalChildOutputDirectory(workspace, externalRunRoot / "lane-0"))
+        .fold(message => throw new Exception(message), identity)
+      os.makeDir.all(lane)
+      val outputIdentity = sha256(physicalPath(lane).toString)
+      val records        = (0 until 2).map { index =>
+        runChild(index, mill, workspace, smokeRun, lane, outputIdentity, rootOutput)
+      }
+
+      if records.map(_.childPid).distinct.size != records.size then
+        throw new Exception("linker benchmark successor children must have distinct PIDs")
+      if records.map(_.proofFilename).distinct.size != records.size then
+        throw new Exception("linker benchmark successor children must have distinct proofs")
+      if records.map(_.effectiveMaxHeapBytes).distinct.size != 1 then
+        throw new Exception("linker benchmark successor children reported different effective heaps")
+      if fileState(rootOutput / "ci" / "linkerBenchmarkWorkerSmoke.json") != normalTaskOutputBefore then
+        throw new Exception("linker benchmark smoke wrote worker task output below the normal repository out root")
+
+      records.zipWithIndex.foreach { case (record, index) =>
+        println(
+          s"linker smoke child ${index + 1}/2: pid=${record.childPid} effectiveHeapBytes=${record.effectiveMaxHeapBytes} proof=${record.proofFilename}"
+        )
+      }
+      println("linker smoke: 2/2 sequential workers succeeded with one external lane")
+    } catch {
+      case error: Throwable =>
+        primaryFailure = error
+        throw error
+    } finally
+      try clearExternalRunDirectory(workspace, temporaryBase, externalRunRoot)
+      catch {
+        case NonFatal(cleanupError) if primaryFailure != null => primaryFailure.addSuppressed(cleanupError)
+      }
+  }
+
+  private def runChild(
+      index: Int,
+      mill: Path,
+      workspace: os.Path,
+      controlDirectory: os.Path,
+      lane: os.Path,
+      outputIdentity: String,
+      rootOutput: os.Path
+  ): SmokeRecord = {
+    val marker      = controlDirectory / s"child-$index-marker.json"
+    val stdout      = controlDirectory / s"child-$index-stdout.log"
+    val stderr      = controlDirectory / s"child-$index-stderr.log"
+    val environment = Map(
+      "MILL_OUTPUT_DIR"              -> LinkerBenchmark.smokeChildOutputDirectoryValue(lane),
+      "JAVA_OPTS"                    -> "-Xmx1g",
+      "OS_LIB_PATH_RELATIVIZER_BASE" -> "",
+      OutputIdentityEnv              -> outputIdentity
+    )
+    if !environment.get("MILL_OUTPUT_DIR").exists(_.nonEmpty) then
+      throw new Exception("linker benchmark child MILL_OUTPUT_DIR is missing")
+    val command = Seq(
+      mill.toString,
+      "--ticker",
+      "false",
+      "--no-daemon",
+      "ci.linkerBenchmarkWorkerSmoke",
+      "--marker",
+      physicalPath(marker).toString
+    )
+    val result = os.Path.pathSerializer.withValue(PhysicalPathSerializer) {
+      LinkerBenchmarkProcess.run(
+        command = command,
+        workingDirectory = workspace,
+        environment = environment,
+        timeout = 5.minutes,
+        startupMarker = marker,
+        stdout = stdout,
+        stderr = stderr,
+        environmentRemovals = LinkerBenchmark.smokeEnvironmentRemovals
+      )
+    }
+    if result.outcome != Outcome.Succeeded then
+      throw new Exception(
+        s"linker benchmark smoke child $index failed: ${LinkerBenchmark.redact(result.detail)}; durable logs: child-$index-stdout.log, child-$index-stderr.log"
+      )
+    if !os.isFile(marker) then throw new Exception(s"linker benchmark smoke child $index did not write its marker")
+    val record =
+      try read[SmokeRecord](os.read(marker))
+      catch {
+        case error: Exception =>
+          throw new Exception(s"linker benchmark smoke child $index marker is invalid: ${error.getClass.getSimpleName}")
+      }
+    verifyRecord(record, outputIdentity)
+    verifyArtifacts(record, controlDirectory, lane, marker, stdout, stderr, rootOutput)
+    record
+  }
+
+  private def verifyRecord(record: SmokeRecord, outputIdentity: String): Unit = {
+    if record.outputDirectoryIdentity != outputIdentity then
+      throw new Exception("linker benchmark smoke child reported the wrong output directory identity")
+    LinkerBenchmark
+      .validateSmokeHeapProbe(record, LinkerBenchmark.ciProfile)
+      .fold(
+        message =>
+          throw new Exception(s"linker benchmark smoke heap validation failed: ${LinkerBenchmark.redact(message)}"),
+        _ => ()
+      )
+  }
+
+  private def verifyArtifacts(
+      record: SmokeRecord,
+      controlDirectory: os.Path,
+      lane: os.Path,
+      marker: os.Path,
+      stdout: os.Path,
+      stderr: os.Path,
+      rootOutput: os.Path
+  ): Unit = {
+    val canonicalControl    = physicalPath(controlDirectory)
+    val canonicalLane       = physicalPath(lane)
+    val canonicalRootOutput = physicalPath(rootOutput)
+    Seq(marker, stdout, stderr).foreach { artifact =>
+      val canonicalArtifact = physicalPath(artifact)
+      if !canonicalArtifact.startsWith(canonicalControl) then
+        throw new Exception("linker benchmark smoke control artifact escaped the durable smoke run directory")
+      if canonicalArtifact.startsWith(canonicalLane) || canonicalArtifact.startsWith(canonicalRootOutput) then
+        throw new Exception("linker benchmark smoke control artifact used a Mill output directory")
+      if !Files.isRegularFile(canonicalArtifact) then
+        throw new Exception(s"linker benchmark smoke control artifact is missing: ${artifact.last}")
+    }
+
+    val taskOutput = physicalPath(lane / "ci" / "linkerBenchmarkWorkerSmoke.json")
+    if !Files.isRegularFile(taskOutput) || Files.size(taskOutput) == 0L then
+      throw new Exception("linker benchmark smoke task output is missing or incomplete in the external lane")
+    if !taskOutput.startsWith(canonicalLane) || taskOutput.startsWith(canonicalRootOutput) then
+      throw new Exception("linker benchmark smoke task output escaped the external lane")
+    if !Files.isDirectory(physicalPath(lane / "mill-no-daemon")) then
+      throw new Exception("linker benchmark smoke did not create daemonless Mill artifacts in the external lane")
+
+    val matchingProofs = os.walk(lane).filter(_.last == record.proofFilename)
+    if matchingProofs.size != 1 then
+      throw new Exception(s"linker benchmark smoke child ${record.childPid} proof was not uniquely discoverable")
+    val proofPath = physicalPath(matchingProofs.head)
+    if !proofPath.startsWith(canonicalLane) || proofPath.startsWith(canonicalRootOutput) then
+      throw new Exception(s"linker benchmark smoke child ${record.childPid} proof escaped the external lane")
+    val proof =
+      try read[SmokeProof](Files.readString(proofPath, StandardCharsets.UTF_8))
+      catch {
+        case error: Exception =>
+          throw new Exception(
+            s"linker benchmark smoke child ${record.childPid} proof is invalid: ${error.getClass.getSimpleName}"
+          )
+      }
+    if proof != SmokeProof(record.childPid, record.outputDirectoryIdentity) then
+      throw new Exception(s"linker benchmark smoke child ${record.childPid} proof does not match its marker")
+  }
+
+  private def clearSmokeRunDirectory(workspace: os.Path, smokeBase: os.Path, smokeRun: os.Path): Unit = {
+    LinkerBenchmark
+      .validateSmokeRunDirectory(workspace, smokeBase, smokeRun)
+      .fold(message => throw new Exception(message), _ => ())
+    os.remove.all(smokeRun)
+    os.makeDir.all(smokeRun)
+  }
+
+  private def clearExternalRunDirectory(
+      workspace: os.Path,
+      temporaryBase: os.Path,
+      externalRunRoot: os.Path
+  ): Unit = {
+    val validated = LinkerBenchmark
+      .validateExternalSmokeCleanupRoot(workspace, temporaryBase, externalRunRoot)
+      .fold(message => throw new Exception(message), identity)
+    os.remove.all(os.Path(validated))
+  }
+
+  private def verifyPinnedLauncher(mill: Path, workspace: os.Path): Unit = {
+    if !Files.isRegularFile(mill) then throw new Exception("the pinned Mill launcher is not a file")
+    if !Files.isExecutable(mill) then throw new Exception("the pinned Mill launcher is not executable")
+    if os.read(workspace / ".mill-version").trim.isEmpty then throw new Exception(".mill-version is empty")
+    if !Files.readString(mill, StandardCharsets.UTF_8).contains("MILL_OUTPUT_DIR") then
+      throw new Exception("the pinned Mill launcher does not honor MILL_OUTPUT_DIR")
+  }
+
+  private def verifyMissingOutputDirectoryProbe(orchestratorOutput: os.Path): Unit = {
+    val rejection = LinkerBenchmark.validateChildOutputDirectory(orchestratorOutput, orchestratorOutput)
+    if rejection != Left(CollisionMessage) then
+      throw new Exception("benchmark child without MILL_OUTPUT_DIR was not rejected before launch")
+  }
+
+  private def physicalPath(path: os.Path): Path =
+    LinkerBenchmark.canonicalPhysicalPath(path).fold(message => throw new Exception(message), identity)
+
+  private def fileState(path: os.Path): Option[(Long, Long)] =
+    Option.when(os.isFile(path))((os.size(path), Files.getLastModifiedTime(physicalPath(path)).toMillis))
+
+  private def sha256(value: String): String =
+    MessageDigest
+      .getInstance("SHA-256")
+      .digest(value.getBytes(StandardCharsets.UTF_8))
+      .map(byte => f"${byte & 0xff}%02x")
+      .mkString
+
+  private object PhysicalPathSerializer extends os.Path.Serializer {
+    override def serializeString(path: os.Path): String     = path.wrapped.toString
+    override def serializeFile(path: os.Path): java.io.File = path.wrapped.toFile
+    override def serializePath(path: os.Path): Path         = path.wrapped
+    override def deserialize(value: String): Path           = java.nio.file.Paths.get(value)
+    override def deserialize(value: java.io.File): Path     = value.toPath
+    override def deserialize(value: Path): Path             = value
+    override def deserialize(value: java.net.URI): Path     = java.nio.file.Paths.get(value)
+  }
+}

--- a/scripts/ci/LinkerBenchmark.scala
+++ b/scripts/ci/LinkerBenchmark.scala
@@ -293,7 +293,6 @@ private object LinkerBenchmarkOrchestrator {
     val cases               = Seq.newBuilder[StrategyTrialRecord]
     val inventoryByPlatform = inventory.map(entry => entry.platform -> entry).toMap
     val schedule            = LinkerBenchmark.evaluationSchedule(orders, inventory.map(_.platform))
-    var failed              = skippedCases.nonEmpty
     try
       LinkerBenchmark.runEvaluationSchedule(schedule, configuration.continueOnFailure) { scheduled =>
         val entry       = inventoryByPlatform(scheduled.platform)
@@ -344,7 +343,6 @@ private object LinkerBenchmarkOrchestrator {
             )
             caseOutcome
           }
-        failed ||= outcome != Outcome.Succeeded
         outcome
       }
     finally sampler.stop()
@@ -357,7 +355,7 @@ private object LinkerBenchmarkOrchestrator {
     )
     writeAtomically(outputRoot / "results.json", LinkerBenchmark.renderJson(result))
     writeAtomically(outputRoot / "summary.md", LinkerBenchmark.renderMarkdown(result))
-    if failed && !configuration.continueOnFailure then
+    if LinkerBenchmark.evaluationFailed(result.cases.map(_.outcome)) then
       throw new Exception("one or more linker benchmark cases failed; reports were written")
   }
 


### PR DESCRIPTION
## Summary

- Centralize JVM, Scala.js, Wasm, and Native CI grouping behind Mill commands, with deterministic fresh-JVM Native shards.
- Add a process-isolated linker benchmark and a manual hosted profiling workflow with checked presets, bounded overrides, fixed-heap verification, cleanup, and retained artifacts.
- Record the local evidence boundary, hosted adoption gates, and rollback strategy in the CI capability documentation.

This PR is stacked on #1028 so its diff contains only the linker-worker work. It preserves the resolved test inventory for every platform, but changes Native execution from batches of five to four deterministic shards running in fresh daemonless Mill JVMs. The hosted workflow remains manual. Long-lived and recycled workers remain profiler-only strategies until hosted evidence passes the documented adoption gates.

## Test plan

- `./mill --ticker false -i millbuildHelpers.test`
- `mise run test:squire`
- `mise run kb:check`
- `mise run lint`
- `actionlint .github/workflows/linker-benchmark.yml`
- `./mill --ticker false scripts/ci/LinkerBenchmark.scala --preset quick-smoke --plan-only true`
- Local bounded `quick-smoke`: 9/9 strategy cases succeeded with one target per platform and the expected 8 GiB heap.