### PR TITLE
feat(cli): rename serve command to server

### DIFF
--- a/.claude/skills/kb/KbCheck.scala
+++ b/.claude/skills/kb/KbCheck.scala
@@ -1,7 +1,7 @@
 //| scalaVersion: 3.8.4
 //| moduleDeps: [KbStore.scala, KbDecision.scala]
 //| mvnDeps:
-//| - io.getkyo::kyo-core:1.0.0-RC5
+//| - io.getkyo::kyo-core:1.0.0-RC6
 
 /** Conformance and drift checks over a knowledge base.
   *

--- a/.claude/skills/kb/KbDecision.scala
+++ b/.claude/skills/kb/KbDecision.scala
@@ -1,7 +1,7 @@
 //| scalaVersion: 3.8.4
 //| moduleDeps: [KbStore.scala]
 //| mvnDeps:
-//| - io.getkyo::kyo-core:1.0.0-RC5
+//| - io.getkyo::kyo-core:1.0.0-RC6
 
 /** Decision Records — architectural decisions recorded as prose, with supersession rather than revision.
   *

--- a/.claude/skills/kb/KbIndex.scala
+++ b/.claude/skills/kb/KbIndex.scala
@@ -1,7 +1,7 @@
 //| scalaVersion: 3.8.4
 //| moduleDeps: [KbStore.scala]
 //| mvnDeps:
-//| - io.getkyo::kyo-core:1.0.0-RC5
+//| - io.getkyo::kyo-core:1.0.0-RC6
 //| - org.xerial:sqlite-jdbc:3.53.2.1
 
 /** A SQLite index over the knowledge base.

--- a/.claude/skills/kb/KbIntent.scala
+++ b/.claude/skills/kb/KbIntent.scala
@@ -1,7 +1,7 @@
 //| scalaVersion: 3.8.4
 //| moduleDeps: [KbScaffold.scala, KbCheck.scala]
 //| mvnDeps:
-//| - io.getkyo::kyo-core:1.0.0-RC5
+//| - io.getkyo::kyo-core:1.0.0-RC6
 
 /** Intent management — features, enhancements and bugs recorded as prose with a lifecycle.
   *

--- a/.claude/skills/kb/KbIntentEdit.scala
+++ b/.claude/skills/kb/KbIntentEdit.scala
@@ -1,7 +1,7 @@
 //| scalaVersion: 3.8.4
 //| moduleDeps: [KbIntent.scala]
 //| mvnDeps:
-//| - io.getkyo::kyo-core:1.0.0-RC5
+//| - io.getkyo::kyo-core:1.0.0-RC6
 
 /** Writing intent: creating records, moving them between states, and regenerating the grouped index.
   *

--- a/.claude/skills/kb/KbModel.scala
+++ b/.claude/skills/kb/KbModel.scala
@@ -1,6 +1,6 @@
 //| scalaVersion: 3.8.4
 //| mvnDeps:
-//| - io.getkyo::kyo-core:1.0.0-RC5
+//| - io.getkyo::kyo-core:1.0.0-RC6
 //| - org.yaml:snakeyaml:2.6
 
 /** Domain model for an Open Knowledge Format knowledge base.
@@ -24,6 +24,9 @@ object KbPath:
   /** Segments of `child` below `base`, or None when `child` is not under `base`. */
   def segmentsUnder(child: Path, base: Path): Option[Seq[String]] =
     Option.when(isUnder(child, base))(child.parts.drop(base.parts.size).toSeq)
+
+  /** Converts a Kyo path to the current platform's native path syntax. */
+  def toNio(p: Path): java.nio.file.Path = java.nio.file.Path.of(p.toString)
 
   def render(p: Path): String = p.parts.filter(_.nonEmpty).mkString("/", "/", "")
 

--- a/.claude/skills/kb/KbRefresh.scala
+++ b/.claude/skills/kb/KbRefresh.scala
@@ -1,7 +1,7 @@
 //| scalaVersion: 3.8.4
 //| moduleDeps: [KbScaffold.scala, KbIndex.scala, KbIntentEdit.scala]
 //| mvnDeps:
-//| - io.getkyo::kyo-core:1.0.0-RC5
+//| - io.getkyo::kyo-core:1.0.0-RC6
 
 /** Bringing derived state back in line with the markdown.
   *

--- a/.claude/skills/kb/KbRender.scala
+++ b/.claude/skills/kb/KbRender.scala
@@ -1,7 +1,7 @@
 //| scalaVersion: 3.8.4
 //| moduleDeps: [KbStore.scala, KbScaffold.scala]
 //| mvnDeps:
-//| - io.getkyo::kyo-core:1.0.0-RC5
+//| - io.getkyo::kyo-core:1.0.0-RC6
 
 /** Rendering for the `kb` commands — text for humans, JSON for machines.
   *

--- a/.claude/skills/kb/KbScaffold.scala
+++ b/.claude/skills/kb/KbScaffold.scala
@@ -1,7 +1,7 @@
 //| scalaVersion: 3.8.4
 //| moduleDeps: [KbStore.scala]
 //| mvnDeps:
-//| - io.getkyo::kyo-core:1.0.0-RC5
+//| - io.getkyo::kyo-core:1.0.0-RC6
 
 /** Creating bundles and concepts, and keeping indexes and logs in step.
   *

--- a/.claude/skills/kb/KbStore.scala
+++ b/.claude/skills/kb/KbStore.scala
@@ -1,7 +1,7 @@
 //| scalaVersion: 3.8.4
 //| moduleDeps: [KbModel.scala]
 //| mvnDeps:
-//| - io.getkyo::kyo-core:1.0.0-RC5
+//| - io.getkyo::kyo-core:1.0.0-RC6
 //| - org.yaml:snakeyaml:2.6
 //| - org.commonmark:commonmark:0.29.0
 

--- a/.claude/skills/kb/KbSync.scala
+++ b/.claude/skills/kb/KbSync.scala
@@ -1,7 +1,7 @@
 //| scalaVersion: 3.8.4
 //| moduleDeps: [KbScaffold.scala, KbCheck.scala]
 //| mvnDeps:
-//| - io.getkyo::kyo-core:1.0.0-RC5
+//| - io.getkyo::kyo-core:1.0.0-RC6
 //| - org.yaml:snakeyaml:2.6
 
 /** Vendoring external documents into a bundle, and projecting them back out.
@@ -428,7 +428,7 @@ object KbSync:
     java.security.MessageDigest.getInstance("SHA-256").digest(bytes)
       .map(b => String.format("%02x", Integer.valueOf(b & 0xff))).mkString
 
-  private def jpath(p: Path): java.nio.file.Path = java.nio.file.Path.of(KbPath.render(p))
+  private def jpath(p: Path): java.nio.file.Path = KbPath.toNio(p)
 
   def readBytes(p: Path): Array[Byte] < (Sync & Abort[Throwable]) =
     Sync.defer(java.nio.file.Files.readAllBytes(jpath(p)))

--- a/.claude/skills/kb/KbTests.scala
+++ b/.claude/skills/kb/KbTests.scala
@@ -3,8 +3,8 @@
 //| resources: [test-resources]
 //| moduleDeps: [KbIntentEdit.scala, KbRefresh.scala, KbRender.scala, KbSync.scala]
 //| mvnDeps:
-//| - io.getkyo::kyo-test-api:1.0.0-RC5
-//| - io.getkyo::kyo-test-runner:1.0.0-RC5
+//| - io.getkyo::kyo-test-api:1.0.0-RC6
+//| - io.getkyo::kyo-test-runner:1.0.0-RC6
 
 /** Tests for the kb and intent skill code, using kyo-test — the same framework `langkit` and `kit` use.
   *
@@ -122,6 +122,13 @@ class KbParsingSpec extends Test[Any]:
 // ------------------------------------------------------------------------ paths
 
 class KbPathsSpec extends Test[Any]:
+
+  "native path conversion" - {
+    "round-trips an absolute path on the current platform (regression)" in {
+      val native = java.nio.file.Path.of(sys.props("user.dir")).toAbsolutePath.normalize()
+      assert(KbPath.toNio(Path(native.toString)) == native)
+    }
+  }
 
   "segmentsUnder" - {
     "relativises a path below the base" in {

--- a/.claude/skills/kb/kb.scala
+++ b/.claude/skills/kb/kb.scala
@@ -2,7 +2,7 @@
 //| mainClass: KbApp
 //| moduleDeps: [KbCheck.scala, KbScaffold.scala, KbRender.scala, KbIndex.scala, KbRefresh.scala, KbIntentEdit.scala, KbSync.scala]
 //| mvnDeps:
-//| - io.getkyo::kyo-case-app:1.0.0-RC5
+//| - io.getkyo::kyo-case-app:1.0.0-RC6
 
 /** `kb` — knowledge base management for the Morphir knowledge base under `kb/`.
   *

--- a/.gitignore
+++ b/.gitignore
@@ -455,6 +455,9 @@ build.user.properties
 build.user.conf
 build.user.yaml
 
+# Local Mill JVM selection. Windows ARM64 contributors use this to select their native system JDK.
+.mill-jvm-version
+
 
 .yarn/*
 !.yarn/cache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,31 @@ Or use Mill directly:
 ./mill morphir.runtime.classic.jvm.test
 ```
 
+### Windows ARM64 build JVM
+
+On Windows ARM64, check the JVM that Mill uses before diagnosing a slow Scala.js link:
+
+```powershell
+.\mill.bat --no-server --version
+```
+
+The output must report `os.arch: aarch64`. Mill's default managed JDK may resolve to an x64 Azul build and run under
+Windows emulation even when the machine itself is ARM64. That mismatch can make the Closure phase of `fullLinkJS`
+appear stuck.
+
+Use the native Microsoft OpenJDK already installed through Scoop, or install it if absent. Select it and create
+Mill's ignored local override:
+
+```powershell
+scoop install microsoft-lts-jdk # only when it is not already installed
+scoop reset microsoft-lts-jdk
+Set-Content .mill-jvm-version system
+```
+
+Run the version check again before a Scala.js build. Do not treat a multi-minute Closure pass as a code-generation
+failure until Mill reports `aarch64`. See [CONTRIBUTING.md](./CONTRIBUTING.md#windows-arm64) for the contributor
+workflow.
+
 ### Cross-Platform Sources
 
 The project uses a custom cross-platform source layout. For a module at `morphir/foo/`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ a release.
 ## [Unreleased]
 
 ### Changed
+- The local browser host command is now `morphir server`; the earlier `morphir serve` spelling is removed.
 - The repository moved to trunk-based development. Pull requests target `main` and merge into it; the `develop`
   integration branch, its promotion pull request and its back-migration are retired. Snapshots publish from `main`
   alone, and `squire branch refresh` now requires `--target`. See decision 0014.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,38 @@ The focused CI jobs are:
 
 The cache changes performance only. A disabled or empty cache must not change build results.
 
+### Windows ARM64
+
+Scala.js linking runs inside Mill's build JVM. Mill normally downloads its own JDK, independently of `JAVA_HOME`.
+On Windows ARM64, that managed JDK may resolve to an x64 build and run under Windows emulation. A production
+`fullLinkJS` can then spend several minutes in Closure without producing `main.js`.
+
+Use a native ARM64 JDK and tell Mill to use the system JVM. The Microsoft OpenJDK package from Scoop provides a
+native build:
+
+```powershell
+scoop install microsoft-lts-jdk # only when it is not already installed
+scoop reset microsoft-lts-jdk
+Set-Content .mill-jvm-version system
+```
+
+The repository ignores `.mill-jvm-version` because this selection belongs to the local machine. Confirm the build
+JVM before running Scala.js links:
+
+```powershell
+.\mill.bat --no-server --version
+```
+
+The output must report `os.arch: aarch64`. It should name the native JDK selected above, rather than a cached
+`win_x64` JDK under the Coursier directory. `--no-server` prevents an older x64 Mill daemon from satisfying the
+check. Node does not need a separate global installation for the build; Mill owns its JavaScript tool acquisition.
+
+The local browser host can then be built and run with:
+
+```powershell
+.\mill.bat --no-server --ticker false morphir.main.run server --no-open --port 8123
+```
+
 ### Refreshing a long-lived branch from `main`
 
 `main` is the trunk: pull requests target it and merge into it, and there is no integration branch in front of it.

--- a/README.md
+++ b/README.md
@@ -194,6 +194,20 @@ More detail for the evaluator-tests Elm tree:
 
 #### IntelliJ Setup for Windows
 
+Windows on ARM64 needs a native build JVM for Scala.js linking. Mill's managed JDK may resolve to an x64 build and
+run under emulation, which makes the Closure phase of `fullLinkJS` much slower. Select the native Microsoft OpenJDK
+and add the ignored local Mill override:
+
+```powershell
+scoop install microsoft-lts-jdk # only when it is not already installed
+scoop reset microsoft-lts-jdk
+Set-Content .mill-jvm-version system
+.\mill.bat --no-server --version
+```
+
+The last command must report `os.arch: aarch64`. See the
+[Windows ARM64 contributor setup](./CONTRIBUTING.md#windows-arm64) for the explanation and server command.
+
 If you are using IntelliJ IDEA to edit morphir-scala's Scala code, you can create the
 IntelliJ project files via or use the **BSP Setup** option (BSP is the recommended approach):
 

--- a/kb/bundles/intent/0035-local-web-host-and-github-connection-settings.md
+++ b/kb/bundles/intent/0035-local-web-host-and-github-connection-settings.md
@@ -35,7 +35,7 @@ remembered on the device. The shared settings view defaults to session-only use.
 
 Both hosts implement the same service. Electron handles it in the main process over the existing JSON-RPC IPC
 transport. A new Kyo JVM web host serves the browser UI and JSON-RPC from one loopback origin. The existing Kyo
-CaseApp CLI adds `morphir serve` and runs this host directly. It does not route through the legacy ZIO dispatcher or
+CaseApp CLI adds `morphir server` and runs this host directly. It does not route through the legacy ZIO dispatcher or
 add a ZIO-to-Kyo bridge.
 
 Extend appkit with a writable `SecretVault`. The JVM host uses the operating-system credential store. Electron uses
@@ -51,7 +51,7 @@ The full design is [GitHub connection settings and local web host](../morphir/mo
 ## Scope
 
 This intent includes GitHub.com, pasted personal access tokens, the shared settings UI, secure optional persistence,
-Electron hosting, the loopback web host, and the `morphir serve` command.
+Electron hosting, the loopback web host, and the `morphir server` command.
 
 GitHub Enterprise Server is follow-up work because the current connector fixes its live endpoint to
 `https://api.github.com/graphql`. OAuth, device flow, remote binding, and multi-user deployment are also outside this

--- a/kb/bundles/intent/0036-local-web-host-and-github-connection-settings.md
+++ b/kb/bundles/intent/0036-local-web-host-and-github-connection-settings.md
@@ -35,7 +35,7 @@ remembered on the device. The shared settings view defaults to session-only use.
 
 Both hosts implement the same service. Electron handles it in the main process over the existing JSON-RPC IPC
 transport. A new Kyo JVM web host serves the browser UI and JSON-RPC from one loopback origin. The existing Kyo
-CaseApp CLI adds `morphir serve` and runs this host directly. It does not route through the legacy ZIO dispatcher or
+CaseApp CLI adds `morphir server` and runs this host directly. It does not route through the legacy ZIO dispatcher or
 add a ZIO-to-Kyo bridge.
 
 Extend appkit with a writable `SecretVault`. The JVM host uses the operating-system credential store. Electron uses
@@ -51,7 +51,7 @@ The full design is [GitHub connection settings and local web host](../morphir/mo
 ## Scope
 
 This intent includes GitHub.com, pasted personal access tokens, the shared settings UI, secure optional persistence,
-Electron hosting, the loopback web host, and the `morphir serve` command.
+Electron hosting, the loopback web host, and the `morphir server` command.
 
 GitHub Enterprise Server is follow-up work because the current connector fixes its live endpoint to
 `https://api.github.com/graphql`. OAuth, device flow, remote binding, and multi-user deployment are also outside this

--- a/kb/bundles/morphir/morphir-scala/build-system.md
+++ b/kb/bundles/morphir/morphir-scala/build-system.md
@@ -39,9 +39,28 @@ mise run test:jvm
 Tasks live in `.config/mise/tasks/`, one executable script per task, and cover setup, formatting, linting, the three
 test platforms, the knowledge base check, and local CI.
 
+## Windows ARM64 build JVM
+
+Scala.js linking runs inside Mill's build JVM. Mill normally resolves that JVM through Coursier instead of using
+`JAVA_HOME`. On Windows ARM64, the default managed JDK may resolve to `win_x64`. Windows can run that binary under
+emulation, but Closure linking becomes much slower.
+
+Windows ARM64 contributors select a native Microsoft OpenJDK and put `system` in `.mill-jvm-version`. The ignored
+local file tells Mill to use the `java` selected by `JAVA_HOME` and `PATH`:
+
+```powershell
+scoop reset microsoft-lts-jdk
+Set-Content .mill-jvm-version system
+.\mill.bat --no-server --version
+```
+
+The version output must report `os.arch: aarch64`. The `--no-server` check avoids reusing an x64 daemon started
+before the override existed. Mill owns Node acquisition for the build, so this workaround does not add a global
+Node prerequisite.
+
 ## Dependencies
 
-Declared with the `mvn""` interpolator — `ivy""` is deprecated in Mill 1.x. For JS and Native dependencies the
+Declare dependencies with the `mvn""` interpolator. Mill 1.x deprecates `ivy""`. For JS and Native dependencies the
 double-colon form (`group::artifact::version`) is required; a single colon cross-builds only by Scala version and
 silently resolves the JVM jar.
 

--- a/kb/bundles/morphir/morphir-scala/design/github-connection-settings-and-local-web-host.md
+++ b/kb/bundles/morphir/morphir-scala/design/github-connection-settings-and-local-web-host.md
@@ -145,7 +145,7 @@ The work follows the module boundaries already established for the connector, UI
 | `morphir/ui` | Connection protocol, store, view, safe status, and errors |
 | `morphir/web/renderer` | Browser entry point that mounts the shared UI |
 | `morphir/web/server` | Loopback HTTP, sessions, static assets, JSON-RPC routes, and host services |
-| `morphir/main` | Pure Kyo `serve` command and options |
+| `morphir/main` | Pure Kyo `server` command and options |
 
 The UI module adds a JVM variant so the web server can use the same schema and route definitions as the Scala.js
 clients. The web modules form an unpublished application like `morphir/desktop`; the published libraries keep host
@@ -153,7 +153,7 @@ assembly and static assets out of their artifacts.
 
 ## Browser host
 
-The existing CLI entry point is a Kyo CaseApp dispatcher whose legacy commands call ZIO. `morphir serve` is a pure
+The existing CLI entry point is a Kyo CaseApp dispatcher whose legacy commands call ZIO. `morphir server` is a pure
 Kyo command. It runs a new JVM web-host module directly and does not add another ZIO-to-Kyo adapter. This follows
 [Decision Record 0005](../decisions/0005-bridge-nothing-between-zio-and-kyo.md).
 

--- a/kb/bundles/morphir/morphir-scala/log.md
+++ b/kb/bundles/morphir/morphir-scala/log.md
@@ -4,6 +4,8 @@
 
 * **Update**: [GitHub connection settings and local web host](/design/github-connection-settings-and-local-web-host.md)
   now names `morphir server` as the CLI entry point for the loopback browser host.
+* **Update**: [Build System](/build-system.md) now records the native Mill build-JVM setup required for Scala.js
+  linking on Windows ARM64.
 
 ## 2026-08-25
 

--- a/kb/bundles/morphir/morphir-scala/log.md
+++ b/kb/bundles/morphir/morphir-scala/log.md
@@ -1,5 +1,10 @@
 # Log
 
+## 2026-08-26
+
+* **Update**: [GitHub connection settings and local web host](/design/github-connection-settings-and-local-web-host.md)
+  now names `morphir server` as the CLI entry point for the loopback browser host.
+
 ## 2026-08-25
 
 * **Update**: [GitHub connection settings and local web host](/design/github-connection-settings-and-local-web-host.md)

--- a/kb/bundles/morphir/morphir-scala/log.md
+++ b/kb/bundles/morphir/morphir-scala/log.md
@@ -6,6 +6,10 @@
   now names `morphir server` as the CLI entry point for the loopback browser host.
 * **Update**: [Build System](/build-system.md) now records the native Mill build-JVM setup required for Scala.js
   linking on Windows ARM64.
+* **Update**: KB scripts now use Kyo 1.0.0-RC6, which fixes `Frame` macro expansion against CRLF source files on
+  Windows.
+* **Update**: KB sync now converts Kyo paths to native Java paths before byte-level file operations, so Windows drive
+  letters no longer produce invalid `/C:/...` paths.
 
 ## 2026-08-25
 

--- a/morphir/langkit/CONTRIBUTING.md
+++ b/morphir/langkit/CONTRIBUTING.md
@@ -25,8 +25,7 @@ arithmetic over a string.
 ## One `Span` type
 
 There is a single `morphir.langkit.core.Span`, exposing both `offset`/`length` and `start`/`end` views of the same
-half-open range. It replaced a pair of types — one for syntax nodes, one for diagnostics — that differed only in
-encoding.
+half-open range. It replaced two types that differed only in encoding, one for syntax nodes and one for diagnostics.
 
 Do not reintroduce a second span type for a new encoding. If a caller wants boundaries rather than an extent, use
 `Span.fromStartEnd`; if it wants both plus a resolved line and column, use `SourceSpan`, which wraps a `Span` rather
@@ -38,13 +37,13 @@ Every module here builds for the JVM, Scala.js, and Scala Native, so dependency 
 form for the JS and Native blocks:
 
 ```yaml
-- io.getkyo::kyo-core:1.0.0-RC5     # jvm
-- io.getkyo::kyo-core::1.0.0-RC5    # js and native
+- io.getkyo::kyo-core:1.0.0-RC6     # jvm
+- io.getkyo::kyo-core::1.0.0-RC6    # js and native
 ```
 
-A single colon cross-builds only by Scala version and silently resolves the JVM jar. Nothing fails at resolution — it
-surfaces later as a `ClassNotFoundException` when the class is actually loaded, which is why it is worth getting right
-up front.
+A single colon cross-builds only by Scala version and silently resolves the JVM jar. Nothing fails at resolution. The
+mistake surfaces later as a `ClassNotFoundException` when the class is loaded, so use the double-colon form from the
+start.
 
 Native test blocks additionally need `org.scala-native::test-interface::<version>`; Mill does not pull it in, and
 without it the link fails on an unreachable `sbt.testing.Framework`.

--- a/morphir/main/src/org/finos/morphir/cli/MorphirCliMain.scala
+++ b/morphir/main/src/org/finos/morphir/cli/MorphirCliMain.scala
@@ -260,7 +260,7 @@ object ElmTestCommand extends KyoCommand[ElmTestOptions]:
 object MorphirCliMain extends CommandsEntryPoint:
   def progName                  = "morphir-cli"
   def commands: Seq[Command[?]] =
-    val serve = if ServeCommand.available then Seq(ServeCommand) else Seq.empty
+    val server = if ServerCommand.available then Seq(ServerCommand) else Seq.empty
     Seq(
       BundleCommand,
       DevelopCommand,
@@ -268,7 +268,7 @@ object MorphirCliMain extends CommandsEntryPoint:
       SetupCommand,
       TestCommand,
       VersionCommand
-    ) ++ serve ++ Seq(
+    ) ++ server ++ Seq(
       ElmCommand,
       ElmDevelopCommand,
       ElmInitCommand,

--- a/morphir/main/src/org/finos/morphir/cli/ServerCommand.scala
+++ b/morphir/main/src/org/finos/morphir/cli/ServerCommand.scala
@@ -12,14 +12,14 @@ import kyo.*
 import kyo.kernel.Effect
 
 @AppName("Serve the Morphir browser application on loopback.")
-final case class ServeOptions(
+final case class ServerOptions(
     @HelpMessage("Port to bind on 127.0.0.1. Use 0 to select an available port.")
     port: Int = 0,
     @HelpMessage("Do not open the browser after the server starts.")
     noOpen: Boolean = false
 )
 
-object ServeOptions:
+object ServerOptions:
   private given boundedPortParser: ArgParser[Int] =
     ArgParser.int.xmapError(
       identity,
@@ -28,9 +28,9 @@ object ServeOptions:
         else Left(Error.Other("port must be between 0 and 65535"))
     )
 
-  given parser: Parser[ServeOptions] = Parser.derive[ServeOptions]
+  given parser: Parser[ServerOptions] = Parser.derive[ServerOptions]
 
-object ServeCommand extends Command[ServeOptions]:
+object ServerCommand extends Command[ServerOptions]:
   private val WebHostClassName = "morphir.web.server.WebHost$"
 
   private[cli] val browserWarning = "Warning: Unable to open the browser."
@@ -90,15 +90,15 @@ object ServeCommand extends Command[ServeOptions]:
       output: Output
   )
 
-  override def name = "serve"
+  override def name = "server"
 
-  def run(options: ServeOptions, remainingArgs: RemainingArgs): Unit =
-    ServeRunner.run(options, remainingArgs)
+  def run(options: ServerOptions, remainingArgs: RemainingArgs): Unit =
+    ServerRunner.run(options, remainingArgs)
 
-  private object ServeRunner extends KyoCommand[ServeOptions]:
-    override def name = "serve"
+  private object ServerRunner extends KyoCommand[ServerOptions]:
+    override def name = "server"
 
-    this.run { options => ServeCommand.run(options, ServeCommandLive.dependencies) }
+    this.run { options => ServerCommand.run(options, ServerCommandLive.dependencies) }
 
   private[cli] def available: Boolean =
     webHostAvailable(getClass.getClassLoader)
@@ -110,7 +110,7 @@ object ServeCommand extends Command[ServeOptions]:
     catch case _: ClassNotFoundException => false
 
   private[cli] def run(
-      options: ServeOptions,
+      options: ServerOptions,
       dependencies: Dependencies
   )(using Frame): Unit < (Async & Abort[Throwable]) =
     validate(options).andThen {
@@ -126,6 +126,6 @@ object ServeCommand extends Command[ServeOptions]:
       }
     }
 
-  private def validate(options: ServeOptions)(using Frame): Unit < Abort[Throwable] =
+  private def validate(options: ServerOptions)(using Frame): Unit < Abort[Throwable] =
     if options.port >= 0 && options.port <= 65535 then Kyo.unit
     else Abort.fail(IllegalArgumentException("port must be between 0 and 65535"))

--- a/morphir/main/src/org/finos/morphir/cli/ServerCommandLive.scala
+++ b/morphir/main/src/org/finos/morphir/cli/ServerCommandLive.scala
@@ -5,20 +5,20 @@ import morphir.appkit.SecretVault
 import morphir.connector.github.GitHubTokenVerifier
 import morphir.web.server.WebHost
 
-private[cli] object ServeCommandLive:
+private[cli] object ServerCommandLive:
 
-  def dependencies: ServeCommand.Dependencies =
-    ServeCommand.Dependencies(
+  def dependencies: ServerCommand.Dependencies =
+    ServerCommand.Dependencies(
       LiveHost,
-      ServeCommand.DesktopBrowserLauncher(ServeCommand.DesktopPlatform.system, ServeCommand.Output.console),
-      ServeCommand.Output.console
+      ServerCommand.DesktopBrowserLauncher(ServerCommand.DesktopPlatform.system, ServerCommand.Output.console),
+      ServerCommand.Output.console
     )
 
-  private object LiveHost extends ServeCommand.Host:
+  private object LiveHost extends ServerCommand.Host:
     def start(
-        config: ServeCommand.HostConfig,
-        browserLauncher: ServeCommand.BrowserLauncher
-    )(using Frame): ServeCommand.BoundHost < (Async & Scope & Abort[Throwable]) =
+        config: ServerCommand.HostConfig,
+        browserLauncher: ServerCommand.BrowserLauncher
+    )(using Frame): ServerCommand.BoundHost < (Async & Scope & Abort[Throwable]) =
       val started: AnyRef < (Async & Scope & Abort[Throwable]) = WebHost
         .startWithLauncher(
           WebHost.Config(port = config.port, openBrowser = config.openBrowser),
@@ -34,5 +34,5 @@ private[cli] object ServeCommandLive:
   private final class LiveBoundHost(
       val port: Int,
       waitForClose: () => Unit < Async
-  ) extends ServeCommand.BoundHost:
+  ) extends ServerCommand.BoundHost:
     def await(using Frame): Unit < Async = waitForClose()

--- a/morphir/main/test/src/org/finos/morphir/cli/ServerCommandTests.scala
+++ b/morphir/main/test/src/org/finos/morphir/cli/ServerCommandTests.scala
@@ -7,11 +7,11 @@ import java.net.URISyntaxException
 import kyo.*
 import kyo.test.*
 
-class ServeCommandTests extends Test[Any]:
+class ServerCommandTests extends Test[Any]:
 
   private val launchSentinel = "http://127.0.0.1:43123/#launch=launch-secret-sentinel"
 
-  private final class FakeLauncher extends ServeCommand.BrowserLauncher:
+  private final class FakeLauncher extends ServerCommand.BrowserLauncher:
     private var opened = Vector.empty[String]
 
     def open(url: String)(using Frame): Boolean < Async = Async.defer {
@@ -22,7 +22,7 @@ class ServeCommandTests extends Test[Any]:
     def urls: Vector[String] = opened
 
   private final class FakeBoundHost(events: collection.mutable.ArrayBuffer[String], failAwait: Boolean)
-      extends ServeCommand.BoundHost:
+      extends ServerCommand.BoundHost:
     val port = 43123
 
     def await(using Frame): Unit < Async = Async.defer {
@@ -33,14 +33,14 @@ class ServeCommandTests extends Test[Any]:
   private final class FakeHost(
       failStart: Boolean = false,
       failAwait: Boolean = false
-  ) extends ServeCommand.Host:
+  ) extends ServerCommand.Host:
     val events  = collection.mutable.ArrayBuffer.empty[String]
-    var configs = Vector.empty[ServeCommand.HostConfig]
+    var configs = Vector.empty[ServerCommand.HostConfig]
 
     def start(
-        config: ServeCommand.HostConfig,
-        browserLauncher: ServeCommand.BrowserLauncher
-    )(using Frame): ServeCommand.BoundHost < (Async & Scope & Abort[Throwable]) =
+        config: ServerCommand.HostConfig,
+        browserLauncher: ServerCommand.BrowserLauncher
+    )(using Frame): ServerCommand.BoundHost < (Async & Scope & Abort[Throwable]) =
       Sync.defer {
         events += "start"
         configs = configs :+ config
@@ -55,32 +55,32 @@ class ServeCommandTests extends Test[Any]:
           )
       }
 
-  private final class ThrowingDesktop(failure: Throwable) extends ServeCommand.DesktopPlatform:
+  private final class ThrowingDesktop(failure: Throwable) extends ServerCommand.DesktopPlatform:
     def browse(url: String): Unit = throw failure
 
-  private def dependencies(host: FakeHost, launcher: ServeCommand.BrowserLauncher = FakeLauncher()) =
-    ServeCommand.Dependencies(host, launcher, ServeCommand.Output.console)
+  private def dependencies(host: FakeHost, launcher: ServerCommand.BrowserLauncher = FakeLauncher()) =
+    ServerCommand.Dependencies(host, launcher, ServerCommand.Output.console)
 
-  private def runCommand(options: ServeOptions, dependencies: ServeCommand.Dependencies) =
-    Console.withOut(Abort.run[Throwable](ServeCommand.run(options, dependencies)))
+  private def runCommand(options: ServerOptions, dependencies: ServerCommand.Dependencies) =
+    Console.withOut(Abort.run[Throwable](ServerCommand.run(options, dependencies)))
 
   private def parse(args: String*) =
-    Parser[ServeOptions].parse(args)
+    Parser[ServerOptions].parse(args)
 
-  "ServeOptions parsing" - {
+  "ServerOptions parsing" - {
     "uses an ephemeral port and opens the browser by default" in
-      assert(parse() == Right((ServeOptions(), Seq.empty)))
+      assert(parse() == Right((ServerOptions(), Seq.empty)))
 
     "accepts an explicit port" in
-      assert(parse("--port", "8123") == Right((ServeOptions(port = 8123), Seq.empty)))
+      assert(parse("--port", "8123") == Right((ServerOptions(port = 8123), Seq.empty)))
 
     "accepts both ends of the TCP port range" in {
-      assert(parse("--port", "0") == Right((ServeOptions(port = 0), Seq.empty)))
-      assert(parse("--port", "65535") == Right((ServeOptions(port = 65535), Seq.empty)))
+      assert(parse("--port", "0") == Right((ServerOptions(port = 0), Seq.empty)))
+      assert(parse("--port", "65535") == Right((ServerOptions(port = 65535), Seq.empty)))
     }
 
     "accepts --no-open" in
-      assert(parse("--no-open") == Right((ServeOptions(noOpen = true), Seq.empty)))
+      assert(parse("--no-open") == Right((ServerOptions(noOpen = true), Seq.empty)))
 
     "rejects ports outside the TCP range" in {
       assert(parse("--port", "-1").isLeft)
@@ -92,7 +92,7 @@ class ServeCommandTests extends Test[Any]:
   }
 
   "command registration" - {
-    "adds serve without changing the legacy command names" in {
+    "adds server without changing the legacy command names" in {
       val commandNames = MorphirCliMain.commands.flatMap(_.names).map(_.mkString(" "))
       assert(
         commandNames == Seq(
@@ -102,7 +102,7 @@ class ServeCommandTests extends Test[Any]:
           "setup",
           "test",
           "version",
-          "serve",
+          "server",
           "elm",
           "elm develop",
           "elm init",
@@ -113,8 +113,8 @@ class ServeCommandTests extends Test[Any]:
       )
     }
 
-    "keeps the registered serve command free of process signal ownership" in {
-      val command: Any = ServeCommand
+    "keeps the registered server command free of process signal ownership" in {
+      val command: Any = ServerCommand
       assert(command.isInstanceOf[Command[?]])
       assert(!command.isInstanceOf[KyoCommand[?]])
     }
@@ -126,7 +126,7 @@ class ServeCommandTests extends Test[Any]:
         override protected def loadClass(name: String, resolve: Boolean): Class[?] =
           throw ClassNotFoundException(name)
 
-      assert(!ServeCommand.webHostAvailable(missing))
+      assert(!ServerCommand.webHostAvailable(missing))
     }
 
     "propagates linkage failures from the implementation class" in {
@@ -135,20 +135,20 @@ class ServeCommandTests extends Test[Any]:
         override protected def loadClass(name: String, resolve: Boolean): Class[?] = throw failure
 
       var observed: Throwable | Null = null
-      try ServeCommand.webHostAvailable(broken)
+      try ServerCommand.webHostAvailable(broken)
       catch case error: Throwable => observed = error
 
       assert(observed eq failure)
     }
   }
 
-  "ServeCommand.run" - {
+  "ServerCommand.run" - {
     "starts on the requested port, opens by default, reports only the bound origin, awaits, and releases" in {
       val host     = FakeHost()
       val launcher = FakeLauncher()
-      runCommand(ServeOptions(), dependencies(host, launcher)).map { case (output, result) =>
+      runCommand(ServerOptions(), dependencies(host, launcher)).map { case (output, result) =>
         assert(result == Result.Success(()))
-        assert(host.configs == Vector(ServeCommand.HostConfig(port = 0, openBrowser = true)))
+        assert(host.configs == Vector(ServerCommand.HostConfig(port = 0, openBrowser = true)))
         assert(launcher.urls == Vector(launchSentinel))
         assert(host.events.toVector == Vector("start", "await", "release"))
         assert(output.stdOut == "Listening on http://127.0.0.1:43123\n")
@@ -162,10 +162,10 @@ class ServeCommandTests extends Test[Any]:
     "passes --no-open through without touching the browser launcher" in {
       val host     = FakeHost()
       val launcher = FakeLauncher()
-      runCommand(ServeOptions(port = 8123, noOpen = true), dependencies(host, launcher)).map {
+      runCommand(ServerOptions(port = 8123, noOpen = true), dependencies(host, launcher)).map {
         case (output, result) =>
           assert(result == Result.Success(()))
-          assert(host.configs == Vector(ServeCommand.HostConfig(port = 8123, openBrowser = false)))
+          assert(host.configs == Vector(ServerCommand.HostConfig(port = 8123, openBrowser = false)))
           assert(launcher.urls.isEmpty)
           assert(host.events.toVector == Vector("start", "await", "release"))
           assert(output == Console.Out("Listening on http://127.0.0.1:43123\n", ""))
@@ -174,17 +174,17 @@ class ServeCommandTests extends Test[Any]:
 
     "keeps awaiting after the desktop browser launch fails" in {
       val host     = FakeHost()
-      val launcher = ServeCommand.DesktopBrowserLauncher(
+      val launcher = ServerCommand.DesktopBrowserLauncher(
         ThrowingDesktop(RuntimeException("launch-secret-sentinel")),
-        ServeCommand.Output.console
+        ServerCommand.Output.console
       )
-      runCommand(ServeOptions(), dependencies(host, launcher)).map { case (output, result) =>
+      runCommand(ServerOptions(), dependencies(host, launcher)).map { case (output, result) =>
         assert(result == Result.Success(()))
         assert(host.events.toVector == Vector("start", "await", "release"))
         assert(
           output == Console.Out(
             "Listening on http://127.0.0.1:43123\n",
-            s"${ServeCommand.browserWarning}\n"
+            s"${ServerCommand.browserWarning}\n"
           )
         )
         assert(!output.toString.contains("#launch="))
@@ -195,8 +195,8 @@ class ServeCommandTests extends Test[Any]:
     "rejects directly constructed invalid options before starting the host" in {
       val lowHost  = FakeHost()
       val highHost = FakeHost()
-      runCommand(ServeOptions(port = -1), dependencies(lowHost)).map { case (lowOutput, lowResult) =>
-        runCommand(ServeOptions(port = 65536), dependencies(highHost)).map { case (highOutput, highResult) =>
+      runCommand(ServerOptions(port = -1), dependencies(lowHost)).map { case (lowOutput, lowResult) =>
+        runCommand(ServerOptions(port = 65536), dependencies(highHost)).map { case (highOutput, highResult) =>
           assert(lowResult.isFailure)
           assert(highResult.isFailure)
           assert(lowHost.events.isEmpty)
@@ -209,7 +209,7 @@ class ServeCommandTests extends Test[Any]:
 
     "propagates host startup failure without output or an await" in {
       val host = FakeHost(failStart = true)
-      runCommand(ServeOptions(noOpen = true), dependencies(host)).map { case (output, result) =>
+      runCommand(ServerOptions(noOpen = true), dependencies(host)).map { case (output, result) =>
         assert(result.isFailure)
         assert(host.events.toVector == Vector("start"))
         assert(output == Console.Out("", ""))
@@ -218,7 +218,7 @@ class ServeCommandTests extends Test[Any]:
 
     "releases the host when awaiting termination panics" in {
       val host = FakeHost(failAwait = true)
-      runCommand(ServeOptions(noOpen = true), dependencies(host)).map { case (output, result) =>
+      runCommand(ServerOptions(noOpen = true), dependencies(host)).map { case (output, result) =>
         assert(result.isPanic)
         assert(host.events.toVector == Vector("start", "await", "release"))
         assert(output == Console.Out("Listening on http://127.0.0.1:43123\n", ""))
@@ -230,9 +230,9 @@ class ServeCommandTests extends Test[Any]:
   "DesktopBrowserLauncher" - {
     "opens a supported browser without writing output" in {
       var openedUrls = Vector.empty[String]
-      val desktop    = new ServeCommand.DesktopPlatform:
+      val desktop    = new ServerCommand.DesktopPlatform:
         def browse(url: String): Unit = openedUrls = openedUrls :+ url
-      val launcher = ServeCommand.DesktopBrowserLauncher(desktop, ServeCommand.Output.console)
+      val launcher = ServerCommand.DesktopBrowserLauncher(desktop, ServerCommand.Output.console)
       Console.withOut(launcher.open(launchSentinel)).map { case (output, launched) =>
         assert(launched)
         assert(openedUrls == Vector(launchSentinel))
@@ -250,11 +250,11 @@ class ServeCommandTests extends Test[Any]:
         AssertionError("error launch-secret-sentinel")
       )
       Async.foreachDiscard(failures) { failure =>
-        val launcher = ServeCommand.DesktopBrowserLauncher(ThrowingDesktop(failure), ServeCommand.Output.console)
+        val launcher = ServerCommand.DesktopBrowserLauncher(ThrowingDesktop(failure), ServerCommand.Output.console)
         Console.withOut(launcher.open(launchSentinel)).map { case (output, opened) =>
           assert(!opened)
           assert(output.stdOut.isEmpty)
-          assert(output.stdErr == s"${ServeCommand.browserWarning}\n")
+          assert(output.stdErr == s"${ServerCommand.browserWarning}\n")
           assert(!output.toString.contains("launch-secret-sentinel"))
           assert(!output.toString.contains(failure.getClass.getName))
         }

--- a/morphir/main/test/src/org/finos/morphir/cli/ServerCommandWebHostTests.scala
+++ b/morphir/main/test/src/org/finos/morphir/cli/ServerCommandWebHostTests.scala
@@ -8,7 +8,7 @@ import kyo.test.*
 import morphir.connector.github.GitHubTokenVerifier
 import morphir.web.server.WebHost
 
-class ServeCommandWebHostTests extends Test[Any]:
+class ServerCommandWebHostTests extends Test[Any]:
 
   private final case class Response(status: Int, headers: Map[String, String])
 
@@ -68,12 +68,12 @@ class ServeCommandWebHostTests extends Test[Any]:
       case Array(_, launch) => launch
       case _                => throw AssertionError("missing launch fragment")
 
-  "ServeCommand live WebHost composition" - {
+  "ServerCommand live WebHost composition" - {
     "keeps serving a manual launch after the desktop browser fails safely" in {
       val failureText = "desktop-launch-secret-sentinel"
-      val desktop     = new ServeCommand.DesktopPlatform:
+      val desktop     = new ServerCommand.DesktopPlatform:
         def browse(url: String): Unit = throw RuntimeException(failureText)
-      val launcher = ServeCommand.DesktopBrowserLauncher(desktop, ServeCommand.Output.console)
+      val launcher = ServerCommand.DesktopBrowserLauncher(desktop, ServerCommand.Output.console)
       val verifier = GitHubTokenVerifier.recorded("""{"data":{"viewer":{"login":"octocat"}}}""")
 
       Console.withOut {
@@ -106,11 +106,11 @@ class ServeCommandWebHostTests extends Test[Any]:
         }
       }.map { case (output, _) =>
         assert(output.stdOut.isEmpty)
-        assert(output.stdErr == s"${ServeCommand.browserWarning}\n")
+        assert(output.stdErr == s"${ServerCommand.browserWarning}\n")
         assert(!output.toString.contains("#launch="))
         assert(!output.toString.contains(failureText))
         assert(!output.toString.contains(classOf[RuntimeException].getName))
       }
     }
   }
-end ServeCommandWebHostTests
+end ServerCommandWebHostTests

--- a/morphir/web/README.md
+++ b/morphir/web/README.md
@@ -16,21 +16,21 @@ JavaScript remains a build output under `out/` and is not committed; the product
 Run the browser application with:
 
 ```text
-morphir serve
+morphir server
 ```
 
 It binds `127.0.0.1` only and asks the operating system to choose a port by default. It then opens the browser.
-Use `morphir serve --no-open` when the browser should not be opened automatically, or `morphir serve --port <port>`
+Use `morphir server --no-open` when the browser should not be opened automatically, or `morphir server --port <port>`
 to request a specific loopback port. The command prints the loopback origin but never the one-use launch credential.
 
 The Connections settings panel accepts GitHub.com personal access tokens. Create a token in
 [GitHub's personal access token settings](https://github.com/settings/tokens) and grant only the access needed for
 the repositories or organizations you use. The Remember this device control starts unchecked. A regular connection
-therefore lasts only while `morphir serve` runs. If a remembered write fails, the host retains the previous
+therefore lasts only while `morphir server` runs. If a remembered write fails, the host retains the previous
 connection and reports the failure. It does not silently switch to session-only use. Disconnect removes the active
 token and the remembered operating-system credential, if one exists.
 
 GitHub Enterprise Server is not supported by this host; follow-up `morphir-sx3` owns hostname selection and
 Enterprise credential isolation. Server shutdown finalization has a separate upstream Kyo follow-up,
 `morphir-3h7`; it does not change connection behavior, but it remains relevant to operators supervising a stopped
-`morphir serve` process.
+`morphir server` process.


### PR DESCRIPTION
## Summary

- rename the morphir-scala CLI command from `serve` to `server`
- update the local web host documentation and Morphir knowledge records
- document and verify the native Windows ARM64 setup for Scala.js linking
- update the standalone KB scripts to Kyo 1.0.0-RC6 for CRLF-safe macro expansion
- use native Java path syntax for KB sync byte operations on Windows

## Verification

- started the host with `morphir.main.run server --no-open --port 8123` and observed `Listening on http://127.0.0.1:8123`
- ran all 116 KB and intent skill tests on Windows with CRLF Scala sources
- ran `kb check --verbose`: 0 errors
- ran `kb intent check`: 0 errors

Kyo already fixed the RC5 CRLF macro defect in getkyo/kyo#1807 and released the fix in RC6, so no duplicate upstream issue was filed.
