### PR TITLE
chore(changelog): date 0.5.0-M05 and open the 0.5.0-M06 line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ the shape of the next release, and it is what CI stamps on every build. Dated he
 `## [Unreleased]` is optional and carries no build meaning; use it for entries not yet assigned to
 a release.
 
-## [0.5.0-M05]
+## [0.5.0-M06]
+
+## [0.5.0-M05] - 2026-08-27
 
 The first release cut through the independent version streams, and the first since this changelog
 existed. It carries roughly seventy merged pull requests; the notable ones are below, and the GitHub


### PR DESCRIPTION
Post-release step of the two-phase flow: [v0.5.0-M05](https://github.com/finos/morphir-scala/releases/tag/v0.5.0-M05) shipped on 2026-08-27, so its changelog heading takes that date and a new undated heading opens the next release line.

One decision to review: `squire release prepare` proposed **0.5.1** as the next line. This PR opens **0.5.0-M06** instead, keeping the M01→M05 milestone sequence, since 0.5.0 final has not shipped. If the roadmap calls for 0.5.0 final (or 0.5.1) next, edit the heading here.

Until this merges, snapshot builds on `main` still stamp `0.5.0-M05-<n>-SNAPSHOT` coordinates counting toward the already-shipped release, so merging promptly keeps snapshot coordinates honest.

## Validation

- `squire changelog check` — 3 areas OK
- `squire release status` — clean